### PR TITLE
[codex] Write per-attack run artifacts

### DIFF
--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -95,6 +95,10 @@ def run(
         float,
         typer.Option(help="HTTP timeout in seconds."),
     ] = 10.0,
+    artifact_dir: Annotated[
+        Path | None,
+        typer.Option(help="Optional directory for per-attack request/response artifacts."),
+    ] = None,
 ) -> None:
     """Run a saved attack suite against a live API."""
     suite = load_attack_suite(attacks)
@@ -106,6 +110,7 @@ def run(
         default_headers=default_headers,
         default_query=default_query,
         timeout_seconds=timeout,
+        artifact_dir=artifact_dir,
     )
     out.write_text(results.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
 

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,63 @@ def _excerpt(text: str, limit: int = 300) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 3] + "..."
+
+
+def _request_body_artifact(attack: AttackCase, headers: dict[str, str]) -> dict[str, Any]:
+    if attack.omit_body:
+        return {"present": False}
+    if attack.raw_body is not None:
+        return {
+            "present": True,
+            "kind": "raw",
+            "content_type": headers.get("Content-Type") or attack.content_type,
+            "excerpt": _excerpt(attack.raw_body),
+        }
+    if attack.body_json is not None:
+        serialized = json.dumps(attack.body_json, sort_keys=True)
+        return {
+            "present": True,
+            "kind": "json",
+            "content_type": headers.get("Content-Type") or "application/json",
+            "excerpt": _excerpt(serialized),
+        }
+    return {"present": False}
+
+
+def _write_attack_artifact(
+    artifact_root: Path,
+    *,
+    attack: AttackCase,
+    url: str,
+    headers: dict[str, str],
+    query: dict[str, Any],
+    response: httpx.Response | None,
+    error: str | None,
+    duration_ms: float,
+) -> None:
+    artifact = {
+        "attack": {
+            "id": attack.id,
+            "name": attack.name,
+            "kind": attack.kind,
+            "operation_id": attack.operation_id,
+        },
+        "request": {
+            "method": attack.method,
+            "url": url,
+            "headers": headers,
+            "query": query,
+            "body": _request_body_artifact(attack, headers),
+        },
+        "response": {
+            "status_code": response.status_code if response is not None else None,
+            "error": error,
+            "duration_ms": round(duration_ms, 2),
+            "body_excerpt": _excerpt(response.text) if response is not None else None,
+        },
+    }
+    artifact_path = artifact_root / f"{attack.id}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
 
 
 def _normalized_content_type(content_type: str | None) -> str:
@@ -265,10 +323,14 @@ def execute_attack_suite(
     default_headers: dict[str, str] | None = None,
     default_query: dict[str, Any] | None = None,
     timeout_seconds: float = 10.0,
+    artifact_dir: str | Path | None = None,
 ) -> AttackResults:
     default_headers = dict(default_headers or {})
     default_query = dict(default_query or {})
     results: list[AttackResult] = []
+    artifact_root = Path(artifact_dir) if artifact_dir is not None else None
+    if artifact_root is not None:
+        artifact_root.mkdir(parents=True, exist_ok=True)
 
     normalized_base_url = base_url.rstrip("/")
 
@@ -302,6 +364,18 @@ def execute_attack_suite(
             except Exception as exc:  # noqa: BLE001
                 error = str(exc)
             duration_ms = (time.perf_counter() - start) * 1000.0
+
+            if artifact_root is not None:
+                _write_attack_artifact(
+                    artifact_root,
+                    attack=attack,
+                    url=url,
+                    headers=request_kwargs["headers"],
+                    query=query,
+                    response=response,
+                    error=error,
+                    duration_ms=duration_ms,
+                )
 
             flagged, issue = evaluate_result(response.status_code if response else None, error)
             response_schema_status: str | None = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from knives_out.cli import app
+from knives_out.models import AttackResults, AttackSuite
 
 runner = CliRunner()
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
@@ -23,3 +24,51 @@ def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
     assert out_path.exists()
     raw = out_path.read_text(encoding="utf-8")
     assert '"attacks"' in raw
+
+
+def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    artifact_dir = tmp_path / "artifacts"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+    ) -> AttackResults:
+        captured["suite_source"] = suite.source
+        captured["base_url"] = base_url
+        captured["artifact_dir"] = artifact_dir
+        return AttackResults(source=suite.source, base_url=base_url, results=[])
+
+    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert out_path.exists()
+    assert captured["suite_source"] == "unit"
+    assert captured["base_url"] == "https://example.com"
+    assert captured["artifact_dir"] == artifact_dir

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 
 from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite
@@ -292,3 +294,59 @@ def test_execute_attack_suite_removes_only_declared_auth_query_param(monkeypatch
         "limit": 10,
         "page": "2",
     }
+
+
+def test_execute_attack_suite_writes_artifacts(tmp_path, monkeypatch) -> None:
+    response = httpx.Response(422, text="invalid input from server")
+    _install_recording_client(monkeypatch, response)
+    artifact_dir = tmp_path / "artifacts"
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_artifact",
+                name="Artifact attack",
+                kind="wrong_type_param",
+                operation_id="createPet",
+                method="POST",
+                path="/pets",
+                description="Artifact attack",
+                headers={"X-Tenant": "tenant-123"},
+                query={"limit": 10},
+                body_json={"name": "Milo"},
+            )
+        ],
+    )
+
+    execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        default_headers={"Authorization": "Bearer dev-token"},
+        default_query={"page": "2"},
+        artifact_dir=artifact_dir,
+    )
+
+    artifact_path = artifact_dir / "atk_artifact.json"
+    assert artifact_path.exists()
+
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact["attack"]["id"] == "atk_artifact"
+    assert artifact["request"]["method"] == "POST"
+    assert artifact["request"]["url"] == "https://example.com/pets"
+    assert artifact["request"]["headers"] == {
+        "Authorization": "Bearer dev-token",
+        "X-Tenant": "tenant-123",
+    }
+    assert artifact["request"]["query"] == {
+        "limit": 10,
+        "page": "2",
+    }
+    assert artifact["request"]["body"] == {
+        "present": True,
+        "kind": "json",
+        "content_type": "application/json",
+        "excerpt": '{"name": "Milo"}',
+    }
+    assert artifact["response"]["status_code"] == 422
+    assert artifact["response"]["body_excerpt"] == "invalid input from server"


### PR DESCRIPTION
## Summary
Add optional per-attack artifact output during `run` so each executed attack preserves request metadata and a response excerpt for triage.

## What changed
- add `--artifact-dir` to the `run` CLI command
- create the artifact directory on demand during execution
- write one stable JSON artifact per attack, keyed by `attack.id`
- capture request method, URL, headers, query, body metadata, response status, duration, and body excerpt
- add runner and CLI coverage for artifact creation and stable naming

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- GitHub Actions `test` workflow on this branch

Closes #5