### PR TITLE
[codex] Add OpenAPI preflight warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Shows a summary of operations discovered in an OpenAPI document.
 knives-out inspect path/to/openapi.yaml
 ```
 
+`inspect` surfaces preflight warnings for spec gaps such as missing request schemas, vague
+security declarations, and broken `$ref` pointers.
+
 ### `generate`
 
 Builds an `AttackSuite` JSON file from an OpenAPI document.
@@ -125,6 +128,9 @@ Builds an `AttackSuite` JSON file from an OpenAPI document.
 ```bash
 knives-out generate path/to/openapi.yaml --out attacks.json
 ```
+
+`generate` echoes the same preflight warnings as `inspect` because many CI flows skip an explicit
+inspection step. `run` does not re-lint the spec because it operates on a saved attack suite.
 
 You can load custom attack packs from installed entry points or local modules:
 

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -10,7 +10,8 @@ from rich.table import Table
 from knives_out.attack_packs import load_attack_packs
 from knives_out.filtering import filter_attack_suite
 from knives_out.generator import generate_attack_suite
-from knives_out.openapi_loader import load_operations
+from knives_out.models import PreflightWarning
+from knives_out.openapi_loader import load_operations_with_warnings
 from knives_out.reporting import load_attack_results, render_markdown_report
 from knives_out.runner import execute_attack_suite, load_attack_suite
 
@@ -32,10 +33,35 @@ def _parse_key_value(items: list[str] | None, *, separator: str) -> dict[str, An
     return parsed
 
 
+def _warning_target(warning: PreflightWarning) -> str:
+    if warning.operation_id:
+        return f"{warning.operation_id} ({warning.method} {warning.path})"
+    if warning.method and warning.path:
+        return f"{warning.method} {warning.path}"
+    return "spec"
+
+
+def _print_preflight_warnings(warnings: list[PreflightWarning]) -> None:
+    if not warnings:
+        return
+
+    table = Table(title=f"Preflight warnings ({len(warnings)})")
+    table.add_column("Code")
+    table.add_column("Target")
+    table.add_column("Message")
+
+    for warning in warnings:
+        table.add_row(warning.code, _warning_target(warning), warning.message)
+
+    console.print("")
+    console.print(table)
+
+
 @app.command()
 def inspect(spec: Path) -> None:
     """Show the operations discovered in an OpenAPI spec."""
-    operations = load_operations(spec)
+    loaded = load_operations_with_warnings(spec)
+    operations = loaded.operations
 
     table = Table(title=f"knives-out inspect: {spec}")
     table.add_column("Operation ID")
@@ -57,6 +83,7 @@ def inspect(spec: Path) -> None:
 
     console.print(table)
     console.print(f"\nFound {len(operations)} operations.")
+    _print_preflight_warnings(loaded.warnings)
 
 
 @app.command()
@@ -103,7 +130,8 @@ def generate(
 
     Filters are applied after attack generation and before the suite is written.
     """
-    operations = load_operations(spec)
+    loaded = load_operations_with_warnings(spec)
+    operations = loaded.operations
     attack_packs = load_attack_packs(entry_point_names=pack, module_paths=pack_module)
     suite = generate_attack_suite(operations, source=str(spec), extra_packs=attack_packs)
     suite = filter_attack_suite(
@@ -117,6 +145,7 @@ def generate(
     )
     out.write_text(suite.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     console.print(f"Wrote {len(suite.attacks)} attacks to [bold]{out}[/bold].")
+    _print_preflight_warnings(loaded.warnings)
 
 
 @app.command()

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -36,6 +36,19 @@ class OperationSpec(BaseModel):
     response_schemas: dict[str, ResponseSpec] = Field(default_factory=dict)
 
 
+class PreflightWarning(BaseModel):
+    code: str
+    message: str
+    operation_id: str | None = None
+    method: str | None = None
+    path: str | None = None
+
+
+class LoadedOperations(BaseModel):
+    operations: list[OperationSpec] = Field(default_factory=list)
+    warnings: list[PreflightWarning] = Field(default_factory=list)
+
+
 class AttackCase(BaseModel):
     id: str
     name: str

--- a/src/knives_out/openapi_loader.py
+++ b/src/knives_out/openapi_loader.py
@@ -6,10 +6,27 @@ from typing import Any
 
 import yaml
 
-from knives_out.models import OperationSpec, ParameterSpec, ResponseSpec
+from knives_out.models import (
+    LoadedOperations,
+    OperationSpec,
+    ParameterSpec,
+    PreflightWarning,
+    ResponseSpec,
+)
 
 HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
 PARAMETER_LOCATION_ORDER = {"path": 0, "query": 1, "header": 2, "cookie": 3}
+
+
+class RefResolutionError(ValueError):
+    def __init__(self, *, code: str, ref: Any) -> None:
+        self.code = code
+        self.ref = ref
+        if code == "unsupported_ref":
+            message = f"Unsupported ref {ref!r}; only local '#/...' refs are supported."
+        else:
+            message = f"Unresolved local ref {ref!r}."
+        super().__init__(message)
 
 
 def load_openapi_document(path: str | Path) -> dict[str, Any]:
@@ -29,15 +46,133 @@ def load_openapi_document(path: str | Path) -> dict[str, Any]:
     return document
 
 
+def _operation_id(route: str, method: str, operation: dict[str, Any]) -> str:
+    operation_id = operation.get("operationId")
+    if operation_id:
+        return operation_id
+
+    sanitized_path = route.strip("/").replace("/", "_").replace("{", "").replace("}", "") or "root"
+    return f"{method}_{sanitized_path}"
+
+
+def _warning_context(route: str, method: str, operation: dict[str, Any]) -> dict[str, str]:
+    return {
+        "operation_id": _operation_id(route, method, operation),
+        "method": method.upper(),
+        "path": route,
+    }
+
+
+def _add_warning(
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    *,
+    code: str,
+    message: str,
+    operation_id: str | None = None,
+    method: str | None = None,
+    path: str | None = None,
+) -> None:
+    key = (code, message, operation_id, method, path)
+    if key in seen:
+        return
+    seen.add(key)
+    warnings.append(
+        PreflightWarning(
+            code=code,
+            message=message,
+            operation_id=operation_id,
+            method=method,
+            path=path,
+        )
+    )
+
+
+def _resolve_ref_target(ref: Any, root: dict[str, Any]) -> Any:
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        raise RefResolutionError(code="unsupported_ref", ref=ref)
+
+    target: Any = root
+    try:
+        for part in ref[2:].split("/"):
+            target = target[part]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RefResolutionError(code="unresolved_ref", ref=ref) from exc
+    return target
+
+
+def _record_ref_warning(
+    error: RefResolutionError,
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    *,
+    operation_id: str,
+    method: str,
+    path: str,
+) -> None:
+    _add_warning(
+        warnings,
+        seen,
+        code=error.code,
+        message=str(error),
+        operation_id=operation_id,
+        method=method,
+        path=path,
+    )
+
+
+def _lint_refs(
+    node: Any,
+    root: dict[str, Any],
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    *,
+    operation_id: str,
+    method: str,
+    path: str,
+) -> None:
+    if isinstance(node, dict):
+        if "$ref" in node:
+            try:
+                _resolve_ref_target(node["$ref"], root)
+            except RefResolutionError as exc:
+                _record_ref_warning(
+                    exc,
+                    warnings,
+                    seen,
+                    operation_id=operation_id,
+                    method=method,
+                    path=path,
+                )
+        for value in node.values():
+            _lint_refs(
+                value,
+                root,
+                warnings,
+                seen,
+                operation_id=operation_id,
+                method=method,
+                path=path,
+            )
+        return
+
+    if isinstance(node, list):
+        for item in node:
+            _lint_refs(
+                item,
+                root,
+                warnings,
+                seen,
+                operation_id=operation_id,
+                method=method,
+                path=path,
+            )
+
+
 def resolve_refs(node: Any, root: dict[str, Any]) -> Any:
     if isinstance(node, dict):
         if "$ref" in node:
-            ref = node["$ref"]
-            if not isinstance(ref, str) or not ref.startswith("#/"):
-                raise ValueError(f"Only local refs are supported right now: {ref!r}")
-            target: Any = root
-            for part in ref[2:].split("/"):
-                target = target[part]
+            target = _resolve_ref_target(node["$ref"], root)
             resolved = resolve_refs(deepcopy(target), root)
             sibling_keys = {k: v for k, v in node.items() if k != "$ref"}
             if sibling_keys and isinstance(resolved, dict):
@@ -55,10 +190,27 @@ def _merge_parameters(
     root: dict[str, Any],
     path_parameters: list[dict[str, Any]],
     operation_parameters: list[dict[str, Any]],
+    *,
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    operation_id: str,
+    method: str,
+    path: str,
 ) -> list[dict[str, Any]]:
     merged: dict[tuple[str, str], dict[str, Any]] = {}
     for parameter in path_parameters + operation_parameters:
-        resolved = resolve_refs(parameter, root)
+        try:
+            resolved = resolve_refs(parameter, root)
+        except RefResolutionError as exc:
+            _record_ref_warning(
+                exc,
+                warnings,
+                seen,
+                operation_id=operation_id,
+                method=method,
+                path=path,
+            )
+            continue
         merged[(resolved["name"], resolved["in"])] = resolved
     return sorted(
         merged.values(),
@@ -72,23 +224,73 @@ def _merge_parameters(
 def _extract_request_body(
     operation: dict[str, Any],
     root: dict[str, Any],
+    *,
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    operation_id: str,
+    method: str,
+    path: str,
 ) -> tuple[bool, dict[str, Any] | None, str | None]:
     request_body = operation.get("requestBody")
     if not request_body:
         return False, None, None
 
-    resolved = resolve_refs(request_body, root)
+    try:
+        resolved = resolve_refs(request_body, root)
+    except RefResolutionError as exc:
+        _record_ref_warning(
+            exc,
+            warnings,
+            seen,
+            operation_id=operation_id,
+            method=method,
+            path=path,
+        )
+        return False, None, None
     content = resolved.get("content", {})
     if not isinstance(content, dict) or not content:
+        _add_warning(
+            warnings,
+            seen,
+            code="missing_request_schema",
+            message="Request body is declared but no usable schema was found.",
+            operation_id=operation_id,
+            method=method,
+            path=path,
+        )
         return bool(resolved.get("required", False)), None, None
 
-    preferred_type, schema = _extract_content_schema(content, root)
+    preferred_type, schema = _extract_content_schema(
+        content,
+        root,
+        warnings=warnings,
+        seen=seen,
+        operation_id=operation_id,
+        method=method,
+        path=path,
+    )
+    if schema is None:
+        _add_warning(
+            warnings,
+            seen,
+            code="missing_request_schema",
+            message="Request body is declared but no usable schema was found.",
+            operation_id=operation_id,
+            method=method,
+            path=path,
+        )
     return bool(resolved.get("required", False)), schema, preferred_type
 
 
 def _extract_content_schema(
     content: dict[str, Any],
     root: dict[str, Any],
+    *,
+    warnings: list[PreflightWarning] | None = None,
+    seen: set[tuple[str, str, str | None, str | None, str | None]] | None = None,
+    operation_id: str | None = None,
+    method: str | None = None,
+    path: str | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
     if "application/json" in content:
         preferred_type = "application/json"
@@ -99,13 +301,34 @@ def _extract_content_schema(
         return None, None
 
     media_type = content.get(preferred_type, {})
-    schema = resolve_refs(media_type.get("schema"), root) if media_type.get("schema") else None
+    if not media_type.get("schema"):
+        return preferred_type, None
+
+    try:
+        schema = resolve_refs(media_type.get("schema"), root)
+    except RefResolutionError as exc:
+        if warnings is not None and seen is not None and operation_id and method and path:
+            _record_ref_warning(
+                exc,
+                warnings,
+                seen,
+                operation_id=operation_id,
+                method=method,
+                path=path,
+            )
+        return preferred_type, None
     return preferred_type, schema
 
 
 def _extract_security(
     operation: dict[str, Any],
     root: dict[str, Any],
+    *,
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    operation_id: str,
+    method: str,
+    path: str,
 ) -> tuple[bool, list[str], list[str]]:
     if "security" in operation:
         security = operation["security"]
@@ -120,6 +343,7 @@ def _extract_security(
     query_names: set[str] = set()
     has_non_optional_requirement = False
     has_optional_requirement = False
+    vague_security_reasons: set[str] = set()
 
     for requirement in security:
         if not isinstance(requirement, dict):
@@ -129,7 +353,19 @@ def _extract_security(
             continue
         has_non_optional_requirement = True
         for scheme_name in requirement:
-            scheme = resolve_refs(schemes.get(scheme_name, {}), root)
+            try:
+                scheme = resolve_refs(schemes.get(scheme_name, {}), root)
+            except RefResolutionError as exc:
+                _record_ref_warning(
+                    exc,
+                    warnings,
+                    seen,
+                    operation_id=operation_id,
+                    method=method,
+                    path=path,
+                )
+                vague_security_reasons.add(str(scheme_name))
+                continue
             scheme_type = scheme.get("type")
             if scheme_type == "http":
                 header_names.add("Authorization")
@@ -140,14 +376,37 @@ def _extract_security(
                     header_names.add(name)
                 elif location == "query" and name:
                     query_names.add(name)
+                else:
+                    vague_security_reasons.add(str(scheme_name))
+            else:
+                vague_security_reasons.add(str(scheme_name))
 
     auth_required = has_non_optional_requirement and not has_optional_requirement
+    if has_non_optional_requirement and vague_security_reasons:
+        scheme_list = ", ".join(sorted(vague_security_reasons))
+        _add_warning(
+            warnings,
+            seen,
+            code="vague_security",
+            message=(
+                f"Security requirements include unsupported or ambiguous schemes: {scheme_list}."
+            ),
+            operation_id=operation_id,
+            method=method,
+            path=path,
+        )
     return auth_required, sorted(header_names), sorted(query_names)
 
 
 def _extract_response_schemas(
     operation: dict[str, Any],
     root: dict[str, Any],
+    *,
+    warnings: list[PreflightWarning],
+    seen: set[tuple[str, str, str | None, str | None, str | None]],
+    operation_id: str,
+    method: str,
+    path: str,
 ) -> dict[str, ResponseSpec]:
     responses = operation.get("responses", {})
     if not isinstance(responses, dict):
@@ -155,13 +414,33 @@ def _extract_response_schemas(
 
     extracted: dict[str, ResponseSpec] = {}
     for status_code, response in responses.items():
-        resolved = resolve_refs(response, root)
+        try:
+            resolved = resolve_refs(response, root)
+        except RefResolutionError as exc:
+            _record_ref_warning(
+                exc,
+                warnings,
+                seen,
+                operation_id=operation_id,
+                method=method,
+                path=path,
+            )
+            extracted[str(status_code)] = ResponseSpec()
+            continue
         content = resolved.get("content", {})
         if not isinstance(content, dict) or not content:
             extracted[str(status_code)] = ResponseSpec()
             continue
 
-        content_type, schema = _extract_content_schema(content, root)
+        content_type, schema = _extract_content_schema(
+            content,
+            root,
+            warnings=warnings,
+            seen=seen,
+            operation_id=operation_id,
+            method=method,
+            path=path,
+        )
         extracted[str(status_code)] = ResponseSpec(
             content_type=content_type,
             schema_def=schema,
@@ -170,9 +449,11 @@ def _extract_response_schemas(
     return extracted
 
 
-def load_operations(path: str | Path) -> list[OperationSpec]:
+def load_operations_with_warnings(path: str | Path) -> LoadedOperations:
     document = load_openapi_document(path)
     operations: list[OperationSpec] = []
+    warnings: list[PreflightWarning] = []
+    seen_warnings: set[tuple[str, str, str | None, str | None, str | None]] = set()
 
     for route, path_item in document.get("paths", {}).items():
         if not isinstance(path_item, dict):
@@ -184,8 +465,31 @@ def load_operations(path: str | Path) -> list[OperationSpec]:
             if not operation:
                 continue
 
+            context = _warning_context(route, method, operation)
+            _lint_refs(
+                {
+                    "path_parameters": path_parameters,
+                    "operation": operation,
+                },
+                document,
+                warnings,
+                seen_warnings,
+                operation_id=context["operation_id"],
+                method=context["method"],
+                path=context["path"],
+            )
+
             operation_parameters = operation.get("parameters", [])
-            merged_parameters = _merge_parameters(document, path_parameters, operation_parameters)
+            merged_parameters = _merge_parameters(
+                document,
+                path_parameters,
+                operation_parameters,
+                warnings=warnings,
+                seen=seen_warnings,
+                operation_id=context["operation_id"],
+                method=context["method"],
+                path=context["path"],
+            )
             parsed_parameters = [
                 ParameterSpec(
                     name=parameter["name"],
@@ -200,24 +504,38 @@ def load_operations(path: str | Path) -> list[OperationSpec]:
                 request_body_required,
                 request_body_schema,
                 request_body_content_type,
-            ) = _extract_request_body(operation, document)
+            ) = _extract_request_body(
+                operation,
+                document,
+                warnings=warnings,
+                seen=seen_warnings,
+                operation_id=context["operation_id"],
+                method=context["method"],
+                path=context["path"],
+            )
             auth_required, auth_header_names, auth_query_names = _extract_security(
                 operation,
                 document,
+                warnings=warnings,
+                seen=seen_warnings,
+                operation_id=context["operation_id"],
+                method=context["method"],
+                path=context["path"],
             )
-            response_schemas = _extract_response_schemas(operation, document)
-
-            operation_id = operation.get("operationId")
-            if not operation_id:
-                sanitized_path = (
-                    route.strip("/").replace("/", "_").replace("{", "").replace("}", "") or "root"
-                )
-                operation_id = f"{method}_{sanitized_path}"
+            response_schemas = _extract_response_schemas(
+                operation,
+                document,
+                warnings=warnings,
+                seen=seen_warnings,
+                operation_id=context["operation_id"],
+                method=context["method"],
+                path=context["path"],
+            )
 
             operations.append(
                 OperationSpec(
-                    operation_id=operation_id,
-                    method=method.upper(),
+                    operation_id=context["operation_id"],
+                    method=context["method"],
                     path=route,
                     summary=operation.get("summary") or operation.get("description"),
                     parameters=parsed_parameters,
@@ -231,4 +549,8 @@ def load_operations(path: str | Path) -> list[OperationSpec]:
                 )
             )
 
-    return operations
+    return LoadedOperations(operations=operations, warnings=warnings)
+
+
+def load_operations(path: str | Path) -> list[OperationSpec]:
+    return load_operations_with_warnings(path).operations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,13 @@ from textwrap import dedent
 from typer.testing import CliRunner
 
 from knives_out.cli import app
-from knives_out.models import AttackCase, AttackResults, AttackSuite
+from knives_out.models import (
+    AttackCase,
+    AttackResults,
+    AttackSuite,
+    LoadedOperations,
+    PreflightWarning,
+)
 
 runner = CliRunner()
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
@@ -15,6 +21,31 @@ def test_inspect_command_runs() -> None:
 
     assert result.exit_code == 0
     assert "Found 3 operations." in result.stdout
+
+
+def test_inspect_command_shows_preflight_warnings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "knives_out.cli.load_operations_with_warnings",
+        lambda spec: LoadedOperations(
+            operations=[],
+            warnings=[
+                PreflightWarning(
+                    code="missing_request_schema",
+                    message="Request body is declared but no usable schema was found.",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                )
+            ],
+        ),
+    )
+
+    result = runner.invoke(app, ["inspect", str(EXAMPLE_SPEC)])
+
+    assert result.exit_code == 0
+    assert "Preflight warnings" in result.stdout
+    assert "missing_request_schema" in result.stdout
+    assert "createPet" in result.stdout
 
 
 def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
@@ -78,7 +109,10 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
 def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
     out_path = tmp_path / "attacks.json"
 
-    monkeypatch.setattr("knives_out.cli.load_operations", lambda spec: [])
+    monkeypatch.setattr(
+        "knives_out.cli.load_operations_with_warnings",
+        lambda spec: LoadedOperations(operations=[], warnings=[]),
+    )
     monkeypatch.setattr(
         "knives_out.cli.generate_attack_suite",
         lambda operations, source, extra_packs=None: AttackSuite(
@@ -121,6 +155,39 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
     assert result.exit_code == 0
     suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert [attack.id for attack in suite.attacks] == ["atk_post"]
+
+
+def test_generate_command_echoes_preflight_warnings(tmp_path: Path, monkeypatch) -> None:
+    out_path = tmp_path / "attacks.json"
+
+    monkeypatch.setattr(
+        "knives_out.cli.load_operations_with_warnings",
+        lambda spec: LoadedOperations(
+            operations=[],
+            warnings=[
+                PreflightWarning(
+                    code="vague_security",
+                    message=(
+                        "Security requirements include unsupported or ambiguous schemes: "
+                        "oauthSecurity."
+                    ),
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                )
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        "knives_out.cli.generate_attack_suite",
+        lambda operations, source, extra_packs=None: AttackSuite(source=source, attacks=[]),
+    )
+
+    result = runner.invoke(app, ["generate", str(EXAMPLE_SPEC), "--out", str(out_path)])
+
+    assert result.exit_code == 0
+    assert "Preflight warnings" in result.stdout
+    assert "vague_security" in result.stdout
 
 
 def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_openapi_loader.py
+++ b/tests/test_openapi_loader.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 
-from knives_out.openapi_loader import load_operations
+from knives_out.openapi_loader import load_operations, load_operations_with_warnings
 
 
 def test_load_operations_prefers_operation_level_parameter_overrides(tmp_path) -> None:
@@ -247,3 +247,73 @@ def test_load_operations_extracts_api_key_auth_from_components(tmp_path) -> None
 
     assert operations["optionalAuth"].auth_required is False
     assert operations["optionalAuth"].auth_header_names == ["X-API-Key"]
+
+
+def test_load_operations_with_warnings_reports_missing_request_schema_and_vague_security(
+    tmp_path,
+) -> None:
+    spec = tmp_path / "preflight-warnings.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Warning test
+              version: 1.0.0
+            components:
+              securitySchemes:
+                oauthSecurity:
+                  type: oauth2
+                  flows:
+                    clientCredentials:
+                      tokenUrl: https://example.com/token
+                      scopes: {}
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  security:
+                    - oauthSecurity: []
+                  requestBody:
+                    required: true
+                    content:
+                      application/json: {}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_operations_with_warnings(spec)
+
+    warning_codes = {warning.code for warning in loaded.warnings}
+    assert warning_codes == {"missing_request_schema", "vague_security"}
+    assert {warning.operation_id for warning in loaded.warnings} == {"createPet"}
+
+
+def test_load_operations_with_warnings_reports_bad_refs_without_failing(tmp_path) -> None:
+    spec = tmp_path / "bad-refs.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Bad refs
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: getPets
+                  parameters:
+                    - $ref: ./parameters.yaml#/PetId
+                  requestBody:
+                    $ref: "#/components/requestBodies/MissingBody"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_operations_with_warnings(spec)
+
+    assert [operation.operation_id for operation in loaded.operations] == ["getPets"]
+    warning_codes = {warning.code for warning in loaded.warnings}
+    assert warning_codes == {"unsupported_ref", "unresolved_ref"}


### PR DESCRIPTION
## Summary
Add spec preflight warnings for common OpenAPI gaps so users can distinguish generation limits caused by the tool from limits caused by the spec itself.

## What changed
- add warning/result models for preflight analysis and a loader entry point that returns both operations and warnings
- detect and surface missing request schemas, vague security declarations, and unresolved or unsupported `$ref` values
- make spec loading tolerant of those non-fatal gaps so inspect/generate can continue and show the warnings instead of crashing
- render warnings in `knives-out inspect` and echo them in `knives-out generate`
- document that `generate` echoes the same warnings because CI users often skip an explicit inspect step
- add tests for warning detection and CLI presentation

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- `python3 -m pytest -q tests/test_openapi_loader.py tests/test_cli.py` *(not available in this host shell: `/Library/Developer/CommandLineTools/usr/bin/python3: No module named pytest`)*
- GitHub Actions `test` workflow on this branch

Closes #10