### PR TITLE
[codex] Add stateful workflow attacks

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -22,7 +22,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Generate attack suite
-        run: knives-out generate "$SPEC_PATH" --out attacks.json
+        run: |
+          knives-out generate "$SPEC_PATH" --out attacks.json
+          # For stateful coverage, opt in to built-in workflows:
+          # knives-out generate "$SPEC_PATH" --auto-workflows --out attacks.json
+          # For app-specific journeys, add a workflow pack module:
+          # knives-out generate "$SPEC_PATH" \
+          #   --auto-workflows \
+          #   --workflow-pack-module examples/workflow_packs/listed_pet_lookup.py \
+          #   --out attacks.json
       - name: Run suite against dev environment
         shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # knives-out
 
+[![CI](https://github.com/keithwegner/knives-out/actions/workflows/ci.yml/badge.svg)](https://github.com/keithwegner/knives-out/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
 `knives-out` is a CLI for adversarial API testing from OpenAPI specs.
 
 It helps developers break their APIs on purpose before someone else does.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Given an OpenAPI document, `knives-out` can:
 
 - inspect the operations in the spec
 - generate replayable negative test cases
+- optionally chain setup requests into replayable workflow attacks
 - run those attacks against a live base URL
 - produce a Markdown report that highlights suspicious outcomes
 
@@ -34,6 +35,7 @@ The starter scaffold generates a first wave of useful negative tests:
 - missing request bodies
 - malformed JSON bodies
 - missing auth headers or query credentials when the spec declares security
+- opt-in setup-plus-terminal workflow attacks that reuse extracted response values
 
 This is not a full fuzzing engine yet. It is a structured attack generator and runner.
 
@@ -72,6 +74,14 @@ Generate attacks:
 
 ```bash
 knives-out generate examples/openapi/petstore.yaml --out attacks.json
+```
+
+Opt in to built-in stateful workflows:
+
+```bash
+knives-out generate examples/openapi/petstore.yaml \
+  --auto-workflows \
+  --out attacks.json
 ```
 
 Run them against a live API:
@@ -119,7 +129,10 @@ teams can always upload `results.json`, `report.md`, and per-attack artifacts fo
 
 For built-in gating, use `knives-out verify` after `run`. It can fail on qualifying findings in the
 current run, or only on new qualifying findings when you also pass `--baseline previous-results.json`.
-See `docs/ci.md` for the sample workflow, secret setup, and baseline-aware CI patterns.
+When you want stateful coverage, generate with `--auto-workflows` first, then add
+`--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
+you move from generic coverage to app-specific journeys. See `docs/ci.md` for the sample workflow,
+secret setup, and baseline-aware CI patterns.
 
 ## CLI
 
@@ -151,6 +164,15 @@ You can load custom attack packs from installed entry points or local modules:
 knives-out generate path/to/openapi.yaml \
   --pack unexpected-header \
   --pack-module examples/custom_packs/unexpected_header.py \
+  --out attacks.json
+```
+
+You can also opt in to built-in workflow generation or load workflow packs:
+
+```bash
+knives-out generate path/to/openapi.yaml \
+  --auto-workflows \
+  --workflow-pack-module examples/workflow_packs/listed_pet_lookup.py \
   --out attacks.json
 ```
 
@@ -289,9 +311,45 @@ Then load it with:
 knives-out generate examples/openapi/petstore.yaml --pack unexpected-header --out attacks.json
 ```
 
+## Custom workflow packs
+
+Workflow packs contribute `WorkflowAttackCase` records after the request attacks are generated, so
+they can reuse existing terminal attacks instead of rebuilding request payloads from scratch.
+
+A workflow pack can be either:
+
+- a callable `generate(operations: list[OperationSpec], request_attacks: list[AttackCase]) -> list[WorkflowAttackCase]`
+- an object exposed as `workflow_pack` with a `name` and `generate(operations, request_attacks)` method
+
+The easiest helper is `make_workflow_pack()` from `knives_out.workflow_packs`.
+
+Local module example:
+
+```bash
+knives-out generate examples/openapi/petstore.yaml \
+  --auto-workflows \
+  --workflow-pack-module examples/workflow_packs/listed_pet_lookup.py \
+  --out attacks.json
+```
+
+Installed entry point example:
+
+```toml
+[project.entry-points."knives_out.workflow_packs"]
+listed-id-lookup = "my_package.workflow_packs:workflow_pack"
+```
+
+Then load it with:
+
+```bash
+knives-out generate examples/openapi/petstore.yaml \
+  --workflow-pack listed-id-lookup \
+  --out attacks.json
+```
+
 ## Roadmap
 
-The first milestone is intentionally modest:
+The current direction is still intentionally modest:
 
 - parse common OpenAPI patterns well
 - generate useful negative tests with low noise

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,10 +3,11 @@
 `knives-out` is designed to fit a normal CI workflow:
 
 1. generate a replayable attack suite from a checked-in OpenAPI spec
-2. run that suite against a dev or staging deployment
-3. render a Markdown report for review
-4. verify the results against a CI policy
-5. publish the JSON results, Markdown report, and per-attack artifacts
+2. optionally opt in to workflow generation for stateful coverage
+3. run that suite against a dev or staging deployment
+4. render a Markdown report for review
+5. verify the results against a CI policy
+6. publish the JSON results, Markdown report, and per-attack artifacts
 
 The repository includes a ready-to-adapt GitHub Actions example at
 `.github/workflows/dev-environment-example.yml`.
@@ -73,6 +74,33 @@ findings:
 
 The tool does not fetch that baseline for you. Your workflow is responsible for placing
 `previous-results.json` in the workspace before this step.
+
+## Optional: stateful workflow coverage
+
+Start simple with request-only generation:
+
+```yaml
+- name: Generate request attacks
+  run: knives-out generate "$SPEC_PATH" --out attacks.json
+```
+
+When you want stateful setup-plus-terminal coverage, opt in:
+
+```yaml
+- name: Generate attacks with built-in workflows
+  run: knives-out generate "$SPEC_PATH" --auto-workflows --out attacks.json
+```
+
+You can add app-specific journeys by loading a workflow pack module or entry point:
+
+```yaml
+- name: Generate attacks with custom workflows
+  run: |
+    knives-out generate "$SPEC_PATH" \
+      --auto-workflows \
+      --workflow-pack-module examples/workflow_packs/listed_pet_lookup.py \
+      --out attacks.json
+```
 
 ## Optional: baseline-aware report
 

--- a/examples/workflow_packs/listed_pet_lookup.py
+++ b/examples/workflow_packs/listed_pet_lookup.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from knives_out.generator import attack_id, base_request_context
+from knives_out.models import (
+    AttackCase,
+    ExtractRule,
+    OperationSpec,
+    WorkflowAttackCase,
+    WorkflowStep,
+)
+from knives_out.workflow_packs import make_workflow_pack
+
+
+def generate(
+    operations: list[OperationSpec],
+    request_attacks: list[AttackCase],
+) -> list[WorkflowAttackCase]:
+    producer = next(
+        (operation for operation in operations if operation.operation_id == "listPets"), None
+    )
+    if producer is None:
+        return []
+
+    path_params, query, headers, body = base_request_context(producer)
+    workflows: list[WorkflowAttackCase] = []
+    for attack in request_attacks:
+        if attack.operation_id != "getPet" or "petId" not in attack.path_params:
+            continue
+
+        terminal_attack = attack.model_copy(deep=True)
+        terminal_attack.path_params["petId"] = "{{id}}"
+        workflows.append(
+            WorkflowAttackCase(
+                id=attack_id(
+                    attack.operation_id,
+                    f"workflow_{attack.kind}",
+                    f"{producer.operation_id}:{attack.id}",
+                ),
+                name=f"Listed id lookup workflow: {attack.name}",
+                kind=attack.kind,
+                operation_id=attack.operation_id,
+                method=attack.method,
+                path=attack.path,
+                description=(
+                    "Lists pets, extracts the first item id, then reuses that value "
+                    "when executing the terminal attack."
+                ),
+                setup_steps=[
+                    WorkflowStep(
+                        name="List pets for setup",
+                        operation_id=producer.operation_id,
+                        method=producer.method,
+                        path=producer.path,
+                        path_params=path_params,
+                        query=query,
+                        headers=headers,
+                        body_json=body,
+                        extracts=[ExtractRule(name="id", json_pointer="/0/id")],
+                    )
+                ],
+                terminal_attack=terminal_attack,
+            )
+        )
+
+    return workflows
+
+
+workflow_pack = make_workflow_pack("listed-id-lookup", generate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ knives-out = "knives_out.cli:main"
 [project.entry-points."knives_out.attack_packs"]
 unexpected-header = "knives_out.example_packs:attack_pack"
 
+[project.entry-points."knives_out.workflow_packs"]
+listed-id-lookup = "knives_out.example_workflow_packs:workflow_pack"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/knives_out"]
 

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -17,6 +17,7 @@ from knives_out.openapi_loader import load_operations_with_warnings
 from knives_out.reporting import load_attack_results, render_markdown_report
 from knives_out.runner import execute_attack_suite, load_attack_suite
 from knives_out.verification import ComparedFinding, evaluate_verification
+from knives_out.workflow_packs import load_workflow_packs
 
 app = typer.Typer(no_args_is_help=True, help="Adversarial API testing from OpenAPI specs.")
 console = Console()
@@ -173,6 +174,23 @@ def generate(
         list[Path] | None,
         typer.Option(help="Load custom attack packs from local Python module paths. Repeatable."),
     ] = None,
+    auto_workflows: Annotated[
+        bool,
+        typer.Option(
+            "--auto-workflows/--no-auto-workflows",
+            help="Opt in to built-in setup+terminal workflow generation.",
+        ),
+    ] = False,
+    workflow_pack: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Load custom workflow packs from installed entry point names. Repeatable."
+        ),
+    ] = None,
+    workflow_pack_module: Annotated[
+        list[Path] | None,
+        typer.Option(help="Load custom workflow packs from local Python module paths. Repeatable."),
+    ] = None,
 ) -> None:
     """Generate a replayable attack suite from an OpenAPI spec.
 
@@ -181,7 +199,17 @@ def generate(
     loaded = load_operations_with_warnings(spec)
     operations = loaded.operations
     attack_packs = load_attack_packs(entry_point_names=pack, module_paths=pack_module)
-    suite = generate_attack_suite(operations, source=str(spec), extra_packs=attack_packs)
+    workflow_packs = load_workflow_packs(
+        entry_point_names=workflow_pack,
+        module_paths=workflow_pack_module,
+    )
+    suite = generate_attack_suite(
+        operations,
+        source=str(spec),
+        extra_packs=attack_packs,
+        auto_workflows=auto_workflows,
+        workflow_packs=workflow_packs,
+    )
     suite = filter_attack_suite(
         suite,
         include_operations=operation,
@@ -192,7 +220,12 @@ def generate(
         exclude_kinds=exclude_kind,
     )
     out.write_text(suite.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
-    console.print(f"Wrote {len(suite.attacks)} attacks to [bold]{out}[/bold].")
+    workflow_count = sum(1 for attack in suite.attacks if attack.type == "workflow")
+    request_count = len(suite.attacks) - workflow_count
+    console.print(
+        f"Wrote {len(suite.attacks)} attack entries to [bold]{out}[/bold]. "
+        f"({request_count} request attacks, {workflow_count} workflows)"
+    )
     _print_preflight_warnings(loaded.warnings)
 
 

--- a/src/knives_out/example_workflow_packs.py
+++ b/src/knives_out/example_workflow_packs.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from knives_out.generator import attack_id, base_request_context
+from knives_out.models import (
+    AttackCase,
+    ExtractRule,
+    OperationSpec,
+    WorkflowAttackCase,
+    WorkflowStep,
+)
+from knives_out.workflow_packs import make_workflow_pack
+
+
+def generate_listed_id_lookup_workflows(
+    operations: list[OperationSpec],
+    request_attacks: list[AttackCase],
+) -> list[WorkflowAttackCase]:
+    producer = next(
+        (operation for operation in operations if operation.operation_id == "listPets"), None
+    )
+    if producer is None:
+        return []
+
+    path_params, query, headers, body = base_request_context(producer)
+    workflows: list[WorkflowAttackCase] = []
+    for attack in request_attacks:
+        if attack.operation_id != "getPet" or "petId" not in attack.path_params:
+            continue
+
+        terminal_attack = attack.model_copy(deep=True)
+        terminal_attack.path_params["petId"] = "{{id}}"
+        workflows.append(
+            WorkflowAttackCase(
+                id=attack_id(
+                    attack.operation_id,
+                    f"workflow_{attack.kind}",
+                    f"{producer.operation_id}:{attack.id}",
+                ),
+                name=f"Listed id lookup workflow: {attack.name}",
+                kind=attack.kind,
+                operation_id=attack.operation_id,
+                method=attack.method,
+                path=attack.path,
+                description=(
+                    "Lists pets, extracts the first item id, then reuses that value "
+                    "when executing the terminal attack."
+                ),
+                setup_steps=[
+                    WorkflowStep(
+                        name="List pets for setup",
+                        operation_id=producer.operation_id,
+                        method=producer.method,
+                        path=producer.path,
+                        path_params=path_params,
+                        query=query,
+                        headers=headers,
+                        body_json=body,
+                        extracts=[ExtractRule(name="id", json_pointer="/0/id")],
+                    )
+                ],
+                terminal_attack=terminal_attack,
+            )
+        )
+
+    return workflows
+
+
+workflow_pack = make_workflow_pack("listed-id-lookup", generate_listed_id_lookup_workflows)

--- a/src/knives_out/filtering.py
+++ b/src/knives_out/filtering.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from knives_out.models import AttackCase, AttackSuite
+from knives_out.models import AttackCase, AttackSuite, WorkflowAttackCase
 
 
 def _normalized_values(values: list[str] | None) -> set[str]:
@@ -8,7 +8,7 @@ def _normalized_values(values: list[str] | None) -> set[str]:
 
 
 def _matches_attack(
-    attack: AttackCase,
+    attack: AttackCase | WorkflowAttackCase,
     *,
     include_operations: set[str],
     exclude_operations: set[str],

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -1,13 +1,44 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 from knives_out.attack_packs import LoadedAttackPack
-from knives_out.models import AttackCase, AttackSuite, OperationSpec, ParameterSpec
+from knives_out.models import (
+    AttackCase,
+    AttackSuite,
+    ExtractRule,
+    OperationSpec,
+    ParameterSpec,
+    WorkflowAttackCase,
+    WorkflowStep,
+)
+from knives_out.workflow_packs import LoadedWorkflowPack
 
 MAX_SAMPLE_DEPTH = 4
+_SCALAR_SCHEMA_TYPES = {"string", "integer", "number", "boolean"}
+
+
+@dataclass(frozen=True)
+class _ExtractCandidate:
+    name: str
+    json_pointer: str
+
+
+@dataclass(frozen=True)
+class _TargetBinding:
+    target: str
+    name: str
+
+
+@dataclass(frozen=True)
+class _BindingAssignment:
+    binding: _TargetBinding
+    extract: _ExtractCandidate
+    exact_name: bool
 
 
 def _normalize_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
@@ -198,6 +229,259 @@ def _response_schemas_for_attack(operation: OperationSpec) -> dict[str, Any]:
     return deepcopy(operation.response_schemas)
 
 
+def _schema_type(schema: dict[str, Any] | None) -> str | None:
+    if not schema:
+        return None
+    normalized = _normalize_schema(schema)
+    schema_type = normalized.get("type")
+    if isinstance(schema_type, str):
+        return schema_type
+    if normalized.get("properties") or normalized.get("required"):
+        return "object"
+    if "items" in normalized:
+        return "array"
+    return None
+
+
+def _is_scalar_schema(schema: dict[str, Any] | None) -> bool:
+    return _schema_type(schema) in _SCALAR_SCHEMA_TYPES
+
+
+def _escape_json_pointer_token(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")
+
+
+def _name_tokens(name: str) -> tuple[str, ...]:
+    expanded = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    return tuple(token.lower() for token in re.split(r"[^A-Za-z0-9]+", expanded) if token)
+
+
+def _match_names(source_name: str, target_name: str) -> tuple[bool, bool]:
+    source_tokens = _name_tokens(source_name)
+    target_tokens = _name_tokens(target_name)
+    if not source_tokens or not target_tokens:
+        return False, False
+    if source_tokens == target_tokens:
+        return True, True
+    if source_tokens[-1] == "id" and target_tokens[-1] == "id":
+        if source_tokens == ("id",) or target_tokens == ("id",):
+            return True, False
+    return False, False
+
+
+def _is_json_response_schema(content_type: str | None, schema: dict[str, Any] | None) -> bool:
+    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
+    return "json" in normalized_content_type or _schema_type(schema) in {"object", "array"}
+
+
+def _producer_extract_candidates(operation: OperationSpec) -> list[_ExtractCandidate]:
+    if operation.auth_required:
+        return []
+
+    candidates: dict[tuple[str, str], _ExtractCandidate] = {}
+    for status_code, response_spec in operation.response_schemas.items():
+        if not status_code.startswith("2"):
+            continue
+        if not _is_json_response_schema(response_spec.content_type, response_spec.schema_def):
+            continue
+
+        schema = _normalize_schema(response_spec.schema_def)
+        if _schema_type(schema) == "object":
+            for name, property_schema in schema.get("properties", {}).items():
+                property_schema = _normalize_schema(property_schema)
+                if _is_scalar_schema(property_schema):
+                    candidate = _ExtractCandidate(
+                        name=name,
+                        json_pointer=f"/{_escape_json_pointer_token(name)}",
+                    )
+                    candidates[(candidate.name, candidate.json_pointer)] = candidate
+        elif _schema_type(schema) == "array":
+            item_schema = _normalize_schema(schema.get("items", {}))
+            if _schema_type(item_schema) != "object":
+                continue
+            for name, property_schema in item_schema.get("properties", {}).items():
+                property_schema = _normalize_schema(property_schema)
+                if _is_scalar_schema(property_schema):
+                    candidate = _ExtractCandidate(
+                        name=name,
+                        json_pointer=f"/0/{_escape_json_pointer_token(name)}",
+                    )
+                    candidates[(candidate.name, candidate.json_pointer)] = candidate
+
+    return list(candidates.values())
+
+
+def _terminal_required_bindings(
+    operation: OperationSpec,
+    attack: AttackCase,
+) -> list[_TargetBinding]:
+    bindings: list[_TargetBinding] = []
+    for parameter in operation.parameters:
+        if parameter.location == "path" and parameter.name in attack.path_params:
+            bindings.append(_TargetBinding(target="path", name=parameter.name))
+        elif (
+            parameter.location == "query" and parameter.required and parameter.name in attack.query
+        ):
+            bindings.append(_TargetBinding(target="query", name=parameter.name))
+
+    body_schema = _normalize_schema(operation.request_body_schema)
+    if isinstance(attack.body_json, dict) and _schema_type(body_schema) == "object":
+        properties = body_schema.get("properties", {})
+        for name in body_schema.get("required", []):
+            if name not in attack.body_json:
+                continue
+            property_schema = _normalize_schema(properties.get(name, {}))
+            if _is_scalar_schema(property_schema):
+                bindings.append(_TargetBinding(target="body", name=name))
+
+    return bindings
+
+
+def _best_binding_assignment(
+    binding: _TargetBinding,
+    extracts: list[_ExtractCandidate],
+) -> _BindingAssignment | None:
+    best_assignment: _BindingAssignment | None = None
+    best_score = (-1, -1)
+
+    for extract in extracts:
+        matched, exact_name = _match_names(extract.name, binding.name)
+        if not matched:
+            continue
+        score = (1 if exact_name else 0, -len(_name_tokens(extract.name)))
+        if score > best_score:
+            best_assignment = _BindingAssignment(
+                binding=binding,
+                extract=extract,
+                exact_name=exact_name,
+            )
+            best_score = score
+
+    return best_assignment
+
+
+def _set_placeholder_value(attack: AttackCase, binding: _TargetBinding, placeholder: str) -> None:
+    if binding.target == "path":
+        attack.path_params[binding.name] = placeholder
+    elif binding.target == "query":
+        attack.query[binding.name] = placeholder
+    elif binding.target == "body" and isinstance(attack.body_json, dict):
+        attack.body_json[binding.name] = placeholder
+
+
+def _workflow_attack_from_assignments(
+    producer: OperationSpec,
+    terminal_attack: AttackCase,
+    assignments: list[_BindingAssignment],
+) -> WorkflowAttackCase:
+    path_params, query, headers, body = base_request_context(producer)
+    terminal_copy = terminal_attack.model_copy(deep=True)
+
+    extracts: list[ExtractRule] = []
+    seen_extracts: set[tuple[str, str]] = set()
+    for assignment in assignments:
+        extract_key = (assignment.extract.name, assignment.extract.json_pointer)
+        if extract_key not in seen_extracts:
+            extracts.append(
+                ExtractRule(
+                    name=assignment.extract.name,
+                    json_pointer=assignment.extract.json_pointer,
+                )
+            )
+            seen_extracts.add(extract_key)
+        _set_placeholder_value(
+            terminal_copy,
+            assignment.binding,
+            f"{{{{{assignment.extract.name}}}}}",
+        )
+
+    workflow_id = attack_id(
+        terminal_attack.operation_id,
+        f"workflow_{terminal_attack.kind}",
+        f"{producer.operation_id}:{','.join(sorted(name for name, _ in seen_extracts))}",
+    )
+    return WorkflowAttackCase(
+        id=workflow_id,
+        name=f"Workflow via {producer.operation_id}: {terminal_attack.name}",
+        kind=terminal_attack.kind,
+        operation_id=terminal_attack.operation_id,
+        method=terminal_attack.method,
+        path=terminal_attack.path,
+        description=(
+            f"Creates state with {producer.operation_id} before executing "
+            f"the terminal attack '{terminal_attack.name}'."
+        ),
+        setup_steps=[
+            WorkflowStep(
+                name=f"Setup via {producer.operation_id}",
+                operation_id=producer.operation_id,
+                method=producer.method,
+                path=producer.path,
+                path_params=path_params,
+                query=query,
+                headers=headers,
+                body_json=body,
+                extracts=extracts,
+            )
+        ],
+        terminal_attack=terminal_copy,
+    )
+
+
+def generate_workflow_attacks(
+    operations: list[OperationSpec],
+    request_attacks: list[AttackCase],
+) -> list[WorkflowAttackCase]:
+    operations_by_id = {operation.operation_id: operation for operation in operations}
+    producer_candidates = [
+        (operation, _producer_extract_candidates(operation)) for operation in operations
+    ]
+
+    workflows: list[WorkflowAttackCase] = []
+    for attack in request_attacks:
+        operation = operations_by_id.get(attack.operation_id)
+        if operation is None:
+            continue
+
+        bindings = _terminal_required_bindings(operation, attack)
+        if not bindings:
+            continue
+
+        candidate_matches: list[tuple[tuple[int, int], WorkflowAttackCase]] = []
+        for producer, extracts in producer_candidates:
+            if producer.operation_id == attack.operation_id or not extracts:
+                continue
+
+            assignments: list[_BindingAssignment] = []
+            exact_matches = 0
+            for binding in bindings:
+                assignment = _best_binding_assignment(binding, extracts)
+                if assignment is None:
+                    continue
+                assignments.append(assignment)
+                if assignment.exact_name:
+                    exact_matches += 1
+
+            if not assignments:
+                continue
+
+            score = (exact_matches, len(assignments))
+            candidate_matches.append(
+                (score, _workflow_attack_from_assignments(producer, attack, assignments))
+            )
+
+        if not candidate_matches:
+            continue
+
+        candidate_matches.sort(key=lambda item: item[0], reverse=True)
+        best_score, best_workflow = candidate_matches[0]
+        if len(candidate_matches) > 1 and candidate_matches[1][0] == best_score:
+            continue
+        workflows.append(best_workflow)
+
+    return workflows
+
+
 def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]:
     attacks: list[AttackCase] = []
     base_path_params, base_query_params, base_headers, base_body = base_request_context(operation)
@@ -381,6 +665,8 @@ def generate_attack_suite(
     source: str,
     *,
     extra_packs: list[LoadedAttackPack] | None = None,
+    auto_workflows: bool = False,
+    workflow_packs: list[LoadedWorkflowPack] | None = None,
 ) -> AttackSuite:
     attacks: list[AttackCase] = []
     packs = list(extra_packs or [])
@@ -388,4 +674,12 @@ def generate_attack_suite(
         attacks.extend(generate_attacks_for_operation(operation))
         for pack in packs:
             attacks.extend(pack.generate(operation))
-    return AttackSuite(source=source, attacks=attacks)
+
+    workflows: list[WorkflowAttackCase] = []
+    if auto_workflows:
+        workflows.extend(generate_workflow_attacks(operations, attacks))
+
+    for workflow_pack in workflow_packs or []:
+        workflows.extend(workflow_pack.generate(operations, attacks))
+
+    return AttackSuite(source=source, attacks=[*attacks, *workflows])

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 SeverityLevel = Literal["none", "low", "medium", "high", "critical"]
 ConfidenceLevel = Literal["none", "low", "medium", "high"]
+AttackType = Literal["request", "workflow"]
 
 
 class ParameterSpec(BaseModel):
@@ -50,6 +51,7 @@ class LoadedOperations(BaseModel):
 
 
 class AttackCase(BaseModel):
+    type: Literal["request"] = "request"
     id: str
     name: str
     kind: str
@@ -70,13 +72,96 @@ class AttackCase(BaseModel):
     response_schemas: dict[str, ResponseSpec] = Field(default_factory=dict)
 
 
+class ExtractRule(BaseModel):
+    name: str
+    json_pointer: str
+    required: bool = True
+
+
+class WorkflowStep(BaseModel):
+    name: str
+    operation_id: str
+    method: str
+    path: str
+    path_params: dict[str, Any] = Field(default_factory=dict)
+    query: dict[str, Any] = Field(default_factory=dict)
+    headers: dict[str, str] = Field(default_factory=dict)
+    body_json: Any | None = None
+    raw_body: str | None = None
+    content_type: str | None = None
+    omit_body: bool = False
+    omit_header_names: list[str] = Field(default_factory=list)
+    omit_query_names: list[str] = Field(default_factory=list)
+    expected_outcomes: list[str] = Field(default_factory=lambda: ["2xx"])
+    extracts: list[ExtractRule] = Field(default_factory=list)
+
+
+class WorkflowAttackCase(BaseModel):
+    type: Literal["workflow"] = "workflow"
+    id: str
+    name: str
+    kind: str
+    operation_id: str
+    method: str
+    path: str
+    description: str
+    setup_steps: list[WorkflowStep] = Field(default_factory=list)
+    terminal_attack: AttackCase
+
+
+AttackDefinition = Annotated[AttackCase | WorkflowAttackCase, Field(discriminator="type")]
+
+
+def _coerce_attack_definition(attack: Any) -> Any:
+    if not isinstance(attack, dict):
+        return attack
+
+    coerced = dict(attack)
+    coerced.setdefault(
+        "type",
+        "workflow" if "setup_steps" in coerced or "terminal_attack" in coerced else "request",
+    )
+    terminal_attack = coerced.get("terminal_attack")
+    if isinstance(terminal_attack, dict):
+        terminal_coerced = dict(terminal_attack)
+        terminal_coerced.setdefault("type", "request")
+        coerced["terminal_attack"] = terminal_coerced
+    return coerced
+
+
 class AttackSuite(BaseModel):
     source: str
     generated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    attacks: list[AttackCase] = Field(default_factory=list)
+    attacks: list[AttackDefinition] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_attack_types(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        attacks = data.get("attacks")
+        if not isinstance(attacks, list):
+            return data
+
+        coerced = dict(data)
+        coerced["attacks"] = [_coerce_attack_definition(attack) for attack in attacks]
+        return coerced
+
+
+class WorkflowStepResult(BaseModel):
+    name: str
+    operation_id: str
+    method: str
+    url: str
+    status_code: int | None = None
+    error: str | None = None
+    duration_ms: float | None = None
+    response_excerpt: str | None = None
 
 
 class AttackResult(BaseModel):
+    type: AttackType = "request"
     attack_id: str
     operation_id: str
     kind: str
@@ -94,6 +179,7 @@ class AttackResult(BaseModel):
     response_schema_status: str | None = None
     response_schema_valid: bool | None = None
     response_schema_error: str | None = None
+    workflow_steps: list[WorkflowStepResult] | None = None
 
 
 class AttackResults(BaseModel):
@@ -101,3 +187,27 @@ class AttackResults(BaseModel):
     base_url: str
     executed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     results: list[AttackResult] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_result_types(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        results = data.get("results")
+        if not isinstance(results, list):
+            return data
+
+        coerced = dict(data)
+        coerced["results"] = []
+        for result in results:
+            if not isinstance(result, dict):
+                coerced["results"].append(result)
+                continue
+            result_coerced = dict(result)
+            result_coerced.setdefault(
+                "type",
+                "workflow" if result_coerced.get("workflow_steps") else "request",
+            )
+            coerced["results"].append(result_coerced)
+        return coerced

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -30,6 +30,14 @@ def _finding_table_rows(findings: list[ComparedFinding]) -> list[str]:
     return rows
 
 
+def _workflow_phase(result) -> str:
+    if result.type != "workflow":
+        return "request"
+    if result.error and result.error.startswith("Workflow setup failed"):
+        return "setup"
+    return "terminal"
+
+
 def render_markdown_report(
     results: AttackResults,
     *,
@@ -127,9 +135,13 @@ def render_markdown_report(
     for result in results.results:
         lines.append(f"### {result.name}")
         lines.append("")
+        lines.append(f"- Type: `{result.type}`")
         lines.append(f"- Operation: `{result.operation_id}`")
         lines.append(f"- Method: `{result.method}`")
         lines.append(f"- URL: `{result.url}`")
+        if result.type == "workflow":
+            lines.append(f"- Workflow phase: `{_workflow_phase(result)}`")
+            lines.append(f"- Setup steps executed: `{len(result.workflow_steps or [])}`")
         lines.append(
             f"- Status: `{result.status_code}`"
             if result.status_code is not None
@@ -153,6 +165,18 @@ def render_markdown_report(
             lines.append("```text")
             lines.append(result.response_excerpt)
             lines.append("```")
+        if result.workflow_steps:
+            lines.append("")
+            lines.append("| Step | Operation | Method | Status | URL |")
+            lines.append("| --- | --- | --- | ---: | --- |")
+            for step in result.workflow_steps:
+                step_status = str(step.status_code) if step.status_code is not None else "-"
+                lines.append(
+                    f"| {step.name} | {step.operation_id} | {step.method} | "
+                    f"{step_status} | `{step.url}` |"
+                )
+                if step.error:
+                    lines.append(f"| Error | - | - | - | `{step.error}` |")
         lines.append("")
 
     return "\n".join(lines).strip() + "\n"

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import re
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -16,6 +18,9 @@ from knives_out.models import (
     ConfidenceLevel,
     ResponseSpec,
     SeverityLevel,
+    WorkflowAttackCase,
+    WorkflowStep,
+    WorkflowStepResult,
 )
 
 ISSUE_SCORES: dict[str, tuple[SeverityLevel, ConfidenceLevel]] = {
@@ -25,6 +30,52 @@ ISSUE_SCORES: dict[str, tuple[SeverityLevel, ConfidenceLevel]] = {
     "unexpected_success": ("high", "medium"),
     "response_schema_mismatch": ("medium", "high"),
 }
+
+_PLACEHOLDER_RE = re.compile(r"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}")
+_EXACT_PLACEHOLDER_RE = re.compile(r"^\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}$")
+
+
+@dataclass
+class _ExecutedRequest:
+    url: str
+    headers: dict[str, str]
+    query: dict[str, Any]
+    response: httpx.Response | None
+    error: str | None
+    duration_ms: float
+    resolution_error: bool = False
+
+
+@dataclass
+class WorkflowContext:
+    client: httpx.Client
+    extracted_values: dict[str, Any] = field(default_factory=dict)
+
+
+class WorkflowHook:
+    def before_workflow(self, workflow: WorkflowAttackCase, context: WorkflowContext) -> None:
+        return None
+
+    def before_step(
+        self,
+        workflow: WorkflowAttackCase,
+        step: WorkflowStep | AttackCase,
+        context: WorkflowContext,
+    ) -> None:
+        return None
+
+    def after_step(
+        self,
+        workflow: WorkflowAttackCase,
+        step: WorkflowStep | AttackCase,
+        context: WorkflowContext,
+        execution: _ExecutedRequest,
+    ) -> None:
+        return None
+
+
+class WorkflowResolutionError(ValueError):
+    pass
 
 
 def load_attack_suite(path: str | Path) -> AttackSuite:
@@ -75,9 +126,28 @@ def _excerpt(text: str, limit: int = 300) -> str:
     return text[: limit - 3] + "..."
 
 
-def _request_body_artifact(attack: AttackCase, headers: dict[str, str]) -> dict[str, Any]:
+def _request_body_artifact(
+    attack: AttackCase | WorkflowStep,
+    headers: dict[str, str],
+    request_kwargs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     if attack.omit_body:
         return {"present": False}
+    if request_kwargs and "content" in request_kwargs:
+        return {
+            "present": True,
+            "kind": "raw",
+            "content_type": headers.get("Content-Type") or attack.content_type,
+            "excerpt": _excerpt(str(request_kwargs["content"])),
+        }
+    if request_kwargs and "json" in request_kwargs:
+        serialized = json.dumps(request_kwargs["json"], sort_keys=True)
+        return {
+            "present": True,
+            "kind": "json",
+            "content_type": headers.get("Content-Type") or "application/json",
+            "excerpt": _excerpt(serialized),
+        }
     if attack.raw_body is not None:
         return {
             "present": True,
@@ -96,30 +166,28 @@ def _request_body_artifact(attack: AttackCase, headers: dict[str, str]) -> dict[
     return {"present": False}
 
 
-def _write_attack_artifact(
+def _write_request_artifact(
     artifact_root: Path,
     *,
-    attack: AttackCase,
+    filename: str,
+    request: AttackCase | WorkflowStep,
+    metadata: dict[str, Any],
     url: str,
     headers: dict[str, str],
     query: dict[str, Any],
+    request_kwargs: dict[str, Any] | None,
     response: httpx.Response | None,
     error: str | None,
     duration_ms: float,
 ) -> None:
     artifact = {
-        "attack": {
-            "id": attack.id,
-            "name": attack.name,
-            "kind": attack.kind,
-            "operation_id": attack.operation_id,
-        },
+        "attack": metadata,
         "request": {
-            "method": attack.method,
+            "method": request.method,
             "url": url,
             "headers": headers,
             "query": query,
-            "body": _request_body_artifact(attack, headers),
+            "body": _request_body_artifact(request, headers, request_kwargs),
         },
         "response": {
             "status_code": response.status_code if response is not None else None,
@@ -128,7 +196,7 @@ def _write_attack_artifact(
             "body_excerpt": _excerpt(response.text) if response is not None else None,
         },
     }
-    artifact_path = artifact_root / f"{attack.id}.json"
+    artifact_path = artifact_root / filename
     artifact_path.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
 
 
@@ -342,6 +410,513 @@ def _validate_response_schema(
     return matched_status, True, None
 
 
+def _resolve_templates(value: Any, extracted_values: dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        exact_match = _EXACT_PLACEHOLDER_RE.fullmatch(value)
+        if exact_match:
+            placeholder_name = exact_match.group(1)
+            if placeholder_name not in extracted_values:
+                raise WorkflowResolutionError(f"Missing extracted value '{placeholder_name}'.")
+            return extracted_values[placeholder_name]
+
+        def _replace(match: re.Match[str]) -> str:
+            placeholder_name = match.group(1)
+            if placeholder_name not in extracted_values:
+                raise WorkflowResolutionError(f"Missing extracted value '{placeholder_name}'.")
+            return str(extracted_values[placeholder_name])
+
+        return _PLACEHOLDER_RE.sub(_replace, value)
+    if isinstance(value, list):
+        return [_resolve_templates(item, extracted_values) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _resolve_templates(item, extracted_values) for key, item in value.items()}
+    return value
+
+
+def _status_matches_expected(status_code: int | None, expected_outcomes: list[str]) -> bool:
+    if status_code is None:
+        return False
+    for expected in expected_outcomes:
+        normalized = expected.strip().lower()
+        if not normalized:
+            continue
+        if normalized.endswith("xx") and len(normalized) == 3 and normalized[0].isdigit():
+            if status_code // 100 == int(normalized[0]):
+                return True
+            continue
+        if normalized.isdigit() and status_code == int(normalized):
+            return True
+    return False
+
+
+def _extract_json_pointer(value: Any, pointer: str) -> Any:
+    if pointer == "":
+        return value
+    if not pointer.startswith("/"):
+        raise ValueError(f"Invalid JSON pointer {pointer!r}.")
+
+    current = value
+    for token in pointer.split("/")[1:]:
+        token = token.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, list):
+            if not token.isdigit():
+                raise ValueError(f"Expected array index in JSON pointer {pointer!r}.")
+            index = int(token)
+            if index >= len(current):
+                raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
+            current = current[index]
+        elif isinstance(current, dict):
+            if token not in current:
+                raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
+            current = current[token]
+        else:
+            raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
+    return current
+
+
+def _resolved_headers(
+    request: AttackCase | WorkflowStep,
+    *,
+    default_headers: dict[str, str],
+    extracted_values: dict[str, Any],
+) -> dict[str, str]:
+    resolved = _resolve_templates(request.headers, extracted_values)
+    merged = {
+        **default_headers,
+        **{name: str(value) for name, value in resolved.items()},
+    }
+    return _remove_header_names(merged, request.omit_header_names)
+
+
+def _resolved_query(
+    request: AttackCase | WorkflowStep,
+    *,
+    default_query: dict[str, Any],
+    extracted_values: dict[str, Any],
+) -> dict[str, Any]:
+    resolved = _resolve_templates(request.query, extracted_values)
+    merged = {**default_query, **resolved}
+    for name in request.omit_query_names:
+        merged.pop(name, None)
+    return merged
+
+
+def _resolve_request_path(
+    request: AttackCase | WorkflowStep,
+    *,
+    base_url: str,
+    extracted_values: dict[str, Any],
+) -> str:
+    resolved_path_template = _resolve_templates(request.path, extracted_values)
+    resolved_path_params = _resolve_templates(request.path_params, extracted_values)
+    return base_url.rstrip("/") + _render_path(resolved_path_template, resolved_path_params)
+
+
+def _execute_request(
+    client: httpx.Client,
+    request: AttackCase | WorkflowStep,
+    *,
+    base_url: str,
+    default_headers: dict[str, str],
+    default_query: dict[str, Any],
+    extracted_values: dict[str, Any],
+    artifact_root: Path | None,
+    artifact_filename: str | None,
+    artifact_metadata: dict[str, Any] | None,
+) -> _ExecutedRequest:
+    try:
+        url = _resolve_request_path(
+            request,
+            base_url=base_url,
+            extracted_values=extracted_values,
+        )
+        headers = _resolved_headers(
+            request,
+            default_headers=default_headers,
+            extracted_values=extracted_values,
+        )
+        query = _resolved_query(
+            request,
+            default_query=default_query,
+            extracted_values=extracted_values,
+        )
+        request_kwargs: dict[str, Any] = {
+            "params": query,
+            "headers": headers,
+        }
+        if not request.omit_body:
+            if request.raw_body is not None:
+                request_kwargs["content"] = str(
+                    _resolve_templates(request.raw_body, extracted_values)
+                )
+                content_type = request.content_type
+                if content_type is not None:
+                    content_type = str(_resolve_templates(content_type, extracted_values))
+                if content_type and "Content-Type" not in headers:
+                    request_kwargs["headers"] = {**headers, "Content-Type": content_type}
+                    headers = request_kwargs["headers"]
+            elif request.body_json is not None:
+                request_kwargs["json"] = _resolve_templates(request.body_json, extracted_values)
+    except WorkflowResolutionError as exc:
+        execution = _ExecutedRequest(
+            url=base_url.rstrip("/") + request.path,
+            headers={},
+            query={},
+            response=None,
+            error=str(exc),
+            duration_ms=0.0,
+            resolution_error=True,
+        )
+        if (
+            artifact_root is not None
+            and artifact_filename is not None
+            and artifact_metadata is not None
+        ):
+            _write_request_artifact(
+                artifact_root,
+                filename=artifact_filename,
+                request=request,
+                metadata=artifact_metadata,
+                url=execution.url,
+                headers=execution.headers,
+                query=execution.query,
+                request_kwargs=None,
+                response=None,
+                error=execution.error,
+                duration_ms=execution.duration_ms,
+            )
+        return execution
+
+    start = time.perf_counter()
+    response: httpx.Response | None = None
+    error: str | None = None
+    try:
+        response = client.request(request.method, url, **request_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        error = str(exc)
+    duration_ms = (time.perf_counter() - start) * 1000.0
+
+    if (
+        artifact_root is not None
+        and artifact_filename is not None
+        and artifact_metadata is not None
+    ):
+        _write_request_artifact(
+            artifact_root,
+            filename=artifact_filename,
+            request=request,
+            metadata=artifact_metadata,
+            url=url,
+            headers=headers,
+            query=query,
+            request_kwargs=request_kwargs,
+            response=response,
+            error=error,
+            duration_ms=duration_ms,
+        )
+
+    return _ExecutedRequest(
+        url=url,
+        headers=headers,
+        query=query,
+        response=response,
+        error=error,
+        duration_ms=duration_ms,
+    )
+
+
+def _request_result(
+    attack: AttackCase,
+    execution: _ExecutedRequest,
+    *,
+    attack_type: str,
+    workflow_steps: list[WorkflowStepResult] | None = None,
+) -> AttackResult:
+    flagged, issue = evaluate_result(
+        execution.response.status_code if execution.response else None,
+        execution.error,
+    )
+    response_schema_status: str | None = None
+    response_schema_valid: bool | None = None
+    response_schema_error: str | None = None
+    if execution.response is not None:
+        (
+            response_schema_status,
+            response_schema_valid,
+            response_schema_error,
+        ) = _validate_response_schema(attack, execution.response)
+    if response_schema_valid is False:
+        flagged = True
+        if issue in {None, "unexpected_success"}:
+            issue = "response_schema_mismatch"
+    severity, confidence = score_result(flagged=flagged, issue=issue)
+
+    return AttackResult(
+        type=attack_type,
+        attack_id=attack.id,
+        operation_id=attack.operation_id,
+        kind=attack.kind,
+        name=attack.name,
+        method=attack.method,
+        url=execution.url,
+        status_code=execution.response.status_code if execution.response else None,
+        error=execution.error,
+        duration_ms=round(execution.duration_ms, 2),
+        flagged=flagged,
+        issue=issue,
+        severity=severity,
+        confidence=confidence,
+        response_excerpt=_excerpt(execution.response.text)
+        if execution.response is not None
+        else None,
+        response_schema_status=response_schema_status,
+        response_schema_valid=response_schema_valid,
+        response_schema_error=response_schema_error,
+        workflow_steps=workflow_steps,
+    )
+
+
+def _workflow_step_result(
+    step: WorkflowStep,
+    execution: _ExecutedRequest,
+) -> WorkflowStepResult:
+    return WorkflowStepResult(
+        name=step.name,
+        operation_id=step.operation_id,
+        method=step.method,
+        url=execution.url,
+        status_code=execution.response.status_code if execution.response else None,
+        error=execution.error,
+        duration_ms=round(execution.duration_ms, 2),
+        response_excerpt=_excerpt(execution.response.text)
+        if execution.response is not None
+        else None,
+    )
+
+
+def _workflow_terminal_fallback_url(
+    workflow: WorkflowAttackCase,
+    *,
+    base_url: str,
+    extracted_values: dict[str, Any],
+) -> str:
+    try:
+        return _resolve_request_path(
+            workflow.terminal_attack,
+            base_url=base_url,
+            extracted_values=extracted_values,
+        )
+    except WorkflowResolutionError:
+        return base_url.rstrip("/") + workflow.path
+
+
+def _workflow_failure_result(
+    workflow: WorkflowAttackCase,
+    *,
+    base_url: str,
+    error: str,
+    workflow_steps: list[WorkflowStepResult],
+    status_code: int | None = None,
+    response_excerpt: str | None = None,
+    duration_ms: float = 0.0,
+    extracted_values: dict[str, Any] | None = None,
+) -> AttackResult:
+    return AttackResult(
+        type="workflow",
+        attack_id=workflow.id,
+        operation_id=workflow.operation_id,
+        kind=workflow.kind,
+        name=workflow.name,
+        method=workflow.method,
+        url=_workflow_terminal_fallback_url(
+            workflow,
+            base_url=base_url,
+            extracted_values=extracted_values or {},
+        ),
+        status_code=status_code,
+        error=error,
+        duration_ms=round(duration_ms, 2),
+        flagged=False,
+        issue=None,
+        severity="none",
+        confidence="none",
+        response_excerpt=response_excerpt,
+        workflow_steps=workflow_steps,
+    )
+
+
+def _extract_step_values(
+    step: WorkflowStep,
+    response: httpx.Response | None,
+) -> dict[str, Any]:
+    if not step.extracts:
+        return {}
+    if response is None:
+        raise WorkflowResolutionError(
+            f"Workflow setup failed during '{step.name}': no response was available for extraction."
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise WorkflowResolutionError(
+            f"Workflow setup failed during '{step.name}': response body was not JSON ({exc})."
+        ) from exc
+
+    extracted: dict[str, Any] = {}
+    for extract in step.extracts:
+        try:
+            extracted[extract.name] = _extract_json_pointer(payload, extract.json_pointer)
+        except ValueError as exc:
+            if extract.required:
+                raise WorkflowResolutionError(
+                    f"Workflow setup failed during '{step.name}': {exc}"
+                ) from exc
+    return extracted
+
+
+def _execute_workflow_attack(
+    workflow: WorkflowAttackCase,
+    *,
+    base_url: str,
+    default_headers: dict[str, str],
+    default_query: dict[str, Any],
+    timeout_seconds: float,
+    artifact_root: Path | None,
+    workflow_hooks: list[WorkflowHook],
+) -> AttackResult:
+    total_duration_ms = 0.0
+    with httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client:
+        context = WorkflowContext(client=client)
+        for hook in workflow_hooks:
+            hook.before_workflow(workflow, context)
+
+        workflow_steps: list[WorkflowStepResult] = []
+        for index, step in enumerate(workflow.setup_steps, start=1):
+            for hook in workflow_hooks:
+                hook.before_step(workflow, step, context)
+
+            execution = _execute_request(
+                client,
+                step,
+                base_url=base_url,
+                default_headers=default_headers,
+                default_query=default_query,
+                extracted_values=context.extracted_values,
+                artifact_root=artifact_root,
+                artifact_filename=f"{workflow.id}-step-{index:02d}.json" if artifact_root else None,
+                artifact_metadata=(
+                    {
+                        "id": f"{workflow.id}-step-{index:02d}",
+                        "name": step.name,
+                        "kind": "workflow_setup",
+                        "operation_id": step.operation_id,
+                        "type": "workflow_step",
+                        "workflow_id": workflow.id,
+                    }
+                    if artifact_root
+                    else None
+                ),
+            )
+            total_duration_ms += execution.duration_ms
+            step_result = _workflow_step_result(step, execution)
+            workflow_steps.append(step_result)
+
+            setup_error = execution.error
+            if execution.response is not None and not _status_matches_expected(
+                execution.response.status_code,
+                step.expected_outcomes,
+            ):
+                setup_error = (
+                    f"unexpected status {execution.response.status_code}; "
+                    f"expected one of {', '.join(step.expected_outcomes)}"
+                )
+
+            if setup_error is None:
+                try:
+                    context.extracted_values.update(
+                        _extract_step_values(
+                            step,
+                            execution.response,
+                        )
+                    )
+                except WorkflowResolutionError as exc:
+                    setup_error = str(exc)
+
+            for hook in workflow_hooks:
+                hook.after_step(workflow, step, context, execution)
+
+            if setup_error is not None:
+                if not setup_error.startswith("Workflow setup failed"):
+                    setup_error = f"Workflow setup failed during '{step.name}': {setup_error}"
+                return _workflow_failure_result(
+                    workflow,
+                    base_url=base_url,
+                    error=setup_error,
+                    workflow_steps=workflow_steps,
+                    status_code=execution.response.status_code if execution.response else None,
+                    response_excerpt=(
+                        _excerpt(execution.response.text)
+                        if execution.response is not None
+                        else None
+                    ),
+                    duration_ms=total_duration_ms,
+                    extracted_values=context.extracted_values,
+                )
+
+        for hook in workflow_hooks:
+            hook.before_step(workflow, workflow.terminal_attack, context)
+
+        terminal_execution = _execute_request(
+            client,
+            workflow.terminal_attack,
+            base_url=base_url,
+            default_headers=default_headers,
+            default_query=default_query,
+            extracted_values=context.extracted_values,
+            artifact_root=artifact_root,
+            artifact_filename=f"{workflow.id}.json" if artifact_root else None,
+            artifact_metadata=(
+                {
+                    "id": workflow.id,
+                    "name": workflow.name,
+                    "kind": workflow.kind,
+                    "operation_id": workflow.operation_id,
+                    "type": "workflow",
+                    "terminal_attack_id": workflow.terminal_attack.id,
+                }
+                if artifact_root
+                else None
+            ),
+        )
+        total_duration_ms += terminal_execution.duration_ms
+        for hook in workflow_hooks:
+            hook.after_step(workflow, workflow.terminal_attack, context, terminal_execution)
+
+        if terminal_execution.resolution_error:
+            return _workflow_failure_result(
+                workflow,
+                base_url=base_url,
+                error=f"Workflow setup failed before terminal step: {terminal_execution.error}",
+                workflow_steps=workflow_steps,
+                duration_ms=total_duration_ms,
+                extracted_values=context.extracted_values,
+            )
+
+        result = _request_result(
+            workflow.terminal_attack,
+            terminal_execution,
+            attack_type="workflow",
+            workflow_steps=workflow_steps,
+        )
+        return result.model_copy(
+            update={
+                "attack_id": workflow.id,
+                "name": workflow.name,
+                "duration_ms": round(total_duration_ms, 2),
+            }
+        )
+
+
 def execute_attack_suite(
     suite: AttackSuite,
     *,
@@ -350,6 +925,7 @@ def execute_attack_suite(
     default_query: dict[str, Any] | None = None,
     timeout_seconds: float = 10.0,
     artifact_dir: str | Path | None = None,
+    workflow_hooks: list[WorkflowHook] | None = None,
 ) -> AttackResults:
     default_headers = dict(default_headers or {})
     default_query = dict(default_query or {})
@@ -358,87 +934,44 @@ def execute_attack_suite(
     if artifact_root is not None:
         artifact_root.mkdir(parents=True, exist_ok=True)
 
-    normalized_base_url = base_url.rstrip("/")
-
+    hooks = list(workflow_hooks or [])
     with httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client:
         for attack in suite.attacks:
-            url = normalized_base_url + _render_path(attack.path, attack.path_params)
-            headers = {**default_headers, **attack.headers}
-            headers = _remove_header_names(headers, attack.omit_header_names)
-            query = {**default_query, **attack.query}
-            for name in attack.omit_query_names:
-                query.pop(name, None)
-
-            request_kwargs: dict[str, Any] = {
-                "params": query,
-                "headers": headers,
-            }
-
-            if not attack.omit_body:
-                if attack.raw_body is not None:
-                    request_kwargs["content"] = attack.raw_body
-                    if attack.content_type and "Content-Type" not in headers:
-                        request_kwargs["headers"] = {**headers, "Content-Type": attack.content_type}
-                elif attack.body_json is not None:
-                    request_kwargs["json"] = attack.body_json
-
-            start = time.perf_counter()
-            response: httpx.Response | None = None
-            error: str | None = None
-            try:
-                response = client.request(attack.method, url, **request_kwargs)
-            except Exception as exc:  # noqa: BLE001
-                error = str(exc)
-            duration_ms = (time.perf_counter() - start) * 1000.0
-
-            if artifact_root is not None:
-                _write_attack_artifact(
-                    artifact_root,
-                    attack=attack,
-                    url=url,
-                    headers=request_kwargs["headers"],
-                    query=query,
-                    response=response,
-                    error=error,
-                    duration_ms=duration_ms,
+            if isinstance(attack, WorkflowAttackCase):
+                results.append(
+                    _execute_workflow_attack(
+                        attack,
+                        base_url=base_url,
+                        default_headers=default_headers,
+                        default_query=default_query,
+                        timeout_seconds=timeout_seconds,
+                        artifact_root=artifact_root,
+                        workflow_hooks=hooks,
+                    )
                 )
+                continue
 
-            flagged, issue = evaluate_result(response.status_code if response else None, error)
-            response_schema_status: str | None = None
-            response_schema_valid: bool | None = None
-            response_schema_error: str | None = None
-            if response is not None:
-                (
-                    response_schema_status,
-                    response_schema_valid,
-                    response_schema_error,
-                ) = _validate_response_schema(attack, response)
-            if response_schema_valid is False:
-                flagged = True
-                if issue in {None, "unexpected_success"}:
-                    issue = "response_schema_mismatch"
-            severity, confidence = score_result(flagged=flagged, issue=issue)
-
-            results.append(
-                AttackResult(
-                    attack_id=attack.id,
-                    operation_id=attack.operation_id,
-                    kind=attack.kind,
-                    name=attack.name,
-                    method=attack.method,
-                    url=url,
-                    status_code=response.status_code if response else None,
-                    error=error,
-                    duration_ms=round(duration_ms, 2),
-                    flagged=flagged,
-                    issue=issue,
-                    severity=severity,
-                    confidence=confidence,
-                    response_excerpt=_excerpt(response.text) if response is not None else None,
-                    response_schema_status=response_schema_status,
-                    response_schema_valid=response_schema_valid,
-                    response_schema_error=response_schema_error,
-                )
+            execution = _execute_request(
+                client,
+                attack,
+                base_url=base_url,
+                default_headers=default_headers,
+                default_query=default_query,
+                extracted_values={},
+                artifact_root=artifact_root,
+                artifact_filename=f"{attack.id}.json" if artifact_root else None,
+                artifact_metadata=(
+                    {
+                        "id": attack.id,
+                        "name": attack.name,
+                        "kind": attack.kind,
+                        "operation_id": attack.operation_id,
+                        "type": "request",
+                    }
+                    if artifact_root
+                    else None
+                ),
             )
+            results.append(_request_result(attack, execution, attack_type="request"))
 
     return AttackResults(source=suite.source, base_url=base_url, results=results)

--- a/src/knives_out/workflow_packs.py
+++ b/src/knives_out/workflow_packs.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import util
+from importlib.metadata import entry_points
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from knives_out.models import AttackCase, OperationSpec, WorkflowAttackCase
+
+ENTRY_POINT_GROUP = "knives_out.workflow_packs"
+
+WorkflowPackGenerator = Callable[
+    [list[OperationSpec], list[AttackCase]],
+    list[WorkflowAttackCase] | list[dict[str, Any]],
+]
+
+
+@dataclass(frozen=True)
+class LoadedWorkflowPack:
+    name: str
+    generate_fn: WorkflowPackGenerator
+
+    def generate(
+        self,
+        operations: list[OperationSpec],
+        request_attacks: list[AttackCase],
+    ) -> list[WorkflowAttackCase]:
+        generated = self.generate_fn(operations, request_attacks)
+        return [WorkflowAttackCase.model_validate(workflow) for workflow in generated]
+
+
+def make_workflow_pack(name: str, generate_fn: WorkflowPackGenerator) -> LoadedWorkflowPack:
+    return LoadedWorkflowPack(name=name, generate_fn=generate_fn)
+
+
+def _module_name_for_path(module_path: Path) -> str:
+    resolved = module_path.resolve()
+    digest = abs(hash(str(resolved)))
+    return f"knives_out_custom_workflow_pack_{digest}"
+
+
+def _coerce_workflow_pack(candidate: object, *, name_hint: str) -> LoadedWorkflowPack:
+    if isinstance(candidate, LoadedWorkflowPack):
+        return candidate
+    if callable(candidate):
+        return make_workflow_pack(name_hint, candidate)
+
+    generate = getattr(candidate, "generate", None)
+    if callable(generate):
+        name = getattr(candidate, "name", name_hint)
+        return make_workflow_pack(str(name), generate)
+
+    raise ValueError(
+        f"Workflow pack {name_hint!r} must be a callable or expose a callable 'generate'."
+    )
+
+
+def _workflow_pack_from_module(module: ModuleType, *, name_hint: str) -> LoadedWorkflowPack:
+    if hasattr(module, "workflow_pack"):
+        return _coerce_workflow_pack(module.workflow_pack, name_hint=name_hint)
+    if hasattr(module, "generate"):
+        return _coerce_workflow_pack(module.generate, name_hint=name_hint)
+    raise ValueError(
+        f"Workflow pack module {name_hint!r} must define 'workflow_pack' or 'generate'."
+    )
+
+
+def load_entry_point_workflow_packs(names: list[str] | None) -> list[LoadedWorkflowPack]:
+    if not names:
+        return []
+
+    selected_entry_points = {
+        entry_point.name: entry_point
+        for entry_point in entry_points().select(group=ENTRY_POINT_GROUP)
+    }
+    loaded: list[LoadedWorkflowPack] = []
+    for name in names:
+        entry_point = selected_entry_points.get(name)
+        if entry_point is None:
+            raise ValueError(
+                f"Unknown workflow pack entry point {name!r}. "
+                f"Install a package exposing [{ENTRY_POINT_GROUP}] {name}."
+            )
+        loaded.append(_coerce_workflow_pack(entry_point.load(), name_hint=name))
+    return loaded
+
+
+def load_module_workflow_packs(module_paths: list[Path] | None) -> list[LoadedWorkflowPack]:
+    if not module_paths:
+        return []
+
+    loaded: list[LoadedWorkflowPack] = []
+    for module_path in module_paths:
+        if not module_path.exists():
+            raise ValueError(f"Workflow pack module path does not exist: {module_path}")
+
+        spec = util.spec_from_file_location(_module_name_for_path(module_path), module_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Could not load workflow pack module from: {module_path}")
+
+        module = util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Failed to import workflow pack module {module_path}: {exc}") from exc
+
+        loaded.append(_workflow_pack_from_module(module, name_hint=module_path.stem))
+    return loaded
+
+
+def load_workflow_packs(
+    *,
+    entry_point_names: list[str] | None = None,
+    module_paths: list[Path] | None = None,
+) -> list[LoadedWorkflowPack]:
+    return load_entry_point_workflow_packs(entry_point_names) + load_module_workflow_packs(
+        module_paths
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,8 +67,28 @@ def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert out_path.exists()
-    raw = out_path.read_text(encoding="utf-8")
-    assert '"attacks"' in raw
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert suite.attacks
+    assert all(attack.type == "request" for attack in suite.attacks)
+
+
+def test_generate_command_supports_auto_workflows(tmp_path: Path) -> None:
+    out_path = tmp_path / "attacks.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(EXAMPLE_SPEC),
+            "--auto-workflows",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert any(attack.type == "workflow" for attack in suite.attacks)
 
 
 def test_report_command_supports_baseline(tmp_path: Path) -> None:
@@ -178,6 +198,7 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
         default_query: dict[str, str],
         timeout_seconds: float,
         artifact_dir: Path | None,
+        workflow_hooks=None,
     ) -> AttackResults:
         captured["suite_source"] = suite.source
         captured["base_url"] = base_url
@@ -391,28 +412,30 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "knives_out.cli.generate_attack_suite",
-        lambda operations, source, extra_packs=None: AttackSuite(
-            source=source,
-            attacks=[
-                AttackCase(
-                    id="atk_get",
-                    name="GET attack",
-                    kind="missing_auth",
-                    operation_id="listPets",
-                    method="GET",
-                    path="/pets",
-                    description="GET attack",
-                ),
-                AttackCase(
-                    id="atk_post",
-                    name="POST attack",
-                    kind="missing_request_body",
-                    operation_id="createPet",
-                    method="POST",
-                    path="/pets",
-                    description="POST attack",
-                ),
-            ],
+        lambda operations, source, extra_packs=None, auto_workflows=False, workflow_packs=None: (
+            AttackSuite(
+                source=source,
+                attacks=[
+                    AttackCase(
+                        id="atk_get",
+                        name="GET attack",
+                        kind="missing_auth",
+                        operation_id="listPets",
+                        method="GET",
+                        path="/pets",
+                        description="GET attack",
+                    ),
+                    AttackCase(
+                        id="atk_post",
+                        name="POST attack",
+                        kind="missing_request_body",
+                        operation_id="createPet",
+                        method="POST",
+                        path="/pets",
+                        description="POST attack",
+                    ),
+                ],
+            )
         ),
     )
 
@@ -456,7 +479,12 @@ def test_generate_command_echoes_preflight_warnings(tmp_path: Path, monkeypatch)
     )
     monkeypatch.setattr(
         "knives_out.cli.generate_attack_suite",
-        lambda operations, source, extra_packs=None: AttackSuite(source=source, attacks=[]),
+        lambda operations, source, extra_packs=None, auto_workflows=False, workflow_packs=None: (
+            AttackSuite(
+                source=source,
+                attacks=[],
+            )
+        ),
     )
 
     result = runner.invoke(app, ["generate", str(EXAMPLE_SPEC), "--out", str(out_path)])
@@ -506,6 +534,7 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
         default_query: dict[str, str],
         timeout_seconds: float,
         artifact_dir: Path | None,
+        workflow_hooks=None,
     ) -> AttackResults:
         captured["attack_ids"] = [attack.id for attack in suite.attacks]
         return AttackResults(source=suite.source, base_url=base_url, results=[])
@@ -590,3 +619,63 @@ def test_generate_command_loads_local_attack_pack(tmp_path: Path) -> None:
     assert result.exit_code == 0
     suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert any(attack.kind == "custom_probe" for attack in suite.attacks)
+
+
+def test_generate_command_loads_local_workflow_pack(tmp_path: Path) -> None:
+    module_path = tmp_path / "custom_workflow_pack.py"
+    module_path.write_text(
+        dedent(
+            """
+            from knives_out.models import ExtractRule, WorkflowAttackCase, WorkflowStep
+            from knives_out.workflow_packs import make_workflow_pack
+
+            def generate(operations, request_attacks):
+                attack = next(
+                    attack for attack in request_attacks if attack.operation_id == "getPet"
+                )
+                terminal_attack = attack.model_copy(deep=True)
+                terminal_attack.path_params["petId"] = "{{id}}"
+                return [
+                    WorkflowAttackCase(
+                        id="wf_custom",
+                        name="Custom workflow",
+                        kind=attack.kind,
+                        operation_id=attack.operation_id,
+                        method=attack.method,
+                        path=attack.path,
+                        description="Custom workflow",
+                        setup_steps=[
+                            WorkflowStep(
+                                name="List pets",
+                                operation_id="listPets",
+                                method="GET",
+                                path="/pets",
+                                extracts=[ExtractRule(name="id", json_pointer="/0/id")],
+                            )
+                        ],
+                        terminal_attack=terminal_attack,
+                    )
+                ]
+
+            workflow_pack = make_workflow_pack("custom-workflow-pack", generate)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "attacks.json"
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(EXAMPLE_SPEC),
+            "--workflow-pack-module",
+            str(module_path),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert any(attack.type == "workflow" for attack in suite.attacks)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -14,6 +14,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert "KNIVES_OUT_BASE_URL" in readme
     assert "`knives-out run` currently exits with status `0`" in readme
     assert "knives-out verify results.json" in readme
+    assert "--auto-workflows" in readme
+    assert "examples/workflow_packs/listed_pet_lookup.py" in readme
 
 
 def test_dev_environment_workflow_matches_current_cli_surface() -> None:
@@ -24,6 +26,8 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "actions/setup-python@v6" in workflow
     assert "actions/upload-artifact@v6" in workflow
     assert 'knives-out generate "$SPEC_PATH" --out attacks.json' in workflow
+    assert "--auto-workflows" in workflow
+    assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
     assert "knives-out report results.json --out report.md" in workflow
     assert "knives-out verify results.json" in workflow
@@ -39,3 +43,5 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Simple gating with no baseline" in ci_doc
     assert "Baseline-aware gating" in ci_doc
     assert "--baseline previous-results.json" in ci_doc
+    assert "Generate attacks with built-in workflows" in ci_doc
+    assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in ci_doc

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,5 +1,5 @@
 from knives_out.filtering import filter_attack_suite
-from knives_out.models import AttackCase, AttackSuite
+from knives_out.models import AttackCase, AttackSuite, WorkflowAttackCase
 
 
 def _suite() -> AttackSuite:
@@ -64,3 +64,38 @@ def test_filter_attack_suite_combines_include_and_exclude_filters() -> None:
     )
 
     assert [attack.id for attack in suite.attacks] == ["atk_post_auth"]
+
+
+def test_filter_attack_suite_matches_workflow_terminal_metadata() -> None:
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            WorkflowAttackCase(
+                id="wf_post_auth",
+                name="Workflow missing auth",
+                kind="missing_auth",
+                operation_id="createPet",
+                method="POST",
+                path="/pets",
+                description="Workflow missing auth",
+                terminal_attack=AttackCase(
+                    id="atk_post_auth",
+                    name="POST missing auth",
+                    kind="missing_auth",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                    description="POST missing auth",
+                ),
+            )
+        ],
+    )
+
+    filtered = filter_attack_suite(
+        suite,
+        include_operations=["createPet"],
+        include_methods=["post"],
+        include_kinds=["missing_auth"],
+    )
+
+    assert [attack.id for attack in filtered.attacks] == ["wf_post_auth"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from knives_out.generator import generate_attack_suite, sample_value
+from knives_out.models import WorkflowAttackCase
 from knives_out.openapi_loader import load_operations
 
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
@@ -227,3 +228,100 @@ def test_generate_missing_auth_attacks_target_only_api_key_credentials(tmp_path)
     assert query_attack.query == {"limit": 1}
     assert query_attack.omit_header_names == []
     assert query_attack.omit_query_names == ["api_key"]
+
+
+def test_generate_attack_suite_keeps_request_only_default() -> None:
+    operations = load_operations(EXAMPLE_SPEC)
+
+    suite = generate_attack_suite(operations, source=str(EXAMPLE_SPEC))
+
+    assert suite.attacks
+    assert all(attack.type == "request" for attack in suite.attacks)
+
+
+def test_generate_attack_suite_can_emit_built_in_workflows() -> None:
+    operations = load_operations(EXAMPLE_SPEC)
+
+    suite = generate_attack_suite(
+        operations,
+        source=str(EXAMPLE_SPEC),
+        auto_workflows=True,
+    )
+
+    workflows = [attack for attack in suite.attacks if isinstance(attack, WorkflowAttackCase)]
+    assert workflows
+    get_pet_workflow = next(workflow for workflow in workflows if workflow.operation_id == "getPet")
+    assert get_pet_workflow.kind == "wrong_type_param"
+    assert get_pet_workflow.setup_steps[0].operation_id == "listPets"
+    assert get_pet_workflow.setup_steps[0].extracts[0].json_pointer == "/0/id"
+    assert get_pet_workflow.terminal_attack.path_params["petId"] == "{{id}}"
+
+
+def test_generate_attack_suite_skips_ambiguous_workflow_producers(tmp_path: Path) -> None:
+    spec = tmp_path / "ambiguous-workflows.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Ambiguous workflow spec
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  responses:
+                    '200':
+                      description: Pets
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+              /archived-pets:
+                get:
+                  operationId: listArchivedPets
+                  responses:
+                    '200':
+                      description: Archived pets
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+              /pets/{petId}:
+                get:
+                  operationId: getPet
+                  parameters:
+                    - name: petId
+                      in: path
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: Pet
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    operations = load_operations(spec)
+    suite = generate_attack_suite(operations, source=str(spec), auto_workflows=True)
+
+    assert all(attack.type == "request" for attack in suite.attacks)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -148,6 +148,9 @@ def _workflow_attack(
     setup_path: str = "/pets",
     terminal_path: str = "/pets/{petId}",
 ) -> WorkflowAttackCase:
+    setup_extracts = (
+        [ExtractRule(name="id", json_pointer="/0/id")] if extracts is None else extracts
+    )
     return WorkflowAttackCase(
         id="wf_lookup",
         name="Workflow lookup",
@@ -162,7 +165,7 @@ def _workflow_attack(
                 operation_id="listPets",
                 method="GET",
                 path=setup_path,
-                extracts=extracts or [ExtractRule(name="id", json_pointer="/0/id")],
+                extracts=setup_extracts,
             )
         ],
         terminal_attack=AttackCase(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,16 @@ import json
 
 import httpx
 
-from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite
+from knives_out.models import (
+    AttackCase,
+    AttackResult,
+    AttackResults,
+    AttackSuite,
+    ExtractRule,
+    WorkflowAttackCase,
+    WorkflowStep,
+    WorkflowStepResult,
+)
 from knives_out.reporting import render_markdown_report
 from knives_out.runner import execute_attack_suite
 
@@ -46,6 +55,52 @@ class _RecordingClient:
         return self._response
 
 
+class _NoopClient:
+    def __enter__(self) -> _NoopClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def request(self, *_: object, **__: object) -> httpx.Response:
+        raise AssertionError("This client should not have been used.")
+
+
+class _HandlerClient:
+    def __init__(self, handler) -> None:
+        self._handler = handler
+        self.requests: list[dict[str, object]] = []
+        self.cookies: dict[str, str] = {}
+
+    def __enter__(self) -> _HandlerClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
+        headers = dict(kwargs.get("headers") or {})
+        if self.cookies and "Cookie" not in headers:
+            headers["Cookie"] = "; ".join(f"{name}={value}" for name, value in self.cookies.items())
+
+        request = {
+            "method": method,
+            "url": url,
+            "params": kwargs.get("params"),
+            "headers": headers,
+            "json": kwargs.get("json"),
+            "content": kwargs.get("content"),
+        }
+        self.requests.append(request)
+        response = self._handler(request)
+
+        set_cookie = response.headers.get("set-cookie")
+        if set_cookie:
+            cookie_name, cookie_value = set_cookie.split(";", 1)[0].split("=", 1)
+            self.cookies[cookie_name] = cookie_value
+        return response
+
+
 def _install_stub_response(monkeypatch, response: httpx.Response) -> None:
     monkeypatch.setattr(
         "knives_out.runner.httpx.Client",
@@ -62,6 +117,17 @@ def _install_recording_client(monkeypatch, response: httpx.Response) -> _Recordi
     return client
 
 
+def _install_client_sequence(monkeypatch, clients: list[object]) -> None:
+    remaining = list(clients)
+
+    def _client_factory(**_: object):
+        if not remaining:
+            raise AssertionError("No more fake clients were configured.")
+        return remaining.pop(0)
+
+    monkeypatch.setattr("knives_out.runner.httpx.Client", _client_factory)
+
+
 def _attack_case(*, response_schemas: dict[str, dict[str, object]]) -> AttackCase:
     return AttackCase(
         id="atk_test",
@@ -72,6 +138,43 @@ def _attack_case(*, response_schemas: dict[str, dict[str, object]]) -> AttackCas
         path="/pets",
         description="Test attack",
         response_schemas=response_schemas,
+    )
+
+
+def _workflow_attack(
+    *,
+    extracts: list[ExtractRule] | None = None,
+    terminal_path_param: object = "{{id}}",
+    setup_path: str = "/pets",
+    terminal_path: str = "/pets/{petId}",
+) -> WorkflowAttackCase:
+    return WorkflowAttackCase(
+        id="wf_lookup",
+        name="Workflow lookup",
+        kind="wrong_type_param",
+        operation_id="getPet",
+        method="GET",
+        path=terminal_path,
+        description="Workflow lookup",
+        setup_steps=[
+            WorkflowStep(
+                name="List pets",
+                operation_id="listPets",
+                method="GET",
+                path=setup_path,
+                extracts=extracts or [ExtractRule(name="id", json_pointer="/0/id")],
+            )
+        ],
+        terminal_attack=AttackCase(
+            id="atk_terminal",
+            name="Terminal attack",
+            kind="wrong_type_param",
+            operation_id="getPet",
+            method="GET",
+            path=terminal_path,
+            description="Terminal attack",
+            path_params={"petId": terminal_path_param},
+        ),
     )
 
 
@@ -490,3 +593,241 @@ def test_execute_attack_suite_writes_artifacts(tmp_path, monkeypatch) -> None:
     }
     assert artifact["response"]["status_code"] == 422
     assert artifact["response"]["body_excerpt"] == "invalid input from server"
+
+
+def test_attack_suite_supports_mixed_request_and_workflow_round_trip() -> None:
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_request",
+                name="Request attack",
+                kind="missing_auth",
+                operation_id="listPets",
+                method="GET",
+                path="/pets",
+                description="Request attack",
+            ),
+            _workflow_attack(),
+        ],
+    )
+
+    loaded = AttackSuite.model_validate_json(suite.model_dump_json(indent=2))
+
+    assert loaded.attacks[0].type == "request"
+    assert loaded.attacks[1].type == "workflow"
+
+
+def test_attack_results_support_workflow_round_trip() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                type="workflow",
+                attack_id="wf_lookup",
+                operation_id="getPet",
+                kind="wrong_type_param",
+                name="Workflow lookup",
+                method="GET",
+                url="https://example.com/pets/42",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+                workflow_steps=[
+                    WorkflowStepResult(
+                        name="List pets",
+                        operation_id="listPets",
+                        method="GET",
+                        url="https://example.com/pets",
+                        status_code=200,
+                    )
+                ],
+            )
+        ],
+    )
+
+    loaded = AttackResults.model_validate_json(results.model_dump_json(indent=2))
+
+    assert loaded.results[0].type == "workflow"
+    assert loaded.results[0].workflow_steps
+    assert loaded.results[0].workflow_steps[0].name == "List pets"
+
+
+def test_execute_attack_suite_runs_workflow_setup_then_terminal_attack(monkeypatch) -> None:
+    workflow_client = _HandlerClient(
+        lambda request: (
+            httpx.Response(
+                200,
+                headers={"Content-Type": "application/json"},
+                json=[{"id": 42}],
+            )
+            if request["url"] == "https://example.com/pets"
+            else httpx.Response(500, text="boom")
+        )
+    )
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    suite = AttackSuite(source="unit", attacks=[_workflow_attack()])
+
+    results = execute_attack_suite(suite, base_url="https://example.com")
+
+    result = results.results[0]
+    assert result.type == "workflow"
+    assert result.flagged is True
+    assert result.issue == "server_error"
+    assert result.url == "https://example.com/pets/42"
+    assert result.workflow_steps and len(result.workflow_steps) == 1
+    assert [request["url"] for request in workflow_client.requests] == [
+        "https://example.com/pets",
+        "https://example.com/pets/42",
+    ]
+
+
+def test_execute_attack_suite_writes_workflow_artifacts(tmp_path, monkeypatch) -> None:
+    workflow_client = _HandlerClient(
+        lambda request: (
+            httpx.Response(
+                200,
+                headers={"Content-Type": "application/json"},
+                json=[{"id": 42}],
+            )
+            if request["url"] == "https://example.com/pets"
+            else httpx.Response(422, text="invalid")
+        )
+    )
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    artifact_dir = tmp_path / "artifacts"
+    execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_workflow_attack()]),
+        base_url="https://example.com",
+        artifact_dir=artifact_dir,
+    )
+
+    assert (artifact_dir / "wf_lookup-step-01.json").exists()
+    assert (artifact_dir / "wf_lookup.json").exists()
+
+
+def test_execute_attack_suite_persists_cookies_across_workflow_steps(monkeypatch) -> None:
+    workflow = _workflow_attack(extracts=[], terminal_path_param=42)
+    workflow.terminal_attack.path = "/profile"
+    workflow.path = "/profile"
+    workflow.terminal_attack.path_params = {}
+    workflow.terminal_attack.operation_id = "getProfile"
+
+    workflow_client = _HandlerClient(
+        lambda request: (
+            httpx.Response(200, headers={"set-cookie": "session=abc123; Path=/"})
+            if request["url"] == "https://example.com/pets"
+            else httpx.Response(403, text="forbidden")
+        )
+    )
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    execute_attack_suite(
+        AttackSuite(source="unit", attacks=[workflow]),
+        base_url="https://example.com",
+    )
+
+    assert workflow_client.requests[1]["headers"]["Cookie"] == "session=abc123"
+
+
+def test_execute_attack_suite_returns_non_flagged_result_when_required_extract_is_missing(
+    monkeypatch,
+) -> None:
+    workflow_client = _HandlerClient(
+        lambda request: httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            json=[{"name": "Milo"}],
+        )
+    )
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_workflow_attack()]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.type == "workflow"
+    assert result.flagged is False
+    assert "Workflow setup failed during 'List pets'" in (result.error or "")
+    assert len(workflow_client.requests) == 1
+
+
+def test_execute_attack_suite_returns_non_flagged_result_for_unresolved_terminal_placeholder(
+    monkeypatch,
+) -> None:
+    workflow_client = _HandlerClient(lambda request: httpx.Response(200, json={"ok": True}))
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    workflow = _workflow_attack(extracts=[])
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[workflow]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert "before terminal step" in (result.error or "")
+    assert len(workflow_client.requests) == 1
+
+
+def test_execute_attack_suite_requires_json_for_setup_extractions(monkeypatch) -> None:
+    workflow_client = _HandlerClient(
+        lambda request: httpx.Response(200, text="<html>not json</html>")
+    )
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_workflow_attack()]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert "response body was not JSON" in (result.error or "")
+
+
+def test_render_markdown_report_shows_workflow_sections() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                type="workflow",
+                attack_id="wf_lookup",
+                operation_id="getPet",
+                kind="wrong_type_param",
+                name="Workflow lookup",
+                method="GET",
+                url="https://example.com/pets/42",
+                status_code=500,
+                flagged=False,
+                severity="none",
+                confidence="none",
+                error="Workflow setup failed during 'List pets': unexpected status 500",
+                workflow_steps=[
+                    WorkflowStepResult(
+                        name="List pets",
+                        operation_id="listPets",
+                        method="GET",
+                        url="https://example.com/pets",
+                        status_code=500,
+                        error="upstream unavailable",
+                    )
+                ],
+            )
+        ],
+    )
+
+    report = render_markdown_report(results)
+
+    assert "- Type: `workflow`" in report
+    assert "- Workflow phase: `setup`" in report
+    assert "| Step | Operation | Method | Status | URL |" in report
+    assert "List pets" in report

--- a/tests/test_workflow_packs.py
+++ b/tests/test_workflow_packs.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from knives_out.models import AttackCase, OperationSpec, WorkflowAttackCase
+from knives_out.workflow_packs import (
+    ENTRY_POINT_GROUP,
+    load_entry_point_workflow_packs,
+    load_module_workflow_packs,
+    load_workflow_packs,
+    make_workflow_pack,
+)
+
+
+def _operations() -> list[OperationSpec]:
+    return [
+        OperationSpec(operation_id="listPets", method="GET", path="/pets"),
+        OperationSpec(operation_id="getPet", method="GET", path="/pets/{petId}"),
+    ]
+
+
+def _request_attacks() -> list[AttackCase]:
+    return [
+        AttackCase(
+            id="atk_get_pet",
+            name="Get pet wrong type",
+            kind="wrong_type_param",
+            operation_id="getPet",
+            method="GET",
+            path="/pets/{petId}",
+            description="Get pet wrong type",
+            path_params={"petId": "not-an-integer"},
+        )
+    ]
+
+
+def test_load_module_workflow_packs_supports_local_modules(tmp_path: Path) -> None:
+    module_path = tmp_path / "custom_workflow_pack.py"
+    module_path.write_text(
+        dedent(
+            """
+            from knives_out.models import WorkflowAttackCase
+            from knives_out.workflow_packs import make_workflow_pack
+
+            def generate(operations, request_attacks):
+                attack = request_attacks[0]
+                return [
+                    WorkflowAttackCase(
+                        id=f"{attack.id}_workflow",
+                        name="Workflow probe",
+                        kind=attack.kind,
+                        operation_id=attack.operation_id,
+                        method=attack.method,
+                        path=attack.path,
+                        description="Workflow probe",
+                        terminal_attack=attack,
+                    )
+                ]
+
+            workflow_pack = make_workflow_pack("module-workflow-pack", generate)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    packs = load_module_workflow_packs([module_path])
+
+    assert [pack.name for pack in packs] == ["module-workflow-pack"]
+    workflows = packs[0].generate(_operations(), _request_attacks())
+    assert workflows[0].type == "workflow"
+
+
+def test_load_module_workflow_packs_reports_import_failures(tmp_path: Path) -> None:
+    module_path = tmp_path / "broken_workflow_pack.py"
+    module_path.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to import workflow pack module"):
+        load_module_workflow_packs([module_path])
+
+
+def test_load_entry_point_workflow_packs_supports_registered_names(monkeypatch) -> None:
+    class _FakeEntryPoint:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def load(self):
+            return make_workflow_pack(
+                self.name,
+                lambda operations, request_attacks: [
+                    WorkflowAttackCase(
+                        id=f"{request_attacks[0].id}_workflow",
+                        name="Entry point workflow",
+                        kind=request_attacks[0].kind,
+                        operation_id=request_attacks[0].operation_id,
+                        method=request_attacks[0].method,
+                        path=request_attacks[0].path,
+                        description="Entry point workflow",
+                        terminal_attack=request_attacks[0],
+                    )
+                ],
+            )
+
+    class _FakeEntryPoints:
+        def select(self, *, group: str):
+            assert group == ENTRY_POINT_GROUP
+            return [_FakeEntryPoint("example-workflow-pack")]
+
+    monkeypatch.setattr("knives_out.workflow_packs.entry_points", lambda: _FakeEntryPoints())
+
+    packs = load_entry_point_workflow_packs(["example-workflow-pack"])
+
+    assert [pack.name for pack in packs] == ["example-workflow-pack"]
+    assert packs[0].generate(_operations(), _request_attacks())[0].type == "workflow"
+
+
+def test_load_workflow_packs_raises_for_missing_entry_point() -> None:
+    with pytest.raises(ValueError, match="Unknown workflow pack entry point"):
+        load_workflow_packs(entry_point_names=["missing-workflow-pack"])
+
+
+def test_load_workflow_packs_supports_project_entry_point() -> None:
+    packs = load_workflow_packs(entry_point_names=["listed-id-lookup"])
+
+    assert [pack.name for pack in packs] == ["listed-id-lookup"]


### PR DESCRIPTION
## Summary
- add workflow-native suite and result models for setup-plus-terminal attacks
- execute stateful workflows with extraction, placeholder substitution, shared client state, and workflow artifacts
- add opt-in built-in workflow generation, custom workflow packs, and docs/examples for CI usage

## Testing
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `pytest` not available in this host Python 3.9 environment; rely on GitHub Actions for test execution