### PR TITLE
[codex] Add regression-aware CI gating

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -52,6 +52,11 @@ jobs:
           knives-out run attacks.json "${args[@]}"
       - name: Render Markdown report
         run: knives-out report results.json --out report.md
+      - name: Verify findings against CI policy
+        run: |
+          knives-out verify results.json \
+            --min-severity high \
+            --min-confidence medium
       - name: Upload run artifacts
         if: always()
         uses: actions/upload-artifact@v6

--- a/README.md
+++ b/README.md
@@ -85,13 +85,22 @@ Create a Markdown report:
 knives-out report results.json --out report.md
 ```
 
+Verify findings against the default CI policy:
+
+```bash
+knives-out verify results.json
+```
+
 ## CI usage
 
-`knives-out` works well in CI when you split the flow into the same three phases:
+`knives-out` works well in CI when you follow the same generate/run/report flow and add a final
+verification step:
 
 1. generate attacks from a checked-in OpenAPI spec
 2. run them against a dev or staging environment
-3. upload the JSON results, request artifacts, and Markdown report for review
+3. render a Markdown report for review
+4. verify the results against a CI policy
+5. upload the JSON results, request artifacts, and Markdown report for triage
 
 A ready-to-adapt GitHub Actions example lives at `.github/workflows/dev-environment-example.yml`.
 It uses repository secrets instead of hard-coded targets:
@@ -101,12 +110,12 @@ It uses repository secrets instead of hard-coded targets:
 - `KNIVES_OUT_AUTH_QUERY` for an optional query credential like `api_key=...`
 
 `knives-out run` currently exits with status `0` when the suite executes successfully, even if
-some findings are flagged in `results.json`. That makes the default workflow review-friendly:
+some findings are flagged in `results.json`. That keeps execution review-friendly:
 teams can always upload `results.json`, `report.md`, and per-attack artifacts for triage.
 
-If you want the workflow to gate merges, add a follow-up step that reads `results.json` and fails
-when flagged results exceed your threshold. See `docs/ci.md` for the sample workflow, secret
-setup, and an optional gating snippet.
+For built-in gating, use `knives-out verify` after `run`. It can fail on qualifying findings in the
+current run, or only on new qualifying findings when you also pass `--baseline previous-results.json`.
+See `docs/ci.md` for the sample workflow, secret setup, and baseline-aware CI patterns.
 
 ## CLI
 
@@ -165,6 +174,30 @@ Renders Markdown from a results JSON file.
 
 ```bash
 knives-out report results.json --out report.md
+```
+
+You can include a prior `results.json` as a baseline to add regression sections for new, resolved,
+and persisting findings:
+
+```bash
+knives-out report results.json --baseline previous-results.json --out report.md
+```
+
+### `verify`
+
+Checks a results JSON file against a CI policy and exits non-zero when the policy fails.
+
+```bash
+knives-out verify results.json
+```
+
+To fail only on new high-signal regressions, compare against a prior results file:
+
+```bash
+knives-out verify results.json \
+  --baseline previous-results.json \
+  --min-severity high \
+  --min-confidence medium
 ```
 
 ## Development

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,7 +4,9 @@
 
 1. generate a replayable attack suite from a checked-in OpenAPI spec
 2. run that suite against a dev or staging deployment
-3. publish the JSON results, Markdown report, and per-attack artifacts
+3. render a Markdown report for review
+4. verify the results against a CI policy
+5. publish the JSON results, Markdown report, and per-attack artifacts
 
 The repository includes a ready-to-adapt GitHub Actions example at
 `.github/workflows/dev-environment-example.yml`.
@@ -37,23 +39,49 @@ That default behavior is intentional for review-first workflows:
 - `report.md` stays available for humans
 - `artifacts/` keeps one request/response record per attack for debugging
 
-## Optional: fail the job when findings are present
+`knives-out verify` is the built-in gating step. It reads `results.json`, applies severity and
+confidence thresholds, and exits with:
 
-If you want the workflow to gate merges, add a follow-up step after `knives-out run`:
+- `0` when the policy passes
+- `1` when the policy fails
+
+## Simple gating with no baseline
+
+Use this when you want CI to fail on qualifying findings in the current run:
 
 ```yaml
-- name: Fail on flagged findings
+- name: Verify findings
   run: |
-    python - <<'PY'
-    import json
-    from pathlib import Path
-
-    results = json.loads(Path("results.json").read_text(encoding="utf-8"))
-    flagged = sum(1 for result in results["results"] if result.get("flagged"))
-    print(f"Flagged results: {flagged}")
-    raise SystemExit(1 if flagged else 0)
-    PY
+    knives-out verify results.json \
+      --min-severity high \
+      --min-confidence medium
 ```
 
-You can replace that logic with a severity threshold later if you only want to fail on higher
-signal findings.
+## Baseline-aware gating
+
+If your workflow can provide a prior `results.json`, `verify` can fail only on new qualifying
+findings:
+
+```yaml
+- name: Verify against baseline
+  run: |
+    knives-out verify results.json \
+      --baseline previous-results.json \
+      --min-severity high \
+      --min-confidence medium
+```
+
+The tool does not fetch that baseline for you. Your workflow is responsible for placing
+`previous-results.json` in the workspace before this step.
+
+## Optional: baseline-aware report
+
+You can also render a Markdown report that highlights new, resolved, and persisting findings:
+
+```yaml
+- name: Render baseline-aware report
+  run: |
+    knives-out report results.json \
+      --baseline previous-results.json \
+      --out report.md
+```

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -1,22 +1,38 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
 
 import typer
+from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
 from knives_out.attack_packs import load_attack_packs
 from knives_out.filtering import filter_attack_suite
 from knives_out.generator import generate_attack_suite
-from knives_out.models import PreflightWarning
+from knives_out.models import AttackResults, PreflightWarning
 from knives_out.openapi_loader import load_operations_with_warnings
 from knives_out.reporting import load_attack_results, render_markdown_report
 from knives_out.runner import execute_attack_suite, load_attack_suite
+from knives_out.verification import ComparedFinding, evaluate_verification
 
 app = typer.Typer(no_args_is_help=True, help="Adversarial API testing from OpenAPI specs.")
 console = Console()
+
+
+class SeverityThresholdOption(StrEnum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+    critical = "critical"
+
+
+class ConfidenceThresholdOption(StrEnum):
+    low = "low"
+    medium = "medium"
+    high = "high"
 
 
 def _parse_key_value(items: list[str] | None, *, separator: str) -> dict[str, Any]:
@@ -52,6 +68,38 @@ def _print_preflight_warnings(warnings: list[PreflightWarning]) -> None:
 
     for warning in warnings:
         table.add_row(warning.code, _warning_target(warning), warning.message)
+
+    console.print("")
+    console.print(table)
+
+
+def _load_attack_results_or_error(path: Path, *, label: str) -> AttackResults:
+    try:
+        return load_attack_results(path)
+    except (OSError, ValidationError, ValueError) as exc:
+        raise typer.BadParameter(f"Could not read {label} results file '{path}': {exc}") from exc
+
+
+def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> None:
+    if not findings:
+        return
+
+    table = Table(title=title)
+    table.add_column("Attack")
+    table.add_column("Issue")
+    table.add_column("Severity")
+    table.add_column("Confidence")
+    table.add_column("Status")
+
+    for finding in findings:
+        result = finding.result
+        table.add_row(
+            result.name,
+            result.issue or "-",
+            result.severity,
+            result.confidence,
+            str(result.status_code) if result.status_code is not None else "-",
+        )
 
     console.print("")
     console.print(table)
@@ -237,14 +285,21 @@ def run(
 @app.command()
 def report(
     results: Path,
+    baseline: Annotated[
+        Path | None,
+        typer.Option(help="Optional baseline results file for regression comparison."),
+    ] = None,
     out: Annotated[
         Path | None,
         typer.Option(help="Optional Markdown output file."),
     ] = None,
 ) -> None:
     """Render a Markdown report from a results file."""
-    attack_results = load_attack_results(results)
-    markdown = render_markdown_report(attack_results)
+    attack_results = _load_attack_results_or_error(results, label="current")
+    baseline_results = (
+        _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
+    )
+    markdown = render_markdown_report(attack_results, baseline=baseline_results)
 
     if out is None:
         console.print(markdown)
@@ -252,6 +307,70 @@ def report(
 
     out.write_text(markdown, encoding="utf-8")
     console.print(f"Wrote report to [bold]{out}[/bold].")
+
+
+@app.command()
+def verify(
+    results: Path,
+    baseline: Annotated[
+        Path | None,
+        typer.Option(help="Optional baseline results file for regression comparison."),
+    ] = None,
+    min_severity: Annotated[
+        SeverityThresholdOption,
+        typer.Option(help="Minimum severity that should fail verification."),
+    ] = SeverityThresholdOption.high,
+    min_confidence: Annotated[
+        ConfidenceThresholdOption,
+        typer.Option(help="Minimum confidence that should fail verification."),
+    ] = ConfidenceThresholdOption.medium,
+) -> None:
+    """Verify results against CI policy, optionally compared to a baseline."""
+    attack_results = _load_attack_results_or_error(results, label="current")
+    baseline_results = (
+        _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
+    )
+    verification = evaluate_verification(
+        attack_results,
+        baseline=baseline_results,
+        min_severity=min_severity.value,
+        min_confidence=min_confidence.value,
+    )
+    comparison = verification.comparison
+
+    console.print(
+        "Verification policy: "
+        f"severity >= [bold]{min_severity.value}[/bold], "
+        f"confidence >= [bold]{min_confidence.value}[/bold]."
+    )
+    if verification.baseline_used:
+        console.print(
+            "Compared current findings against a baseline. "
+            f"New: {len(comparison.new_findings)}, "
+            f"Resolved: {len(comparison.resolved_findings)}, "
+            f"Persisting: {len(comparison.persisting_findings)}."
+        )
+        _print_compared_findings(
+            "New findings meeting policy",
+            verification.failing_findings,
+        )
+    else:
+        console.print(
+            "Evaluated current flagged findings only. "
+            f"Flagged: {len(comparison.current_findings)}, "
+            f"meeting policy: {len(verification.failing_findings)}."
+        )
+        _print_compared_findings(
+            "Current findings meeting policy",
+            verification.failing_findings,
+        )
+
+    if verification.passed:
+        console.print("Verification passed.")
+        return
+
+    console.print("Verification failed.")
+    raise typer.Exit(code=1)
 
 
 def main() -> None:

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -3,22 +3,12 @@ from __future__ import annotations
 from collections import Counter
 from pathlib import Path
 
-from knives_out.models import AttackResult, AttackResults
-
-SEVERITY_ORDER = {
-    "none": 0,
-    "low": 1,
-    "medium": 2,
-    "high": 3,
-    "critical": 4,
-}
-
-CONFIDENCE_ORDER = {
-    "none": 0,
-    "low": 1,
-    "medium": 2,
-    "high": 3,
-}
+from knives_out.models import AttackResults
+from knives_out.verification import (
+    ComparedFinding,
+    attack_result_sort_key,
+    compare_attack_results,
+)
 
 
 def load_attack_results(path: str | Path) -> AttackResults:
@@ -26,16 +16,25 @@ def load_attack_results(path: str | Path) -> AttackResults:
     return AttackResults.model_validate_json(raw)
 
 
-def _flagged_sort_key(result: AttackResult) -> tuple[int, int, str, str]:
-    return (
-        -SEVERITY_ORDER.get(result.severity, 0),
-        -CONFIDENCE_ORDER.get(result.confidence, 0),
-        result.issue or "",
-        result.name.lower(),
-    )
+def _finding_table_rows(findings: list[ComparedFinding]) -> list[str]:
+    rows: list[str] = []
+    for finding in findings:
+        result = finding.result
+        status = str(result.status_code) if result.status_code is not None else "-"
+        schema = "mismatch" if result.response_schema_valid is False else "-"
+        rows.append(
+            f"| {result.name} | {result.kind} | {status} | "
+            f"{result.issue or '-'} | {result.severity} | {result.confidence} | "
+            f"{schema} | `{result.url}` |"
+        )
+    return rows
 
 
-def render_markdown_report(results: AttackResults) -> str:
+def render_markdown_report(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+) -> str:
     total = len(results.results)
     flagged = sum(1 for result in results.results if result.flagged)
     response_schema_mismatches = sum(
@@ -69,7 +68,7 @@ def render_markdown_report(results: AttackResults) -> str:
     found_flagged = False
     flagged_results = sorted(
         (result for result in results.results if result.flagged),
-        key=_flagged_sort_key,
+        key=attack_result_sort_key,
     )
     for result in flagged_results:
         found_flagged = True
@@ -83,6 +82,44 @@ def render_markdown_report(results: AttackResults) -> str:
 
     if not found_flagged:
         lines.append("| None | - | - | - | - | - | - | - |")
+
+    if baseline is not None:
+        comparison = compare_attack_results(results, baseline)
+
+        lines.append("")
+        lines.append("## Verification summary")
+        lines.append("")
+        lines.append(f"- Baseline executed at: `{baseline.executed_at.isoformat()}`")
+        lines.append(f"- New findings: **{len(comparison.new_findings)}**")
+        lines.append(f"- Resolved findings: **{len(comparison.resolved_findings)}**")
+        lines.append(f"- Persisting findings: **{len(comparison.persisting_findings)}**")
+
+        lines.append("")
+        lines.append("## New findings")
+        lines.append("")
+        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
+        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+        lines.extend(_finding_table_rows(comparison.new_findings))
+        if not comparison.new_findings:
+            lines.append("| None | - | - | - | - | - | - | - |")
+
+        lines.append("")
+        lines.append("## Resolved findings")
+        lines.append("")
+        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
+        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+        lines.extend(_finding_table_rows(comparison.resolved_findings))
+        if not comparison.resolved_findings:
+            lines.append("| None | - | - | - | - | - | - | - |")
+
+        lines.append("")
+        lines.append("## Persisting findings")
+        lines.append("")
+        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
+        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+        lines.extend(_finding_table_rows(comparison.persisting_findings))
+        if not comparison.persisting_findings:
+            lines.append("| None | - | - | - | - | - | - | - |")
 
     lines.append("")
     lines.append("## Detailed results")

--- a/src/knives_out/verification.py
+++ b/src/knives_out/verification.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from knives_out.models import AttackResult, AttackResults
+
+SeverityThreshold = Literal["low", "medium", "high", "critical"]
+ConfidenceThreshold = Literal["low", "medium", "high"]
+FindingChange = Literal["new", "resolved", "persisting"]
+
+SEVERITY_ORDER = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+CONFIDENCE_ORDER = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
+
+@dataclass(frozen=True)
+class ComparedFinding:
+    change: FindingChange
+    current: AttackResult | None
+    baseline: AttackResult | None
+
+    @property
+    def result(self) -> AttackResult:
+        if self.current is not None:
+            return self.current
+        if self.baseline is not None:
+            return self.baseline
+        raise ValueError("ComparedFinding requires a current or baseline result.")
+
+    @property
+    def attack_id(self) -> str:
+        return self.result.attack_id
+
+    @property
+    def issue(self) -> str:
+        issue = self.result.issue
+        if issue is None:
+            raise ValueError("ComparedFinding requires a flagged result with an issue.")
+        return issue
+
+
+@dataclass(frozen=True)
+class ResultComparison:
+    current: AttackResults
+    baseline: AttackResults | None
+    current_findings: list[AttackResult]
+    baseline_findings: list[AttackResult]
+    new_findings: list[ComparedFinding]
+    resolved_findings: list[ComparedFinding]
+    persisting_findings: list[ComparedFinding]
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    comparison: ResultComparison
+    min_severity: SeverityThreshold
+    min_confidence: ConfidenceThreshold
+    failing_findings: list[ComparedFinding]
+
+    @property
+    def passed(self) -> bool:
+        return not self.failing_findings
+
+    @property
+    def baseline_used(self) -> bool:
+        return self.comparison.baseline is not None
+
+
+def attack_result_sort_key(result: AttackResult) -> tuple[int, int, str, str]:
+    return (
+        -SEVERITY_ORDER.get(result.severity, 0),
+        -CONFIDENCE_ORDER.get(result.confidence, 0),
+        result.issue or "",
+        result.name.lower(),
+    )
+
+
+def compared_finding_sort_key(finding: ComparedFinding) -> tuple[int, int, str, str]:
+    return attack_result_sort_key(finding.result)
+
+
+def _flagged_findings(results: AttackResults) -> dict[tuple[str, str], AttackResult]:
+    flagged: dict[tuple[str, str], AttackResult] = {}
+    for result in results.results:
+        if not result.flagged or result.issue is None:
+            continue
+        flagged[(result.attack_id, result.issue)] = result
+    return flagged
+
+
+def compare_attack_results(
+    current: AttackResults,
+    baseline: AttackResults | None = None,
+) -> ResultComparison:
+    current_flagged = _flagged_findings(current)
+    baseline_flagged = _flagged_findings(baseline) if baseline is not None else {}
+
+    current_keys = set(current_flagged)
+    baseline_keys = set(baseline_flagged)
+
+    new_findings = sorted(
+        (
+            ComparedFinding(change="new", current=current_flagged[key], baseline=None)
+            for key in current_keys - baseline_keys
+        ),
+        key=compared_finding_sort_key,
+    )
+    resolved_findings = sorted(
+        (
+            ComparedFinding(change="resolved", current=None, baseline=baseline_flagged[key])
+            for key in baseline_keys - current_keys
+        ),
+        key=compared_finding_sort_key,
+    )
+    persisting_findings = sorted(
+        (
+            ComparedFinding(
+                change="persisting",
+                current=current_flagged[key],
+                baseline=baseline_flagged[key],
+            )
+            for key in current_keys & baseline_keys
+        ),
+        key=compared_finding_sort_key,
+    )
+
+    return ResultComparison(
+        current=current,
+        baseline=baseline,
+        current_findings=sorted(current_flagged.values(), key=attack_result_sort_key),
+        baseline_findings=sorted(baseline_flagged.values(), key=attack_result_sort_key),
+        new_findings=new_findings,
+        resolved_findings=resolved_findings,
+        persisting_findings=persisting_findings,
+    )
+
+
+def meets_thresholds(
+    result: AttackResult,
+    *,
+    min_severity: SeverityThreshold,
+    min_confidence: ConfidenceThreshold,
+) -> bool:
+    return (
+        SEVERITY_ORDER.get(result.severity, 0) >= SEVERITY_ORDER[min_severity]
+        and CONFIDENCE_ORDER.get(result.confidence, 0) >= CONFIDENCE_ORDER[min_confidence]
+    )
+
+
+def evaluate_verification(
+    current: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    min_severity: SeverityThreshold = "high",
+    min_confidence: ConfidenceThreshold = "medium",
+) -> VerificationResult:
+    comparison = compare_attack_results(current, baseline)
+    if baseline is None:
+        failing_findings = [
+            ComparedFinding(change="new", current=result, baseline=None)
+            for result in comparison.current_findings
+            if meets_thresholds(
+                result,
+                min_severity=min_severity,
+                min_confidence=min_confidence,
+            )
+        ]
+    else:
+        failing_findings = [
+            finding
+            for finding in comparison.new_findings
+            if meets_thresholds(
+                finding.result,
+                min_severity=min_severity,
+                min_confidence=min_confidence,
+            )
+        ]
+
+    return VerificationResult(
+        comparison=comparison,
+        min_severity=min_severity,
+        min_confidence=min_confidence,
+        failing_findings=failing_findings,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,7 +289,8 @@ def test_verify_command_passes_with_baseline_when_findings_only_persist(tmp_path
     )
 
     assert result.exit_code == 0
-    assert "Persisting: 1" in result.stdout
+    assert "Persisting:" in result.stdout
+    assert "1." in result.stdout
     assert "Verification passed." in result.stdout
 
 
@@ -378,7 +379,7 @@ def test_verify_command_reports_bad_baseline_file(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 2
-    assert "Could not read baseline results file" in result.stdout
+    assert "Could not read baseline results file" in result.stderr
 
 
 def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 from knives_out.cli import app
 from knives_out.models import (
     AttackCase,
+    AttackResult,
     AttackResults,
     AttackSuite,
     LoadedOperations,
@@ -14,6 +15,18 @@ from knives_out.models import (
 
 runner = CliRunner()
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
+
+
+def _write_results(path: Path, results: AttackResults) -> None:
+    path.write_text(results.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
+
+
+def _results_with_findings(*results: AttackResult) -> AttackResults:
+    return AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=list(results),
+    )
 
 
 def test_inspect_command_runs() -> None:
@@ -56,6 +69,94 @@ def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
     assert out_path.exists()
     raw = out_path.read_text(encoding="utf-8")
     assert '"attacks"' in raw
+
+
+def test_report_command_supports_baseline(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    report_path = tmp_path / "report.md"
+
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_new",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="New server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+            ),
+        ),
+    )
+    _write_results(
+        baseline_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+            ),
+            AttackResult(
+                attack_id="atk_old",
+                operation_id="listPets",
+                kind="missing_auth",
+                name="Resolved auth failure",
+                method="GET",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            str(current_path),
+            "--baseline",
+            str(baseline_path),
+            "--out",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "## Verification summary" in report
+    assert "## New findings" in report
+    assert "## Resolved findings" in report
+    assert "## Persisting findings" in report
 
 
 def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
@@ -104,6 +205,180 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
     assert captured["suite_source"] == "unit"
     assert captured["base_url"] == "https://example.com"
     assert captured["artifact_dir"] == artifact_dir
+
+
+def test_verify_command_passes_without_baseline_when_no_qualifying_findings(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_medium",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Medium mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(app, ["verify", str(results_path)])
+
+    assert result.exit_code == 0
+    assert "Verification passed." in result.stdout
+
+
+def test_verify_command_fails_without_baseline_when_qualifying_findings_exist(
+    tmp_path: Path,
+) -> None:
+    results_path = tmp_path / "results.json"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_server",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(app, ["verify", str(results_path)])
+
+    assert result.exit_code == 1
+    assert "Verification failed." in result.stdout
+    assert "Server failure" in result.stdout
+
+
+def test_verify_command_passes_with_baseline_when_findings_only_persist(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    shared = AttackResult(
+        attack_id="atk_shared",
+        operation_id="createPet",
+        kind="missing_request_body",
+        name="Shared failure",
+        method="POST",
+        url="https://example.com/pets",
+        status_code=500,
+        flagged=True,
+        issue="server_error",
+        severity="high",
+        confidence="high",
+    )
+    _write_results(current_path, _results_with_findings(shared))
+    _write_results(baseline_path, _results_with_findings(shared))
+
+    result = runner.invoke(
+        app,
+        ["verify", str(current_path), "--baseline", str(baseline_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Persisting: 1" in result.stdout
+    assert "Verification passed." in result.stdout
+
+
+def test_verify_command_fails_with_baseline_when_new_qualifying_findings_appear(
+    tmp_path: Path,
+) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_new",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="New server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+    _write_results(baseline_path, _results_with_findings())
+
+    result = runner.invoke(
+        app,
+        ["verify", str(current_path), "--baseline", str(baseline_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "New: 1" in result.stdout
+    assert "New server failure" in result.stdout
+    assert "Verification failed." in result.stdout
+
+
+def test_verify_command_supports_threshold_overrides(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_mismatch",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Schema mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "verify",
+            str(results_path),
+            "--min-severity",
+            "medium",
+            "--min-confidence",
+            "high",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Schema mismatch" in result.stdout
+
+
+def test_verify_command_reports_bad_baseline_file(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_results(current_path, _results_with_findings())
+    baseline_path.write_text("{}", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["verify", str(current_path), "--baseline", str(baseline_path)],
+    )
+
+    assert result.exit_code == 2
+    assert "Could not read baseline results file" in result.stdout
 
 
 def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -13,6 +13,7 @@ def test_readme_includes_ci_guidance() -> None:
     assert ".github/workflows/dev-environment-example.yml" in readme
     assert "KNIVES_OUT_BASE_URL" in readme
     assert "`knives-out run` currently exits with status `0`" in readme
+    assert "knives-out verify results.json" in readme
 
 
 def test_dev_environment_workflow_matches_current_cli_surface() -> None:
@@ -25,6 +26,7 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert 'knives-out generate "$SPEC_PATH" --out attacks.json' in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
     assert "knives-out report results.json --out report.md" in workflow
+    assert "knives-out verify results.json" in workflow
     assert "KNIVES_OUT_BASE_URL" in workflow
 
 
@@ -34,4 +36,6 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "results.json" in ci_doc
     assert "report.md" in ci_doc
     assert "artifacts/" in ci_doc
-    assert "Optional: fail the job when findings are present" in ci_doc
+    assert "Simple gating with no baseline" in ci_doc
+    assert "Baseline-aware gating" in ci_doc
+    assert "--baseline previous-results.json" in ci_doc

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -284,6 +284,83 @@ def test_render_markdown_report_sorts_flagged_findings_by_score() -> None:
     assert report.index("| Schema mismatch |") < report.index("| Transport error |")
 
 
+def test_render_markdown_report_with_baseline_shows_regression_sections() -> None:
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_new",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="New server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+            ),
+        ],
+    )
+    baseline = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+            ),
+            AttackResult(
+                attack_id="atk_resolved",
+                operation_id="listPets",
+                kind="missing_auth",
+                name="Resolved auth failure",
+                method="GET",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+        ],
+    )
+
+    report = render_markdown_report(current, baseline=baseline)
+
+    assert "## Verification summary" in report
+    assert "## New findings" in report
+    assert "## Resolved findings" in report
+    assert "## Persisting findings" in report
+    assert "New server failure" in report
+    assert "Resolved auth failure" in report
+    assert "Persisting mismatch" in report
+
+
 def test_execute_attack_suite_removes_only_declared_auth_header(monkeypatch) -> None:
     response = httpx.Response(401, text="missing api key")
     client = _install_recording_client(monkeypatch, response)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from knives_out.models import AttackResult, AttackResults
+from knives_out.verification import compare_attack_results, evaluate_verification
+
+
+def _results(*results: AttackResult) -> AttackResults:
+    return AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=list(results),
+    )
+
+
+def _finding(
+    attack_id: str,
+    *,
+    issue: str,
+    severity: str,
+    confidence: str,
+    flagged: bool = True,
+) -> AttackResult:
+    return AttackResult(
+        attack_id=attack_id,
+        operation_id="createPet",
+        kind="wrong_type_param",
+        name=f"Finding {attack_id}",
+        method="POST",
+        url=f"https://example.com/pets/{attack_id}",
+        status_code=500 if flagged else 400,
+        flagged=flagged,
+        issue=issue if flagged else None,
+        severity=severity,
+        confidence=confidence,
+    )
+
+
+def test_compare_attack_results_classifies_new_resolved_and_persisting_findings() -> None:
+    current = _results(
+        _finding("atk_new", issue="server_error", severity="high", confidence="high"),
+        _finding(
+            "atk_shared",
+            issue="response_schema_mismatch",
+            severity="medium",
+            confidence="high",
+        ),
+    )
+    baseline = _results(
+        _finding(
+            "atk_shared",
+            issue="response_schema_mismatch",
+            severity="medium",
+            confidence="high",
+        ),
+        _finding("atk_old", issue="transport_error", severity="low", confidence="low"),
+    )
+
+    comparison = compare_attack_results(current, baseline)
+
+    assert [finding.attack_id for finding in comparison.new_findings] == ["atk_new"]
+    assert [finding.attack_id for finding in comparison.resolved_findings] == ["atk_old"]
+    assert [finding.attack_id for finding in comparison.persisting_findings] == ["atk_shared"]
+
+
+def test_compare_attack_results_ignores_non_flagged_results() -> None:
+    current = _results(
+        _finding("atk_flagged", issue="server_error", severity="high", confidence="high"),
+        _finding(
+            "atk_ok",
+            issue="server_error",
+            severity="high",
+            confidence="high",
+            flagged=False,
+        ),
+    )
+
+    comparison = compare_attack_results(current)
+
+    assert [result.attack_id for result in comparison.current_findings] == ["atk_flagged"]
+    assert [finding.attack_id for finding in comparison.new_findings] == ["atk_flagged"]
+
+
+def test_compare_attack_results_treats_issue_changes_as_resolved_and_new() -> None:
+    current = _results(
+        _finding("atk_same", issue="server_error", severity="high", confidence="high"),
+    )
+    baseline = _results(
+        _finding("atk_same", issue="transport_error", severity="low", confidence="low"),
+    )
+
+    comparison = compare_attack_results(current, baseline)
+
+    assert [finding.issue for finding in comparison.new_findings] == ["server_error"]
+    assert [finding.issue for finding in comparison.resolved_findings] == ["transport_error"]
+    assert comparison.persisting_findings == []
+
+
+def test_evaluate_verification_without_baseline_filters_by_thresholds() -> None:
+    current = _results(
+        _finding("atk_high", issue="server_error", severity="high", confidence="high"),
+        _finding(
+            "atk_medium",
+            issue="response_schema_mismatch",
+            severity="medium",
+            confidence="high",
+        ),
+    )
+
+    verification = evaluate_verification(current)
+
+    assert verification.passed is False
+    assert [finding.attack_id for finding in verification.failing_findings] == ["atk_high"]
+
+
+def test_evaluate_verification_with_baseline_fails_only_on_new_findings() -> None:
+    current = _results(
+        _finding("atk_shared", issue="server_error", severity="high", confidence="high"),
+        _finding("atk_new", issue="server_error", severity="high", confidence="high"),
+    )
+    baseline = _results(
+        _finding("atk_shared", issue="server_error", severity="high", confidence="high"),
+    )
+
+    verification = evaluate_verification(current, baseline=baseline)
+
+    assert verification.passed is False
+    assert [finding.attack_id for finding in verification.failing_findings] == ["atk_new"]


### PR DESCRIPTION
## Summary
Add first-class regression comparison and built-in CI verification for results files, plus baseline-aware reporting and updated CI docs.

## What changed
- add `src/knives_out/verification.py` with comparison and policy evaluation for current versus baseline `results.json`
- add `knives-out verify` with optional `--baseline`, `--min-severity`, and `--min-confidence`
- extend `knives-out report` with optional `--baseline` so Markdown can show new, resolved, and persisting findings
- keep `knives-out run` review-first and non-failing by default
- update the README, CI guide, and sample GitHub Actions workflow to use the new verify step
- add regression-oriented tests for comparison, reporting, CLI behavior, and docs/workflow alignment

## Validation
- `python3 -m ruff check src tests docs`
- `python3 -m ruff format --check src tests`
- `.venv/bin/python3 -m pytest -q tests/test_verification.py tests/test_cli.py tests/test_runner.py tests/test_docs.py` *(not available in this host shell: `.venv/bin/python3: No module named pytest`)*
- GitHub Actions `test` workflow on this branch
