### PR TITLE
[codex] Forward GH_TOKEN into devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,9 @@
   "name": "knives-out",
   "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
   "postCreateCommand": "pip install --upgrade pip && pip install -e \".[dev]\"",
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
Forward `GH_TOKEN` from the host environment into the devcontainer so GitHub CLI inside the container can reuse the local personal access token.

## What changed
- add `remoteEnv.GH_TOKEN` to `.devcontainer/devcontainer.json`

## Validation
- config-only change
- GitHub Actions `test` workflow on this branch