### PR TITLE
[codex] Validate responses against OpenAPI schemas

### DIFF
--- a/examples/openapi/petstore.yaml
+++ b/examples/openapi/petstore.yaml
@@ -24,6 +24,12 @@ paths:
       responses:
         '200':
           description: Pet list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
     post:
       operationId: createPet
       summary: Create a pet
@@ -44,6 +50,10 @@ paths:
       responses:
         '201':
           description: Pet created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
   /pets/{petId}:
     get:
       operationId: getPet
@@ -57,6 +67,10 @@ paths:
       responses:
         '200':
           description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
 components:
   securitySchemes:
     bearerAuth:

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -193,6 +193,10 @@ def _parameter_target_label(parameter: ParameterSpec) -> str:
     return f"{parameter.location}:{parameter.name}"
 
 
+def _response_schemas_for_attack(operation: OperationSpec) -> dict[str, Any]:
+    return deepcopy(operation.response_schemas)
+
+
 def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]:
     attacks: list[AttackCase] = []
     base_path_params, base_query_params, base_headers, base_body = _base_request_context(operation)
@@ -226,6 +230,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                     query=query_params,
                     headers=headers,
                     body_json=body,
+                    response_schemas=_response_schemas_for_attack(operation),
                 )
             )
 
@@ -262,6 +267,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 query=query_params,
                 headers=headers,
                 body_json=body,
+                response_schemas=_response_schemas_for_attack(operation),
             )
         )
 
@@ -296,6 +302,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                     query=query_params,
                     headers=headers,
                     body_json=body,
+                    response_schemas=_response_schemas_for_attack(operation),
                 )
             )
 
@@ -316,6 +323,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 query=query_params,
                 headers=headers,
                 omit_body=True,
+                response_schemas=_response_schemas_for_attack(operation),
             )
         )
 
@@ -337,6 +345,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 headers=headers,
                 raw_body=malformed_json_body(operation.request_body_schema),
                 content_type="application/json",
+                response_schemas=_response_schemas_for_attack(operation),
             )
         )
 
@@ -359,6 +368,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 body_json=body,
                 omit_header_names=operation.auth_header_names,
                 omit_query_names=operation.auth_query_names,
+                response_schemas=_response_schemas_for_attack(operation),
             )
         )
 

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -13,6 +13,11 @@ class ParameterSpec(BaseModel):
     schema_def: dict[str, Any] = Field(default_factory=dict)
 
 
+class ResponseSpec(BaseModel):
+    content_type: str | None = None
+    schema_def: dict[str, Any] | None = None
+
+
 class OperationSpec(BaseModel):
     operation_id: str
     method: str
@@ -25,6 +30,7 @@ class OperationSpec(BaseModel):
     auth_required: bool = False
     auth_header_names: list[str] = Field(default_factory=list)
     auth_query_names: list[str] = Field(default_factory=list)
+    response_schemas: dict[str, ResponseSpec] = Field(default_factory=dict)
 
 
 class AttackCase(BaseModel):
@@ -45,6 +51,7 @@ class AttackCase(BaseModel):
     omit_header_names: list[str] = Field(default_factory=list)
     omit_query_names: list[str] = Field(default_factory=list)
     expected_outcomes: list[str] = Field(default_factory=lambda: ["4xx"])
+    response_schemas: dict[str, ResponseSpec] = Field(default_factory=dict)
 
 
 class AttackSuite(BaseModel):
@@ -66,6 +73,9 @@ class AttackResult(BaseModel):
     flagged: bool = False
     issue: str | None = None
     response_excerpt: str | None = None
+    response_schema_status: str | None = None
+    response_schema_valid: bool | None = None
+    response_schema_error: str | None = None
 
 
 class AttackResults(BaseModel):

--- a/src/knives_out/openapi_loader.py
+++ b/src/knives_out/openapi_loader.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import yaml
 
-from knives_out.models import OperationSpec, ParameterSpec
+from knives_out.models import OperationSpec, ParameterSpec, ResponseSpec
 
 HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
 PARAMETER_LOCATION_ORDER = {"path": 0, "query": 1, "header": 2, "cookie": 3}
@@ -82,10 +82,25 @@ def _extract_request_body(
     if not isinstance(content, dict) or not content:
         return bool(resolved.get("required", False)), None, None
 
-    preferred_type = "application/json" if "application/json" in content else next(iter(content))
+    preferred_type, schema = _extract_content_schema(content, root)
+    return bool(resolved.get("required", False)), schema, preferred_type
+
+
+def _extract_content_schema(
+    content: dict[str, Any],
+    root: dict[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    if "application/json" in content:
+        preferred_type = "application/json"
+    else:
+        preferred_type = next(iter(content), None)
+
+    if preferred_type is None:
+        return None, None
+
     media_type = content.get(preferred_type, {})
     schema = resolve_refs(media_type.get("schema"), root) if media_type.get("schema") else None
-    return bool(resolved.get("required", False)), schema, preferred_type
+    return preferred_type, schema
 
 
 def _extract_security(
@@ -123,6 +138,31 @@ def _extract_security(
     return True, sorted(header_names), sorted(query_names)
 
 
+def _extract_response_schemas(
+    operation: dict[str, Any],
+    root: dict[str, Any],
+) -> dict[str, ResponseSpec]:
+    responses = operation.get("responses", {})
+    if not isinstance(responses, dict):
+        return {}
+
+    extracted: dict[str, ResponseSpec] = {}
+    for status_code, response in responses.items():
+        resolved = resolve_refs(response, root)
+        content = resolved.get("content", {})
+        if not isinstance(content, dict) or not content:
+            extracted[str(status_code)] = ResponseSpec()
+            continue
+
+        content_type, schema = _extract_content_schema(content, root)
+        extracted[str(status_code)] = ResponseSpec(
+            content_type=content_type,
+            schema_def=schema,
+        )
+
+    return extracted
+
+
 def load_operations(path: str | Path) -> list[OperationSpec]:
     document = load_openapi_document(path)
     operations: list[OperationSpec] = []
@@ -158,6 +198,7 @@ def load_operations(path: str | Path) -> list[OperationSpec]:
                 operation,
                 document,
             )
+            response_schemas = _extract_response_schemas(operation, document)
 
             operation_id = operation.get("operationId")
             if not operation_id:
@@ -179,6 +220,7 @@ def load_operations(path: str | Path) -> list[OperationSpec]:
                     auth_required=auth_required,
                     auth_header_names=auth_header_names,
                     auth_query_names=auth_query_names,
+                    response_schemas=response_schemas,
                 )
             )
 

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -14,6 +14,9 @@ def load_attack_results(path: str | Path) -> AttackResults:
 def render_markdown_report(results: AttackResults) -> str:
     total = len(results.results)
     flagged = sum(1 for result in results.results if result.flagged)
+    response_schema_mismatches = sum(
+        1 for result in results.results if result.response_schema_valid is False
+    )
     issue_counter = Counter(result.issue or "ok" for result in results.results)
 
     lines: list[str] = []
@@ -24,6 +27,7 @@ def render_markdown_report(results: AttackResults) -> str:
     lines.append(f"- Executed at: `{results.executed_at.isoformat()}`")
     lines.append(f"- Total attacks: **{total}**")
     lines.append(f"- Flagged results: **{flagged}**")
+    lines.append(f"- Response schema mismatches: **{response_schema_mismatches}**")
     lines.append("")
     lines.append("## Outcome summary")
     lines.append("")
@@ -35,8 +39,8 @@ def render_markdown_report(results: AttackResults) -> str:
     lines.append("")
     lines.append("## Flagged findings")
     lines.append("")
-    lines.append("| Attack | Kind | Status | Issue | URL |")
-    lines.append("| --- | --- | ---: | --- | --- |")
+    lines.append("| Attack | Kind | Status | Issue | Schema | URL |")
+    lines.append("| --- | --- | ---: | --- | --- | --- |")
 
     found_flagged = False
     for result in results.results:
@@ -44,12 +48,14 @@ def render_markdown_report(results: AttackResults) -> str:
             continue
         found_flagged = True
         status = str(result.status_code) if result.status_code is not None else "-"
+        schema = "mismatch" if result.response_schema_valid is False else "-"
         lines.append(
-            f"| {result.name} | {result.kind} | {status} | {result.issue or '-'} | `{result.url}` |"
+            f"| {result.name} | {result.kind} | {status} | "
+            f"{result.issue or '-'} | {schema} | `{result.url}` |"
         )
 
     if not found_flagged:
-        lines.append("| None | - | - | - | - |")
+        lines.append("| None | - | - | - | - | - |")
 
     lines.append("")
     lines.append("## Detailed results")
@@ -66,6 +72,12 @@ def render_markdown_report(results: AttackResults) -> str:
             else "- Status: `-`"
         )
         lines.append(f"- Issue: `{result.issue}`" if result.issue else "- Issue: `ok`")
+        if result.response_schema_status:
+            lines.append(f"- Declared response schema: `{result.response_schema_status}`")
+        if result.response_schema_valid is True:
+            lines.append("- Response schema: `ok`")
+        elif result.response_schema_error:
+            lines.append(f"- Response schema mismatch: `{result.response_schema_error}`")
         if result.error:
             lines.append(f"- Error: `{result.error}`")
         if result.duration_ms is not None:

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 
 import httpx
 
-from knives_out.models import AttackResult, AttackResults, AttackSuite
+from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite, ResponseSpec
 
 
 def load_attack_suite(path: str | Path) -> AttackSuite:
@@ -46,6 +46,216 @@ def _excerpt(text: str, limit: int = 300) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 3] + "..."
+
+
+def _normalized_content_type(content_type: str | None) -> str:
+    if not content_type:
+        return ""
+    return content_type.split(";", 1)[0].strip().lower()
+
+
+def _schema_type(schema: dict[str, Any]) -> str | None:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        return schema_type
+    if schema.get("properties") or schema.get("required"):
+        return "object"
+    if "items" in schema:
+        return "array"
+    return None
+
+
+def _describe_value_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _validate_schema_value(
+    value: Any,
+    schema: dict[str, Any] | None,
+    *,
+    path: str = "$",
+) -> str | None:
+    if schema is None:
+        return None
+    if schema == {}:
+        return None
+    if schema.get("nullable") and value is None:
+        return None
+
+    if "enum" in schema and value not in schema["enum"]:
+        return f"{path}: expected one of {schema['enum']!r}, got {value!r}"
+    if "const" in schema and value != schema["const"]:
+        return f"{path}: expected {schema['const']!r}, got {value!r}"
+
+    if "allOf" in schema:
+        for subschema in schema["allOf"]:
+            mismatch = _validate_schema_value(value, subschema, path=path)
+            if mismatch:
+                return mismatch
+        return None
+
+    if "anyOf" in schema:
+        if any(
+            _validate_schema_value(value, subschema, path=path) is None
+            for subschema in schema["anyOf"]
+        ):
+            return None
+        return f"{path}: value did not match any declared schema"
+
+    if "oneOf" in schema:
+        matches = sum(
+            1
+            for subschema in schema["oneOf"]
+            if _validate_schema_value(value, subschema, path=path) is None
+        )
+        if matches == 1:
+            return None
+        if matches == 0:
+            return f"{path}: value did not match any declared schema"
+        return f"{path}: value matched multiple mutually exclusive schemas"
+
+    schema_type = _schema_type(schema)
+
+    if schema_type == "null":
+        if value is None:
+            return None
+        return f"{path}: expected null, got {_describe_value_type(value)}"
+    if schema_type == "string":
+        if isinstance(value, str):
+            return None
+        return f"{path}: expected string, got {_describe_value_type(value)}"
+    if schema_type == "integer":
+        if isinstance(value, int) and not isinstance(value, bool):
+            return None
+        return f"{path}: expected integer, got {_describe_value_type(value)}"
+    if schema_type == "number":
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return None
+        return f"{path}: expected number, got {_describe_value_type(value)}"
+    if schema_type == "boolean":
+        if isinstance(value, bool):
+            return None
+        return f"{path}: expected boolean, got {_describe_value_type(value)}"
+    if schema_type == "array":
+        if not isinstance(value, list):
+            return f"{path}: expected array, got {_describe_value_type(value)}"
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                mismatch = _validate_schema_value(item, item_schema, path=f"{path}[{index}]")
+                if mismatch:
+                    return mismatch
+        return None
+    if schema_type == "object":
+        if not isinstance(value, dict):
+            return f"{path}: expected object, got {_describe_value_type(value)}"
+
+        properties = schema.get("properties", {})
+        for name in schema.get("required", []):
+            if name not in value:
+                return f"{path}: missing required property '{name}'"
+
+        for name, property_schema in properties.items():
+            if name not in value:
+                continue
+            mismatch = _validate_schema_value(value[name], property_schema, path=f"{path}.{name}")
+            if mismatch:
+                return mismatch
+
+        additional_properties = schema.get("additionalProperties", True)
+        extra_names = sorted(name for name in value if name not in properties)
+        if additional_properties is False and extra_names:
+            return f"{path}: unexpected properties {extra_names!r}"
+        if isinstance(additional_properties, dict):
+            for name in extra_names:
+                mismatch = _validate_schema_value(
+                    value[name],
+                    additional_properties,
+                    path=f"{path}.{name}",
+                )
+                if mismatch:
+                    return mismatch
+        return None
+
+    return None
+
+
+def _matched_response_schema(
+    attack: AttackCase,
+    status_code: int,
+) -> tuple[str | None, ResponseSpec | None]:
+    status_key = str(status_code)
+    if status_key in attack.response_schemas:
+        return status_key, attack.response_schemas[status_key]
+    if "default" in attack.response_schemas:
+        return "default", attack.response_schemas["default"]
+    return None, None
+
+
+def _response_uses_json(
+    response: httpx.Response,
+    response_spec: ResponseSpec,
+) -> bool:
+    schema_type = _schema_type(response_spec.schema_def or {})
+    actual_content_type = _normalized_content_type(response.headers.get("Content-Type"))
+    expected_content_type = _normalized_content_type(response_spec.content_type)
+    return (
+        "json" in actual_content_type
+        or "json" in expected_content_type
+        or schema_type in {"object", "array", "null"}
+    )
+
+
+def _coerce_response_body(
+    response: httpx.Response,
+    response_spec: ResponseSpec,
+) -> tuple[Any | None, str | None]:
+    response_text = response.text.strip()
+    if _response_uses_json(response, response_spec):
+        if not response_text:
+            if _schema_type(response_spec.schema_def or {}) == "null":
+                return None, None
+            return None, "Response body is empty."
+        try:
+            return response.json(), None
+        except ValueError as exc:
+            return None, f"Response body is not valid JSON: {exc}"
+
+    return response.text, None
+
+
+def _validate_response_schema(
+    attack: AttackCase,
+    response: httpx.Response,
+) -> tuple[str | None, bool | None, str | None]:
+    matched_status, response_spec = _matched_response_schema(attack, response.status_code)
+    if response_spec is None:
+        return None, None, None
+    if response_spec.schema_def is None:
+        return matched_status, None, None
+
+    response_body, parse_error = _coerce_response_body(response, response_spec)
+    if parse_error:
+        return matched_status, False, parse_error
+
+    mismatch = _validate_schema_value(response_body, response_spec.schema_def)
+    if mismatch:
+        return matched_status, False, mismatch
+    return matched_status, True, None
 
 
 def execute_attack_suite(
@@ -94,6 +304,20 @@ def execute_attack_suite(
             duration_ms = (time.perf_counter() - start) * 1000.0
 
             flagged, issue = evaluate_result(response.status_code if response else None, error)
+            response_schema_status: str | None = None
+            response_schema_valid: bool | None = None
+            response_schema_error: str | None = None
+            if response is not None:
+                (
+                    response_schema_status,
+                    response_schema_valid,
+                    response_schema_error,
+                ) = _validate_response_schema(attack, response)
+            if response_schema_valid is False:
+                flagged = True
+                if issue is None:
+                    issue = "response_schema_mismatch"
+
             results.append(
                 AttackResult(
                     attack_id=attack.id,
@@ -108,6 +332,9 @@ def execute_attack_suite(
                     flagged=flagged,
                     issue=issue,
                     response_excerpt=_excerpt(response.text) if response is not None else None,
+                    response_schema_status=response_schema_status,
+                    response_schema_valid=response_schema_valid,
+                    response_schema_error=response_schema_error,
                 )
             )
 

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -315,7 +315,7 @@ def execute_attack_suite(
                 ) = _validate_response_schema(attack, response)
             if response_schema_valid is False:
                 flagged = True
-                if issue is None:
+                if issue in {None, "unexpected_success"}:
                     issue = "response_schema_mismatch"
 
             results.append(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -18,6 +18,30 @@ def test_load_operations_extracts_core_operation_shapes() -> None:
     assert create_pet.request_body_required is True
     assert create_pet.auth_required is True
     assert create_pet.auth_header_names == ["Authorization"]
+    assert create_pet.response_schemas["201"].content_type == "application/json"
+    assert create_pet.response_schemas["201"].schema_def == {
+        "allOf": [
+            {
+                "type": "object",
+                "required": ["name", "species"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "species": {
+                        "type": "string",
+                        "enum": ["dog", "cat", "bird"],
+                    },
+                    "age": {"type": "integer"},
+                },
+            },
+            {
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "integer"},
+                },
+            },
+        ]
+    }
 
 
 def test_generate_attack_suite_contains_expected_attack_types() -> None:
@@ -31,6 +55,13 @@ def test_generate_attack_suite_contains_expected_attack_types() -> None:
     assert "malformed_json_body" in create_pet_kinds
     assert "missing_auth" in create_pet_kinds
     assert "missing_required_param" in create_pet_kinds
+
+    create_pet_attacks = [attack for attack in suite.attacks if attack.operation_id == "createPet"]
+    assert create_pet_attacks
+    assert all(
+        attack.response_schemas["201"].content_type == "application/json"
+        for attack in create_pet_attacks
+    )
 
 
 def test_sample_value_preserves_nested_required_fields() -> None:

--- a/tests/test_openapi_loader.py
+++ b/tests/test_openapi_loader.py
@@ -127,3 +127,68 @@ def test_load_operations_orders_parameters_deterministically(tmp_path) -> None:
         ("query", "zQuery"),
         ("header", "X-Mode"),
     ]
+
+
+def test_load_operations_extracts_response_schemas(tmp_path) -> None:
+    spec = tmp_path / "response-schemas.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Response schema test
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  responses:
+                    "200":
+                      description: Pet list
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              required: [id]
+                              properties:
+                                id:
+                                  type: integer
+                    default:
+                      description: Error response
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required: [error]
+                            properties:
+                              error:
+                                type: string
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    operations = load_operations(spec)
+
+    assert len(operations) == 1
+    operation = operations[0]
+    assert operation.response_schemas["200"].content_type == "application/json"
+    assert operation.response_schemas["200"].schema_def == {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id": {"type": "integer"},
+            },
+        },
+    }
+    assert operation.response_schemas["default"].schema_def == {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+            "error": {"type": "string"},
+        },
+    }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import httpx
+
+from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite
+from knives_out.reporting import render_markdown_report
+from knives_out.runner import execute_attack_suite
+
+
+class _StubClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+
+    def __enter__(self) -> _StubClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def request(self, *_: object, **__: object) -> httpx.Response:
+        return self._response
+
+
+def _install_stub_response(monkeypatch, response: httpx.Response) -> None:
+    monkeypatch.setattr(
+        "knives_out.runner.httpx.Client",
+        lambda **_: _StubClient(response),
+    )
+
+
+def _attack_case(*, response_schemas: dict[str, dict[str, object]]) -> AttackCase:
+    return AttackCase(
+        id="atk_test",
+        name="Test attack",
+        kind="wrong_type_param",
+        operation_id="createPet",
+        method="POST",
+        path="/pets",
+        description="Test attack",
+        response_schemas=response_schemas,
+    )
+
+
+def test_execute_attack_suite_flags_response_schema_mismatch(monkeypatch) -> None:
+    response = httpx.Response(
+        201,
+        headers={"Content-Type": "application/json"},
+        json={"id": "not-an-integer"},
+    )
+    _install_stub_response(monkeypatch, response)
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            _attack_case(
+                response_schemas={
+                    "201": {
+                        "content_type": "application/json",
+                        "schema_def": {
+                            "type": "object",
+                            "required": ["id"],
+                            "properties": {
+                                "id": {"type": "integer"},
+                            },
+                        },
+                    }
+                }
+            )
+        ],
+    )
+
+    results = execute_attack_suite(suite, base_url="https://example.com")
+
+    assert len(results.results) == 1
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "response_schema_mismatch"
+    assert result.response_schema_status == "201"
+    assert result.response_schema_valid is False
+    assert result.response_schema_error == "$.id: expected integer, got string"
+
+
+def test_execute_attack_suite_uses_default_response_schema(monkeypatch) -> None:
+    response = httpx.Response(
+        422,
+        headers={"Content-Type": "application/json"},
+        json={"error": "invalid input"},
+    )
+    _install_stub_response(monkeypatch, response)
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            _attack_case(
+                response_schemas={
+                    "default": {
+                        "content_type": "application/json",
+                        "schema_def": {
+                            "type": "object",
+                            "required": ["error"],
+                            "properties": {
+                                "error": {"type": "string"},
+                            },
+                        },
+                    }
+                }
+            )
+        ],
+    )
+
+    results = execute_attack_suite(suite, base_url="https://example.com")
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert result.issue is None
+    assert result.response_schema_status == "default"
+    assert result.response_schema_valid is True
+    assert result.response_schema_error is None
+
+
+def test_execute_attack_suite_skips_unmapped_status_codes(monkeypatch) -> None:
+    response = httpx.Response(
+        422,
+        headers={"Content-Type": "application/json"},
+        json={"error": "invalid input"},
+    )
+    _install_stub_response(monkeypatch, response)
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            _attack_case(
+                response_schemas={
+                    "201": {
+                        "content_type": "application/json",
+                        "schema_def": {
+                            "type": "object",
+                            "required": ["id"],
+                            "properties": {
+                                "id": {"type": "integer"},
+                            },
+                        },
+                    }
+                }
+            )
+        ],
+    )
+
+    results = execute_attack_suite(suite, base_url="https://example.com")
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert result.issue is None
+    assert result.response_schema_status is None
+    assert result.response_schema_valid is None
+    assert result.response_schema_error is None
+
+
+def test_render_markdown_report_highlights_response_schema_mismatches() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_test",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Test attack",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=201,
+                flagged=True,
+                issue="response_schema_mismatch",
+                response_schema_status="201",
+                response_schema_valid=False,
+                response_schema_error="$.id: expected integer, got string",
+            )
+        ],
+    )
+
+    report = render_markdown_report(results)
+
+    assert "Response schema mismatches" in report
+    assert "| Attack | Kind | Status | Issue | Schema | URL |" in report
+    assert "response_schema_mismatch" in report
+    assert "mismatch" in report
+    assert "$.id: expected integer, got string" in report


### PR DESCRIPTION
## Summary
Adds response-schema extraction and validation so attacks can compare live API responses against declared OpenAPI response shapes.

## What changed
- carry declared response schemas from the OpenAPI loader into generated attacks
- validate matching responses in the runner, including `default` responses
- surface response-schema mismatches in markdown reporting
- add regression tests for loader, generator, runner, and reporting behavior

## Validation
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- GitHub Actions `test` workflow on this branch

Closes #3