### PR TITLE
[codex] Cover apiKey auth flows end to end

### DIFF
--- a/src/knives_out/openapi_loader.py
+++ b/src/knives_out/openapi_loader.py
@@ -118,10 +118,16 @@ def _extract_security(
     schemes = root.get("components", {}).get("securitySchemes", {})
     header_names: set[str] = set()
     query_names: set[str] = set()
+    has_non_optional_requirement = False
+    has_optional_requirement = False
 
     for requirement in security:
         if not isinstance(requirement, dict):
             continue
+        if not requirement:
+            has_optional_requirement = True
+            continue
+        has_non_optional_requirement = True
         for scheme_name in requirement:
             scheme = resolve_refs(schemes.get(scheme_name, {}), root)
             scheme_type = scheme.get("type")
@@ -135,7 +141,8 @@ def _extract_security(
                 elif location == "query" and name:
                     query_names.add(name)
 
-    return True, sorted(header_names), sorted(query_names)
+    auth_required = has_non_optional_requirement and not has_optional_requirement
+    return auth_required, sorted(header_names), sorted(query_names)
 
 
 def _extract_response_schemas(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 
 from knives_out.generator import generate_attack_suite, sample_value
 from knives_out.openapi_loader import load_operations
@@ -157,3 +158,72 @@ def test_sample_value_preserves_array_item_shapes_past_depth_limit() -> None:
             ]
         }
     }
+
+
+def test_generate_missing_auth_attacks_target_only_api_key_credentials(tmp_path) -> None:
+    spec = tmp_path / "api-key-attacks.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: API key attack test
+              version: 1.0.0
+            components:
+              securitySchemes:
+                headerKey:
+                  type: apiKey
+                  in: header
+                  name: X-API-Key
+                queryKey:
+                  type: apiKey
+                  in: query
+                  name: api_key
+            paths:
+              /header-auth:
+                get:
+                  operationId: headerAuth
+                  security:
+                    - headerKey: []
+                  parameters:
+                    - name: X-Tenant
+                      in: header
+                      required: true
+                      schema:
+                        type: string
+              /query-auth:
+                get:
+                  operationId: queryAuth
+                  security:
+                    - queryKey: []
+                  parameters:
+                    - name: limit
+                      in: query
+                      required: true
+                      schema:
+                        type: integer
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    operations = load_operations(spec)
+    suite = generate_attack_suite(operations, source=str(spec))
+
+    header_attack = next(
+        attack
+        for attack in suite.attacks
+        if attack.operation_id == "headerAuth" and attack.kind == "missing_auth"
+    )
+    assert header_attack.headers == {"X-Tenant": "example"}
+    assert header_attack.omit_header_names == ["X-API-Key"]
+    assert header_attack.omit_query_names == []
+
+    query_attack = next(
+        attack
+        for attack in suite.attacks
+        if attack.operation_id == "queryAuth" and attack.kind == "missing_auth"
+    )
+    assert query_attack.query == {"limit": 1}
+    assert query_attack.omit_header_names == []
+    assert query_attack.omit_query_names == ["api_key"]

--- a/tests/test_openapi_loader.py
+++ b/tests/test_openapi_loader.py
@@ -192,3 +192,58 @@ def test_load_operations_extracts_response_schemas(tmp_path) -> None:
             "error": {"type": "string"},
         },
     }
+
+
+def test_load_operations_extracts_api_key_auth_from_components(tmp_path) -> None:
+    spec = tmp_path / "api-key-auth.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: API key auth test
+              version: 1.0.0
+            components:
+              securitySchemes:
+                headerKey:
+                  type: apiKey
+                  in: header
+                  name: X-API-Key
+                queryKey:
+                  type: apiKey
+                  in: query
+                  name: api_key
+            paths:
+              /header-auth:
+                get:
+                  operationId: headerAuth
+                  security:
+                    - headerKey: []
+              /query-auth:
+                get:
+                  operationId: queryAuth
+                  security:
+                    - queryKey: []
+              /optional-auth:
+                get:
+                  operationId: optionalAuth
+                  security:
+                    - {}
+                    - headerKey: []
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    operations = {operation.operation_id: operation for operation in load_operations(spec)}
+
+    assert operations["headerAuth"].auth_required is True
+    assert operations["headerAuth"].auth_header_names == ["X-API-Key"]
+    assert operations["headerAuth"].auth_query_names == []
+
+    assert operations["queryAuth"].auth_required is True
+    assert operations["queryAuth"].auth_header_names == []
+    assert operations["queryAuth"].auth_query_names == ["api_key"]
+
+    assert operations["optionalAuth"].auth_required is False
+    assert operations["optionalAuth"].auth_header_names == ["X-API-Key"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -21,11 +21,43 @@ class _StubClient:
         return self._response
 
 
+class _RecordingClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+        self.requests: list[dict[str, object]] = []
+
+    def __enter__(self) -> _RecordingClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "params": kwargs.get("params"),
+                "headers": kwargs.get("headers"),
+            }
+        )
+        return self._response
+
+
 def _install_stub_response(monkeypatch, response: httpx.Response) -> None:
     monkeypatch.setattr(
         "knives_out.runner.httpx.Client",
         lambda **_: _StubClient(response),
     )
+
+
+def _install_recording_client(monkeypatch, response: httpx.Response) -> _RecordingClient:
+    client = _RecordingClient(response)
+    monkeypatch.setattr(
+        "knives_out.runner.httpx.Client",
+        lambda **_: client,
+    )
+    return client
 
 
 def _attack_case(*, response_schemas: dict[str, dict[str, object]]) -> AttackCase:
@@ -185,3 +217,78 @@ def test_render_markdown_report_highlights_response_schema_mismatches() -> None:
     assert "response_schema_mismatch" in report
     assert "mismatch" in report
     assert "$.id: expected integer, got string" in report
+
+
+def test_execute_attack_suite_removes_only_declared_auth_header(monkeypatch) -> None:
+    response = httpx.Response(401, text="missing api key")
+    client = _install_recording_client(monkeypatch, response)
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_header_auth",
+                name="Missing header auth",
+                kind="missing_auth",
+                operation_id="headerAuth",
+                method="GET",
+                path="/pets",
+                description="Missing header auth",
+                headers={"X-Tenant": "tenant-123"},
+                omit_header_names=["X-API-Key"],
+            )
+        ],
+    )
+
+    execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        default_headers={
+            "X-API-Key": "secret-key",
+            "X-Trace-Id": "trace-123",
+            "X-Tenant": "default-tenant",
+        },
+    )
+
+    request = client.requests[0]
+    assert request["headers"] == {
+        "X-Trace-Id": "trace-123",
+        "X-Tenant": "tenant-123",
+    }
+
+
+def test_execute_attack_suite_removes_only_declared_auth_query_param(monkeypatch) -> None:
+    response = httpx.Response(401, text="missing api key")
+    client = _install_recording_client(monkeypatch, response)
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_query_auth",
+                name="Missing query auth",
+                kind="missing_auth",
+                operation_id="queryAuth",
+                method="GET",
+                path="/pets",
+                description="Missing query auth",
+                query={"limit": 10},
+                omit_query_names=["api_key"],
+            )
+        ],
+    )
+
+    execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        default_query={
+            "api_key": "secret-key",
+            "page": "2",
+        },
+    )
+
+    request = client.requests[0]
+    assert request["params"] == {
+        "limit": 10,
+        "page": "2",
+    }


### PR DESCRIPTION
## Summary
Tighten apiKey auth handling and add end-to-end coverage for header and query credential omission during missing-auth attacks.

## What changed
- treat security requirements with an empty `{}` alternative as optional auth instead of required auth
- add loader coverage for header and query `apiKey` schemes from `components.securitySchemes`
- add generator coverage to ensure missing-auth attacks target only the declared credential
- add runner coverage to ensure auth omission does not strip unrelated headers or query params

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- GitHub Actions `test` workflow on this branch

Closes #4