### PR TITLE
[codex] Add CLI attack filters

### DIFF
--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -7,6 +7,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from knives_out.filtering import filter_attack_suite
 from knives_out.generator import generate_attack_suite
 from knives_out.openapi_loader import load_operations
 from knives_out.reporting import load_attack_results, render_markdown_report
@@ -64,10 +65,46 @@ def generate(
         Path,
         typer.Option(help="Where to write the generated attack suite."),
     ] = Path("attacks.json"),
+    operation: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include attacks for these operation ids. Repeatable."),
+    ] = None,
+    exclude_operation: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these operation ids. Repeatable."),
+    ] = None,
+    method: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include attacks for these HTTP methods. Repeatable."),
+    ] = None,
+    exclude_method: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these HTTP methods. Repeatable."),
+    ] = None,
+    kind: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include attacks for these attack kinds. Repeatable."),
+    ] = None,
+    exclude_kind: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these attack kinds. Repeatable."),
+    ] = None,
 ) -> None:
-    """Generate a replayable attack suite from an OpenAPI spec."""
+    """Generate a replayable attack suite from an OpenAPI spec.
+
+    Filters are applied after attack generation and before the suite is written.
+    """
     operations = load_operations(spec)
     suite = generate_attack_suite(operations, source=str(spec))
+    suite = filter_attack_suite(
+        suite,
+        include_operations=operation,
+        exclude_operations=exclude_operation,
+        include_methods=method,
+        exclude_methods=exclude_method,
+        include_kinds=kind,
+        exclude_kinds=exclude_kind,
+    )
     out.write_text(suite.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     console.print(f"Wrote {len(suite.attacks)} attacks to [bold]{out}[/bold].")
 
@@ -99,9 +136,45 @@ def run(
         Path | None,
         typer.Option(help="Optional directory for per-attack request/response artifacts."),
     ] = None,
+    operation: Annotated[
+        list[str] | None,
+        typer.Option(help="Only run attacks for these operation ids. Repeatable."),
+    ] = None,
+    exclude_operation: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these operation ids. Repeatable."),
+    ] = None,
+    method: Annotated[
+        list[str] | None,
+        typer.Option(help="Only run attacks for these HTTP methods. Repeatable."),
+    ] = None,
+    exclude_method: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these HTTP methods. Repeatable."),
+    ] = None,
+    kind: Annotated[
+        list[str] | None,
+        typer.Option(help="Only run attacks for these attack kinds. Repeatable."),
+    ] = None,
+    exclude_kind: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these attack kinds. Repeatable."),
+    ] = None,
 ) -> None:
-    """Run a saved attack suite against a live API."""
+    """Run a saved attack suite against a live API.
+
+    Filters are applied to the loaded suite before any requests are executed.
+    """
     suite = load_attack_suite(attacks)
+    suite = filter_attack_suite(
+        suite,
+        include_operations=operation,
+        exclude_operations=exclude_operation,
+        include_methods=method,
+        exclude_methods=exclude_method,
+        include_kinds=kind,
+        exclude_kinds=exclude_kind,
+    )
     default_headers = _parse_key_value(header, separator=":")
     default_query = _parse_key_value(query, separator="=")
     results = execute_attack_suite(

--- a/src/knives_out/filtering.py
+++ b/src/knives_out/filtering.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from knives_out.models import AttackCase, AttackSuite
+
+
+def _normalized_values(values: list[str] | None) -> set[str]:
+    return {value.strip().casefold() for value in values or [] if value.strip()}
+
+
+def _matches_attack(
+    attack: AttackCase,
+    *,
+    include_operations: set[str],
+    exclude_operations: set[str],
+    include_methods: set[str],
+    exclude_methods: set[str],
+    include_kinds: set[str],
+    exclude_kinds: set[str],
+) -> bool:
+    operation_id = attack.operation_id.casefold()
+    method = attack.method.casefold()
+    kind = attack.kind.casefold()
+
+    if include_operations and operation_id not in include_operations:
+        return False
+    if include_methods and method not in include_methods:
+        return False
+    if include_kinds and kind not in include_kinds:
+        return False
+    if operation_id in exclude_operations:
+        return False
+    if method in exclude_methods:
+        return False
+    if kind in exclude_kinds:
+        return False
+    return True
+
+
+def filter_attack_suite(
+    suite: AttackSuite,
+    *,
+    include_operations: list[str] | None = None,
+    exclude_operations: list[str] | None = None,
+    include_methods: list[str] | None = None,
+    exclude_methods: list[str] | None = None,
+    include_kinds: list[str] | None = None,
+    exclude_kinds: list[str] | None = None,
+) -> AttackSuite:
+    include_operation_set = _normalized_values(include_operations)
+    exclude_operation_set = _normalized_values(exclude_operations)
+    include_method_set = _normalized_values(include_methods)
+    exclude_method_set = _normalized_values(exclude_methods)
+    include_kind_set = _normalized_values(include_kinds)
+    exclude_kind_set = _normalized_values(exclude_kinds)
+
+    filtered_attacks = [
+        attack
+        for attack in suite.attacks
+        if _matches_attack(
+            attack,
+            include_operations=include_operation_set,
+            exclude_operations=exclude_operation_set,
+            include_methods=include_method_set,
+            exclude_methods=exclude_method_set,
+            include_kinds=include_kind_set,
+            exclude_kinds=exclude_kind_set,
+        )
+    ]
+
+    return suite.model_copy(update={"attacks": filtered_attacks})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from knives_out.cli import app
-from knives_out.models import AttackResults, AttackSuite
+from knives_out.models import AttackCase, AttackResults, AttackSuite
 
 runner = CliRunner()
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
@@ -72,3 +72,115 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
     assert captured["suite_source"] == "unit"
     assert captured["base_url"] == "https://example.com"
     assert captured["artifact_dir"] == artifact_dir
+
+
+def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
+    out_path = tmp_path / "attacks.json"
+
+    monkeypatch.setattr("knives_out.cli.load_operations", lambda spec: [])
+    monkeypatch.setattr(
+        "knives_out.cli.generate_attack_suite",
+        lambda operations, source: AttackSuite(
+            source=source,
+            attacks=[
+                AttackCase(
+                    id="atk_get",
+                    name="GET attack",
+                    kind="missing_auth",
+                    operation_id="listPets",
+                    method="GET",
+                    path="/pets",
+                    description="GET attack",
+                ),
+                AttackCase(
+                    id="atk_post",
+                    name="POST attack",
+                    kind="missing_request_body",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                    description="POST attack",
+                ),
+            ],
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(EXAMPLE_SPEC),
+            "--out",
+            str(out_path),
+            "--operation",
+            "createPet",
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert [attack.id for attack in suite.attacks] == ["atk_post"]
+
+
+def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    attacks_path.write_text(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_get",
+                    name="GET attack",
+                    kind="missing_auth",
+                    operation_id="listPets",
+                    method="GET",
+                    path="/pets",
+                    description="GET attack",
+                ),
+                AttackCase(
+                    id="atk_post",
+                    name="POST attack",
+                    kind="missing_request_body",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                    description="POST attack",
+                ),
+            ],
+        ).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+    ) -> AttackResults:
+        captured["attack_ids"] = [attack.id for attack in suite.attacks]
+        return AttackResults(source=suite.source, base_url=base_url, results=[])
+
+    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--method",
+            "POST",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["attack_ids"] == ["atk_post"]

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,66 @@
+from knives_out.filtering import filter_attack_suite
+from knives_out.models import AttackCase, AttackSuite
+
+
+def _suite() -> AttackSuite:
+    return AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_get_missing",
+                name="GET missing auth",
+                kind="missing_auth",
+                operation_id="listPets",
+                method="GET",
+                path="/pets",
+                description="GET missing auth",
+            ),
+            AttackCase(
+                id="atk_post_body",
+                name="POST malformed body",
+                kind="malformed_json_body",
+                operation_id="createPet",
+                method="POST",
+                path="/pets",
+                description="POST malformed body",
+            ),
+            AttackCase(
+                id="atk_post_auth",
+                name="POST missing auth",
+                kind="missing_auth",
+                operation_id="createPet",
+                method="POST",
+                path="/pets",
+                description="POST missing auth",
+            ),
+        ],
+    )
+
+
+def test_filter_attack_suite_by_method() -> None:
+    suite = filter_attack_suite(_suite(), include_methods=["post"])
+
+    assert [attack.id for attack in suite.attacks] == [
+        "atk_post_body",
+        "atk_post_auth",
+    ]
+
+
+def test_filter_attack_suite_by_operation() -> None:
+    suite = filter_attack_suite(_suite(), include_operations=["createPet"])
+
+    assert [attack.id for attack in suite.attacks] == [
+        "atk_post_body",
+        "atk_post_auth",
+    ]
+
+
+def test_filter_attack_suite_combines_include_and_exclude_filters() -> None:
+    suite = filter_attack_suite(
+        _suite(),
+        include_methods=["post"],
+        include_kinds=["missing_auth", "malformed_json_body"],
+        exclude_kinds=["malformed_json_body"],
+    )
+
+    assert [attack.id for attack in suite.attacks] == ["atk_post_auth"]


### PR DESCRIPTION
## Summary
Add include and exclude filters by operation id, method, and attack kind so users can generate or run targeted attack subsets while iterating.

## What changed
- add a shared attack-suite filtering helper that preserves input order deterministically
- add repeatable `--operation`, `--exclude-operation`, `--method`, `--exclude-method`, `--kind`, and `--exclude-kind` options to `generate`
- add the same filter options to `run`
- document in CLI help that generate filters apply before writing and run filters apply before execution
- add unit and CLI coverage for method-only, operation-only, and combined filter cases

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- GitHub Actions `test` workflow on this branch

Closes #6