### PR TITLE
[codex] Add CI usage examples

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -1,0 +1,65 @@
+name: dev-environment-example
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  SPEC_PATH: examples/openapi/petstore.yaml
+
+jobs:
+  knives-out-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Generate attack suite
+        run: knives-out generate "$SPEC_PATH" --out attacks.json
+      - name: Run suite against dev environment
+        shell: bash
+        env:
+          KNIVES_OUT_BASE_URL: ${{ secrets.KNIVES_OUT_BASE_URL }}
+          KNIVES_OUT_AUTH_HEADER: ${{ secrets.KNIVES_OUT_AUTH_HEADER }}
+          KNIVES_OUT_AUTH_QUERY: ${{ secrets.KNIVES_OUT_AUTH_QUERY }}
+        run: |
+          if [[ -z "${KNIVES_OUT_BASE_URL}" ]]; then
+            echo "Set the KNIVES_OUT_BASE_URL repository secret before running this workflow." >&2
+            exit 1
+          fi
+
+          args=(
+            --base-url "${KNIVES_OUT_BASE_URL}"
+            --artifact-dir artifacts
+            --out results.json
+          )
+
+          if [[ -n "${KNIVES_OUT_AUTH_HEADER}" ]]; then
+            args+=(--header "${KNIVES_OUT_AUTH_HEADER}")
+          fi
+
+          if [[ -n "${KNIVES_OUT_AUTH_QUERY}" ]]; then
+            args+=(--query "${KNIVES_OUT_AUTH_QUERY}")
+          fi
+
+          knives-out run attacks.json "${args[@]}"
+      - name: Render Markdown report
+        run: knives-out report results.json --out report.md
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: knives-out-dev-results
+          if-no-files-found: ignore
+          path: |
+            attacks.json
+            results.json
+            report.md
+            artifacts/

--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ Create a Markdown report:
 knives-out report results.json --out report.md
 ```
 
+## CI usage
+
+`knives-out` works well in CI when you split the flow into the same three phases:
+
+1. generate attacks from a checked-in OpenAPI spec
+2. run them against a dev or staging environment
+3. upload the JSON results, request artifacts, and Markdown report for review
+
+A ready-to-adapt GitHub Actions example lives at `.github/workflows/dev-environment-example.yml`.
+It uses repository secrets instead of hard-coded targets:
+
+- `KNIVES_OUT_BASE_URL` for the dev or staging base URL
+- `KNIVES_OUT_AUTH_HEADER` for an optional header like `Authorization: Bearer ...`
+- `KNIVES_OUT_AUTH_QUERY` for an optional query credential like `api_key=...`
+
+`knives-out run` currently exits with status `0` when the suite executes successfully, even if
+some findings are flagged in `results.json`. That makes the default workflow review-friendly:
+teams can always upload `results.json`, `report.md`, and per-attack artifacts for triage.
+
+If you want the workflow to gate merges, add a follow-up step that reads `results.json` and fails
+when flagged results exceed your threshold. See `docs/ci.md` for the sample workflow, secret
+setup, and an optional gating snippet.
+
 ## CLI
 
 ### `inspect`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,59 @@
+# CI usage
+
+`knives-out` is designed to fit a normal CI workflow:
+
+1. generate a replayable attack suite from a checked-in OpenAPI spec
+2. run that suite against a dev or staging deployment
+3. publish the JSON results, Markdown report, and per-attack artifacts
+
+The repository includes a ready-to-adapt GitHub Actions example at
+`.github/workflows/dev-environment-example.yml`.
+
+## Required secrets
+
+The sample workflow expects:
+
+- `KNIVES_OUT_BASE_URL`
+
+Optional secrets:
+
+- `KNIVES_OUT_AUTH_HEADER`
+- `KNIVES_OUT_AUTH_QUERY`
+
+The optional values should match the current CLI surface:
+
+- `KNIVES_OUT_AUTH_HEADER`: `Authorization: Bearer dev-token`
+- `KNIVES_OUT_AUTH_QUERY`: `api_key=dev-secret`
+
+## Expected exit behavior
+
+`knives-out run` currently exits with status `0` when it finishes executing the suite, even if the
+results contain flagged findings such as `server_error`, `unexpected_success`, or
+`response_schema_mismatch`.
+
+That default behavior is intentional for review-first workflows:
+
+- `results.json` stays available for automation
+- `report.md` stays available for humans
+- `artifacts/` keeps one request/response record per attack for debugging
+
+## Optional: fail the job when findings are present
+
+If you want the workflow to gate merges, add a follow-up step after `knives-out run`:
+
+```yaml
+- name: Fail on flagged findings
+  run: |
+    python - <<'PY'
+    import json
+    from pathlib import Path
+
+    results = json.loads(Path("results.json").read_text(encoding="utf-8"))
+    flagged = sum(1 for result in results["results"] if result.get("flagged"))
+    print(f"Flagged results: {flagged}")
+    raise SystemExit(1 if flagged else 0)
+    PY
+```
+
+You can replace that logic with a severity threshold later if you only want to fail on higher
+signal findings.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+CI_DOC = ROOT / "docs" / "ci.md"
+DEV_WORKFLOW = ROOT / ".github" / "workflows" / "dev-environment-example.yml"
+
+
+def test_readme_includes_ci_guidance() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "## CI usage" in readme
+    assert ".github/workflows/dev-environment-example.yml" in readme
+    assert "KNIVES_OUT_BASE_URL" in readme
+    assert "`knives-out run` currently exits with status `0`" in readme
+
+
+def test_dev_environment_workflow_matches_current_cli_surface() -> None:
+    workflow = DEV_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "actions/checkout@v5" in workflow
+    assert "actions/setup-python@v6" in workflow
+    assert "actions/upload-artifact@v6" in workflow
+    assert 'knives-out generate "$SPEC_PATH" --out attacks.json' in workflow
+    assert 'knives-out run attacks.json "${args[@]}"' in workflow
+    assert "knives-out report results.json --out report.md" in workflow
+    assert "KNIVES_OUT_BASE_URL" in workflow
+
+
+def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
+    ci_doc = CI_DOC.read_text(encoding="utf-8")
+
+    assert "results.json" in ci_doc
+    assert "report.md" in ci_doc
+    assert "artifacts/" in ci_doc
+    assert "Optional: fail the job when findings are present" in ci_doc


### PR DESCRIPTION
## Summary
Document how to run knives-out in CI against a dev or staging environment and add a ready-to-adapt GitHub Actions workflow example.

## What changed
- add a `CI usage` section to the README with secret names, expected exit behavior, and a pointer to deeper guidance
- add a manual-only GitHub Actions example workflow that installs the project, generates attacks, runs them against a secret-backed base URL, renders a report, and uploads artifacts
- add `docs/ci.md` with the expected artifact flow and an optional gating step that fails on flagged findings
- add a lightweight regression test so the workflow example stays aligned with the current CLI surface

## Validation
- `python3 -m ruff check src tests docs .github/workflows`
- `python3 -m ruff format --check src tests`
- GitHub Actions `test` workflow on this branch

Closes #9