### PR TITLE
[codex] Add custom attack pack loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Builds an `AttackSuite` JSON file from an OpenAPI document.
 knives-out generate path/to/openapi.yaml --out attacks.json
 ```
 
+You can load custom attack packs from installed entry points or local modules:
+
+```bash
+knives-out generate path/to/openapi.yaml \
+  --pack unexpected-header \
+  --pack-module examples/custom_packs/unexpected_header.py \
+  --out attacks.json
+```
+
 ### `run`
 
 Executes a saved attack suite against a base URL.
@@ -149,6 +158,69 @@ Run lint:
 ```bash
 ruff check .
 ruff format .
+```
+
+## Custom attack packs
+
+Custom attack packs let you contribute additional `AttackCase` records without forking the core generator.
+
+An attack pack can be either:
+
+- a callable `generate(operation: OperationSpec) -> list[AttackCase]`
+- an object exposed as `attack_pack` with a `name` and `generate(operation)` method
+
+The easiest helper is `make_attack_pack()` from `knives_out.attack_packs`.
+
+Local module example:
+
+```python
+from knives_out.attack_packs import make_attack_pack
+from knives_out.generator import attack_id, base_request_context
+from knives_out.models import AttackCase, OperationSpec
+
+
+def generate(operation: OperationSpec) -> list[AttackCase]:
+    path_params, query, headers, body = base_request_context(operation)
+    headers["X-Example-Custom-Pack"] = "unexpected-header"
+    return [
+        AttackCase(
+            id=attack_id(operation.operation_id, "unexpected_header", "header:X-Example"),
+            name="Unexpected header probe",
+            kind="unexpected_header",
+            operation_id=operation.operation_id,
+            method=operation.method,
+            path=operation.path,
+            description="Adds an unexpected header to probe strict header handling.",
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            body_json=body,
+        )
+    ]
+
+
+attack_pack = make_attack_pack("unexpected-header", generate)
+```
+
+Load that module with:
+
+```bash
+knives-out generate examples/openapi/petstore.yaml \
+  --pack-module examples/custom_packs/unexpected_header.py \
+  --out attacks.json
+```
+
+Installed entry point example:
+
+```toml
+[project.entry-points."knives_out.attack_packs"]
+unexpected-header = "my_package.attack_packs:attack_pack"
+```
+
+Then load it with:
+
+```bash
+knives-out generate examples/openapi/petstore.yaml --pack unexpected-header --out attacks.json
 ```
 
 ## Roadmap

--- a/examples/custom_packs/unexpected_header.py
+++ b/examples/custom_packs/unexpected_header.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from knives_out.attack_packs import make_attack_pack
+from knives_out.generator import attack_id, base_request_context
+from knives_out.models import AttackCase, OperationSpec
+
+
+def generate(operation: OperationSpec) -> list[AttackCase]:
+    path_params, query, headers, body = base_request_context(operation)
+    headers["X-Example-Custom-Pack"] = "unexpected-header"
+
+    return [
+        AttackCase(
+            id=attack_id(
+                operation.operation_id,
+                "unexpected_header",
+                "header:X-Example-Custom-Pack",
+            ),
+            name="Unexpected header probe",
+            kind="unexpected_header",
+            operation_id=operation.operation_id,
+            method=operation.method,
+            path=operation.path,
+            description="Adds an unexpected header to probe strict header handling.",
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            body_json=body,
+            response_schemas=deepcopy(operation.response_schemas),
+        )
+    ]
+
+
+attack_pack = make_attack_pack("unexpected-header", generate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dev = [
 [project.scripts]
 knives-out = "knives_out.cli:main"
 
+[project.entry-points."knives_out.attack_packs"]
+unexpected-header = "knives_out.example_packs:attack_pack"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/knives_out"]
 

--- a/src/knives_out/attack_packs.py
+++ b/src/knives_out/attack_packs.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import util
+from importlib.metadata import entry_points
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from knives_out.models import AttackCase, OperationSpec
+
+ENTRY_POINT_GROUP = "knives_out.attack_packs"
+
+
+AttackPackGenerator = Callable[[OperationSpec], list[AttackCase] | list[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class LoadedAttackPack:
+    name: str
+    generate_fn: AttackPackGenerator
+
+    def generate(self, operation: OperationSpec) -> list[AttackCase]:
+        generated = self.generate_fn(operation)
+        return [AttackCase.model_validate(attack) for attack in generated]
+
+
+def make_attack_pack(name: str, generate_fn: AttackPackGenerator) -> LoadedAttackPack:
+    return LoadedAttackPack(name=name, generate_fn=generate_fn)
+
+
+def _module_name_for_path(module_path: Path) -> str:
+    resolved = module_path.resolve()
+    digest = abs(hash(str(resolved)))
+    return f"knives_out_custom_pack_{digest}"
+
+
+def _coerce_attack_pack(candidate: object, *, name_hint: str) -> LoadedAttackPack:
+    if isinstance(candidate, LoadedAttackPack):
+        return candidate
+    if callable(candidate):
+        return make_attack_pack(name_hint, candidate)
+
+    generate = getattr(candidate, "generate", None)
+    if callable(generate):
+        name = getattr(candidate, "name", name_hint)
+        return make_attack_pack(str(name), generate)
+
+    raise ValueError(
+        f"Attack pack {name_hint!r} must be a callable or expose a callable 'generate'."
+    )
+
+
+def _attack_pack_from_module(module: ModuleType, *, name_hint: str) -> LoadedAttackPack:
+    if hasattr(module, "attack_pack"):
+        return _coerce_attack_pack(module.attack_pack, name_hint=name_hint)
+    if hasattr(module, "generate"):
+        return _coerce_attack_pack(module.generate, name_hint=name_hint)
+    raise ValueError(f"Attack pack module {name_hint!r} must define 'attack_pack' or 'generate'.")
+
+
+def load_entry_point_attack_packs(names: list[str] | None) -> list[LoadedAttackPack]:
+    if not names:
+        return []
+
+    selected_entry_points = {
+        entry_point.name: entry_point
+        for entry_point in entry_points().select(group=ENTRY_POINT_GROUP)
+    }
+    loaded: list[LoadedAttackPack] = []
+    for name in names:
+        entry_point = selected_entry_points.get(name)
+        if entry_point is None:
+            raise ValueError(
+                f"Unknown attack pack entry point {name!r}. "
+                f"Install a package exposing [{ENTRY_POINT_GROUP}] {name}."
+            )
+        loaded.append(_coerce_attack_pack(entry_point.load(), name_hint=name))
+    return loaded
+
+
+def load_module_attack_packs(module_paths: list[Path] | None) -> list[LoadedAttackPack]:
+    if not module_paths:
+        return []
+
+    loaded: list[LoadedAttackPack] = []
+    for module_path in module_paths:
+        if not module_path.exists():
+            raise ValueError(f"Attack pack module path does not exist: {module_path}")
+
+        spec = util.spec_from_file_location(_module_name_for_path(module_path), module_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Could not load attack pack module from: {module_path}")
+
+        module = util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Failed to import attack pack module {module_path}: {exc}") from exc
+
+        loaded.append(_attack_pack_from_module(module, name_hint=module_path.stem))
+    return loaded
+
+
+def load_attack_packs(
+    *,
+    entry_point_names: list[str] | None = None,
+    module_paths: list[Path] | None = None,
+) -> list[LoadedAttackPack]:
+    return load_entry_point_attack_packs(entry_point_names) + load_module_attack_packs(module_paths)

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -7,6 +7,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from knives_out.attack_packs import load_attack_packs
 from knives_out.filtering import filter_attack_suite
 from knives_out.generator import generate_attack_suite
 from knives_out.openapi_loader import load_operations
@@ -89,13 +90,22 @@ def generate(
         list[str] | None,
         typer.Option(help="Exclude attacks for these attack kinds. Repeatable."),
     ] = None,
+    pack: Annotated[
+        list[str] | None,
+        typer.Option(help="Load custom attack packs from installed entry point names. Repeatable."),
+    ] = None,
+    pack_module: Annotated[
+        list[Path] | None,
+        typer.Option(help="Load custom attack packs from local Python module paths. Repeatable."),
+    ] = None,
 ) -> None:
     """Generate a replayable attack suite from an OpenAPI spec.
 
     Filters are applied after attack generation and before the suite is written.
     """
     operations = load_operations(spec)
-    suite = generate_attack_suite(operations, source=str(spec))
+    attack_packs = load_attack_packs(entry_point_names=pack, module_paths=pack_module)
+    suite = generate_attack_suite(operations, source=str(spec), extra_packs=attack_packs)
     suite = filter_attack_suite(
         suite,
         include_operations=operation,

--- a/src/knives_out/example_packs.py
+++ b/src/knives_out/example_packs.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from knives_out.attack_packs import make_attack_pack
+from knives_out.generator import attack_id, base_request_context
+from knives_out.models import AttackCase, OperationSpec
+
+
+def generate_unexpected_header_attack(operation: OperationSpec) -> list[AttackCase]:
+    path_params, query, headers, body = base_request_context(operation)
+    headers["X-Knives-Out-Probe"] = "unexpected-header"
+
+    return [
+        AttackCase(
+            id=attack_id(operation.operation_id, "unexpected_header", "header:X-Knives-Out-Probe"),
+            name="Unexpected header probe",
+            kind="unexpected_header",
+            operation_id=operation.operation_id,
+            method=operation.method,
+            path=operation.path,
+            description="Adds an unexpected header to probe strict header handling.",
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            body_json=body,
+            response_schemas=deepcopy(operation.response_schemas),
+        )
+    ]
+
+
+attack_pack = make_attack_pack("unexpected-header", generate_unexpected_header_attack)

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -4,6 +4,7 @@ import hashlib
 from copy import deepcopy
 from typing import Any
 
+from knives_out.attack_packs import LoadedAttackPack
 from knives_out.models import AttackCase, AttackSuite, OperationSpec, ParameterSpec
 
 MAX_SAMPLE_DEPTH = 4
@@ -155,12 +156,12 @@ def malformed_json_body(_: dict[str, Any] | None) -> str:
     return '{"unterminated": true'
 
 
-def _attack_id(operation_id: str, kind: str, target: str) -> str:
+def attack_id(operation_id: str, kind: str, target: str) -> str:
     digest = hashlib.sha1(f"{operation_id}:{kind}:{target}".encode()).hexdigest()[:12]
     return f"atk_{digest}"
 
 
-def _base_request_context(
+def base_request_context(
     operation: OperationSpec,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, str], Any | None]:
     path_params: dict[str, Any] = {}
@@ -199,7 +200,7 @@ def _response_schemas_for_attack(operation: OperationSpec) -> dict[str, Any]:
 
 def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]:
     attacks: list[AttackCase] = []
-    base_path_params, base_query_params, base_headers, base_body = _base_request_context(operation)
+    base_path_params, base_query_params, base_headers, base_body = base_request_context(operation)
 
     for parameter in operation.parameters:
         if parameter.required and parameter.location in {"query", "header"}:
@@ -213,7 +214,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
 
             attacks.append(
                 AttackCase(
-                    id=_attack_id(
+                    id=attack_id(
                         operation.operation_id,
                         "missing_required_param",
                         _parameter_target_label(parameter),
@@ -249,7 +250,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
 
         attacks.append(
             AttackCase(
-                id=_attack_id(
+                id=attack_id(
                     operation.operation_id,
                     "wrong_type_param",
                     _parameter_target_label(parameter),
@@ -287,7 +288,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
 
             attacks.append(
                 AttackCase(
-                    id=_attack_id(
+                    id=attack_id(
                         operation.operation_id,
                         "invalid_enum",
                         _parameter_target_label(parameter),
@@ -312,7 +313,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
         )
         attacks.append(
             AttackCase(
-                id=_attack_id(operation.operation_id, "missing_request_body", "body"),
+                id=attack_id(operation.operation_id, "missing_request_body", "body"),
                 name="Missing request body",
                 kind="missing_request_body",
                 operation_id=operation.operation_id,
@@ -333,7 +334,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
         )
         attacks.append(
             AttackCase(
-                id=_attack_id(operation.operation_id, "malformed_json_body", "body"),
+                id=attack_id(operation.operation_id, "malformed_json_body", "body"),
                 name="Malformed JSON body",
                 kind="malformed_json_body",
                 operation_id=operation.operation_id,
@@ -355,7 +356,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
         )
         attacks.append(
             AttackCase(
-                id=_attack_id(operation.operation_id, "missing_auth", "auth"),
+                id=attack_id(operation.operation_id, "missing_auth", "auth"),
                 name="Missing auth",
                 kind="missing_auth",
                 operation_id=operation.operation_id,
@@ -375,8 +376,16 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
     return attacks
 
 
-def generate_attack_suite(operations: list[OperationSpec], source: str) -> AttackSuite:
+def generate_attack_suite(
+    operations: list[OperationSpec],
+    source: str,
+    *,
+    extra_packs: list[LoadedAttackPack] | None = None,
+) -> AttackSuite:
     attacks: list[AttackCase] = []
+    packs = list(extra_packs or [])
     for operation in operations:
         attacks.extend(generate_attacks_for_operation(operation))
+        for pack in packs:
+            attacks.extend(pack.generate(operation))
     return AttackSuite(source=source, attacks=attacks)

--- a/tests/test_attack_packs.py
+++ b/tests/test_attack_packs.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from knives_out.attack_packs import (
+    ENTRY_POINT_GROUP,
+    load_attack_packs,
+    load_entry_point_attack_packs,
+    load_module_attack_packs,
+    make_attack_pack,
+)
+from knives_out.generator import generate_attack_suite
+from knives_out.models import AttackCase, OperationSpec
+
+
+def _operation() -> OperationSpec:
+    return OperationSpec(
+        operation_id="createPet",
+        method="POST",
+        path="/pets",
+    )
+
+
+def test_generate_attack_suite_accepts_custom_attack_packs() -> None:
+    pack = make_attack_pack(
+        "custom-pack",
+        lambda operation: [
+            AttackCase(
+                id=f"atk_{operation.operation_id}_custom",
+                name="Custom attack",
+                kind="custom_probe",
+                operation_id=operation.operation_id,
+                method=operation.method,
+                path=operation.path,
+                description="Custom attack",
+            )
+        ],
+    )
+
+    suite = generate_attack_suite([_operation()], source="unit", extra_packs=[pack])
+
+    assert any(attack.kind == "custom_probe" for attack in suite.attacks)
+
+
+def test_load_module_attack_packs_supports_local_modules(tmp_path: Path) -> None:
+    module_path = tmp_path / "custom_pack.py"
+    module_path.write_text(
+        dedent(
+            """
+            from knives_out.attack_packs import make_attack_pack
+            from knives_out.models import AttackCase, OperationSpec
+
+            def generate(operation: OperationSpec) -> list[AttackCase]:
+                return [
+                    AttackCase(
+                        id=f"atk_{operation.operation_id}_module",
+                        name="Module pack attack",
+                        kind="module_probe",
+                        operation_id=operation.operation_id,
+                        method=operation.method,
+                        path=operation.path,
+                        description="Module pack attack",
+                    )
+                ]
+
+            attack_pack = make_attack_pack("module-pack", generate)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    packs = load_module_attack_packs([module_path])
+
+    assert [pack.name for pack in packs] == ["module-pack"]
+    attacks = packs[0].generate(_operation())
+    assert attacks[0].kind == "module_probe"
+
+
+def test_load_module_attack_packs_reports_import_failures(tmp_path: Path) -> None:
+    module_path = tmp_path / "broken_pack.py"
+    module_path.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to import attack pack module"):
+        load_module_attack_packs([module_path])
+
+
+def test_load_entry_point_attack_packs_supports_registered_names(monkeypatch) -> None:
+    class _FakeEntryPoint:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def load(self):
+            return make_attack_pack(
+                self.name,
+                lambda operation: [
+                    AttackCase(
+                        id=f"atk_{operation.operation_id}_entry",
+                        name="Entry point attack",
+                        kind="entry_probe",
+                        operation_id=operation.operation_id,
+                        method=operation.method,
+                        path=operation.path,
+                        description="Entry point attack",
+                    )
+                ],
+            )
+
+    class _FakeEntryPoints:
+        def select(self, *, group: str):
+            assert group == ENTRY_POINT_GROUP
+            return [_FakeEntryPoint("example-pack")]
+
+    monkeypatch.setattr("knives_out.attack_packs.entry_points", lambda: _FakeEntryPoints())
+
+    packs = load_entry_point_attack_packs(["example-pack"])
+
+    assert [pack.name for pack in packs] == ["example-pack"]
+    assert packs[0].generate(_operation())[0].kind == "entry_probe"
+
+
+def test_load_attack_packs_raises_for_missing_entry_point() -> None:
+    with pytest.raises(ValueError, match="Unknown attack pack entry point"):
+        load_attack_packs(entry_point_names=["missing-pack"])
+
+
+def test_load_attack_packs_supports_project_entry_point() -> None:
+    packs = load_attack_packs(entry_point_names=["unexpected-header"])
+
+    assert [pack.name for pack in packs] == ["unexpected-header"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 
 from typer.testing import CliRunner
 
@@ -80,7 +81,7 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr("knives_out.cli.load_operations", lambda spec: [])
     monkeypatch.setattr(
         "knives_out.cli.generate_attack_suite",
-        lambda operations, source: AttackSuite(
+        lambda operations, source, extra_packs=None: AttackSuite(
             source=source,
             attacks=[
                 AttackCase(
@@ -184,3 +185,65 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
 
     assert result.exit_code == 0
     assert captured["attack_ids"] == ["atk_post"]
+
+
+def test_generate_command_loads_local_attack_pack(tmp_path: Path) -> None:
+    spec_path = tmp_path / "custom-pack-spec.yaml"
+    spec_path.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Custom pack test
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    module_path = tmp_path / "custom_pack.py"
+    module_path.write_text(
+        dedent(
+            """
+            from knives_out.attack_packs import make_attack_pack
+            from knives_out.models import AttackCase, OperationSpec
+
+            def generate(operation: OperationSpec) -> list[AttackCase]:
+                return [
+                    AttackCase(
+                        id=f"atk_{operation.operation_id}_custom",
+                        name="Custom probe",
+                        kind="custom_probe",
+                        operation_id=operation.operation_id,
+                        method=operation.method,
+                        path=operation.path,
+                        description="Custom probe",
+                    )
+                ]
+
+            attack_pack = make_attack_pack("custom-pack", generate)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "attacks.json"
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(spec_path),
+            "--pack-module",
+            str(module_path),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert any(attack.kind == "custom_probe" for attack in suite.attacks)


### PR DESCRIPTION
## Summary
Add a supported extension seam for custom attack packs, including installed entry point loading, local module loading, an example pack, and documentation.

## What changed
- add an `attack_packs` module with the custom pack interface and loaders for entry points and local module paths
- expose stable generator helpers so custom packs can build baseline request contexts and attack ids
- add `--pack` and `--pack-module` to `generate`
- register a built-in example entry-point pack and add a local module example under `examples/custom_packs/`
- document the attack pack interface and usage in the README
- add tests for pack loading, failure paths, and CLI module loading

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- GitHub Actions `test` workflow on this branch

Closes #7