### PR TITLE
[codex] Add severity and confidence scoring

### DIFF
--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+SeverityLevel = Literal["none", "low", "medium", "high", "critical"]
+ConfidenceLevel = Literal["none", "low", "medium", "high"]
 
 
 class ParameterSpec(BaseModel):
@@ -72,6 +75,8 @@ class AttackResult(BaseModel):
     duration_ms: float | None = None
     flagged: bool = False
     issue: str | None = None
+    severity: SeverityLevel = "none"
+    confidence: ConfidenceLevel = "none"
     response_excerpt: str | None = None
     response_schema_status: str | None = None
     response_schema_valid: bool | None = None

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -3,12 +3,36 @@ from __future__ import annotations
 from collections import Counter
 from pathlib import Path
 
-from knives_out.models import AttackResults
+from knives_out.models import AttackResult, AttackResults
+
+SEVERITY_ORDER = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+CONFIDENCE_ORDER = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def load_attack_results(path: str | Path) -> AttackResults:
     raw = Path(path).read_text(encoding="utf-8")
     return AttackResults.model_validate_json(raw)
+
+
+def _flagged_sort_key(result: AttackResult) -> tuple[int, int, str, str]:
+    return (
+        -SEVERITY_ORDER.get(result.severity, 0),
+        -CONFIDENCE_ORDER.get(result.confidence, 0),
+        result.issue or "",
+        result.name.lower(),
+    )
 
 
 def render_markdown_report(results: AttackResults) -> str:
@@ -39,23 +63,26 @@ def render_markdown_report(results: AttackResults) -> str:
     lines.append("")
     lines.append("## Flagged findings")
     lines.append("")
-    lines.append("| Attack | Kind | Status | Issue | Schema | URL |")
-    lines.append("| --- | --- | ---: | --- | --- | --- |")
+    lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
+    lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
 
     found_flagged = False
-    for result in results.results:
-        if not result.flagged:
-            continue
+    flagged_results = sorted(
+        (result for result in results.results if result.flagged),
+        key=_flagged_sort_key,
+    )
+    for result in flagged_results:
         found_flagged = True
         status = str(result.status_code) if result.status_code is not None else "-"
         schema = "mismatch" if result.response_schema_valid is False else "-"
         lines.append(
             f"| {result.name} | {result.kind} | {status} | "
-            f"{result.issue or '-'} | {schema} | `{result.url}` |"
+            f"{result.issue or '-'} | {result.severity} | {result.confidence} | "
+            f"{schema} | `{result.url}` |"
         )
 
     if not found_flagged:
-        lines.append("| None | - | - | - | - | - |")
+        lines.append("| None | - | - | - | - | - | - | - |")
 
     lines.append("")
     lines.append("## Detailed results")
@@ -72,6 +99,8 @@ def render_markdown_report(results: AttackResults) -> str:
             else "- Status: `-`"
         )
         lines.append(f"- Issue: `{result.issue}`" if result.issue else "- Issue: `ok`")
+        lines.append(f"- Severity: `{result.severity}`")
+        lines.append(f"- Confidence: `{result.confidence}`")
         if result.response_schema_status:
             lines.append(f"- Declared response schema: `{result.response_schema_status}`")
         if result.response_schema_valid is True:

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -8,7 +8,23 @@ from urllib.parse import quote
 
 import httpx
 
-from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite, ResponseSpec
+from knives_out.models import (
+    AttackCase,
+    AttackResult,
+    AttackResults,
+    AttackSuite,
+    ConfidenceLevel,
+    ResponseSpec,
+    SeverityLevel,
+)
+
+ISSUE_SCORES: dict[str, tuple[SeverityLevel, ConfidenceLevel]] = {
+    "transport_error": ("low", "low"),
+    "no_status": ("low", "low"),
+    "server_error": ("high", "high"),
+    "unexpected_success": ("high", "medium"),
+    "response_schema_mismatch": ("medium", "high"),
+}
 
 
 def load_attack_suite(path: str | Path) -> AttackSuite:
@@ -40,6 +56,16 @@ def evaluate_result(status_code: int | None, error: str | None) -> tuple[bool, s
     if 200 <= status_code < 400:
         return True, "unexpected_success"
     return False, None
+
+
+def score_result(
+    *,
+    flagged: bool,
+    issue: str | None,
+) -> tuple[SeverityLevel, ConfidenceLevel]:
+    if not flagged or issue is None:
+        return "none", "none"
+    return ISSUE_SCORES.get(issue, ("medium", "medium"))
 
 
 def _excerpt(text: str, limit: int = 300) -> str:
@@ -391,6 +417,7 @@ def execute_attack_suite(
                 flagged = True
                 if issue in {None, "unexpected_success"}:
                     issue = "response_schema_mismatch"
+            severity, confidence = score_result(flagged=flagged, issue=issue)
 
             results.append(
                 AttackResult(
@@ -405,6 +432,8 @@ def execute_attack_suite(
                     duration_ms=round(duration_ms, 2),
                     flagged=flagged,
                     issue=issue,
+                    severity=severity,
+                    confidence=confidence,
                     response_excerpt=_excerpt(response.text) if response is not None else None,
                     response_schema_status=response_schema_status,
                     response_schema_valid=response_schema_valid,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -109,6 +109,8 @@ def test_execute_attack_suite_flags_response_schema_mismatch(monkeypatch) -> Non
     result = results.results[0]
     assert result.flagged is True
     assert result.issue == "response_schema_mismatch"
+    assert result.severity == "medium"
+    assert result.confidence == "high"
     assert result.response_schema_status == "201"
     assert result.response_schema_valid is False
     assert result.response_schema_error == "$.id: expected integer, got string"
@@ -185,40 +187,101 @@ def test_execute_attack_suite_skips_unmapped_status_codes(monkeypatch) -> None:
     result = results.results[0]
     assert result.flagged is False
     assert result.issue is None
+    assert result.severity == "none"
+    assert result.confidence == "none"
     assert result.response_schema_status is None
     assert result.response_schema_valid is None
     assert result.response_schema_error is None
 
 
-def test_render_markdown_report_highlights_response_schema_mismatches() -> None:
+def test_execute_attack_suite_scores_server_errors(monkeypatch) -> None:
+    response = httpx.Response(503, text="upstream unavailable")
+    _install_stub_response(monkeypatch, response)
+
+    suite = AttackSuite(source="unit", attacks=[_attack_case(response_schemas={})])
+
+    results = execute_attack_suite(suite, base_url="https://example.com")
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "server_error"
+    assert result.severity == "high"
+    assert result.confidence == "high"
+
+
+def test_render_markdown_report_sorts_flagged_findings_by_score() -> None:
     results = AttackResults(
         source="unit",
         base_url="https://example.com",
         results=[
             AttackResult(
+                attack_id="atk_transport",
+                operation_id="listPets",
+                kind="missing_auth",
+                name="Transport error",
+                method="GET",
+                url="https://example.com/pets",
+                flagged=True,
+                issue="transport_error",
+                severity="low",
+                confidence="low",
+                error="timed out",
+            ),
+            AttackResult(
+                attack_id="atk_unexpected",
+                operation_id="listPets",
+                kind="missing_auth",
+                name="Unexpected success",
+                method="GET",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="unexpected_success",
+                severity="high",
+                confidence="medium",
+            ),
+            AttackResult(
                 attack_id="atk_test",
                 operation_id="createPet",
                 kind="wrong_type_param",
-                name="Test attack",
+                name="Schema mismatch",
                 method="POST",
                 url="https://example.com/pets",
                 status_code=201,
                 flagged=True,
                 issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
                 response_schema_status="201",
                 response_schema_valid=False,
                 response_schema_error="$.id: expected integer, got string",
-            )
+            ),
+            AttackResult(
+                attack_id="atk_server",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
         ],
     )
 
     report = render_markdown_report(results)
 
     assert "Response schema mismatches" in report
-    assert "| Attack | Kind | Status | Issue | Schema | URL |" in report
+    assert "| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |" in report
     assert "response_schema_mismatch" in report
     assert "mismatch" in report
     assert "$.id: expected integer, got string" in report
+    assert report.index("| Server failure |") < report.index("| Unexpected success |")
+    assert report.index("| Unexpected success |") < report.index("| Schema mismatch |")
+    assert report.index("| Schema mismatch |") < report.index("| Transport error |")
 
 
 def test_execute_attack_suite_removes_only_declared_auth_header(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Add default severity and confidence scoring for execution findings, serialize those fields in results, and sort flagged report output by score.

## What changed
- add `severity` and `confidence` fields to `AttackResult` with backwards-compatible defaults
- score current finding types in the runner so every execution result carries stable triage metadata
- sort flagged findings by severity/confidence in the Markdown report and display those values in the summary table and detail sections
- add regression coverage for score assignment and report ordering

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- GitHub Actions `test` workflow on this branch

Closes #8