### PR TITLE
[codex] Add auth/session plugins

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -37,6 +37,8 @@ jobs:
           KNIVES_OUT_BASE_URL: ${{ secrets.KNIVES_OUT_BASE_URL }}
           KNIVES_OUT_AUTH_HEADER: ${{ secrets.KNIVES_OUT_AUTH_HEADER }}
           KNIVES_OUT_AUTH_QUERY: ${{ secrets.KNIVES_OUT_AUTH_QUERY }}
+          KNIVES_OUT_LOGIN_USERNAME: ${{ secrets.KNIVES_OUT_LOGIN_USERNAME }}
+          KNIVES_OUT_LOGIN_PASSWORD: ${{ secrets.KNIVES_OUT_LOGIN_PASSWORD }}
         run: |
           if [[ -z "${KNIVES_OUT_BASE_URL}" ]]; then
             echo "Set the KNIVES_OUT_BASE_URL repository secret before running this workflow." >&2
@@ -56,6 +58,9 @@ jobs:
           if [[ -n "${KNIVES_OUT_AUTH_QUERY}" ]]; then
             args+=(--query "${KNIVES_OUT_AUTH_QUERY}")
           fi
+
+          # For login/session auth, load a plugin module instead of static header/query credentials:
+          # args+=(--auth-plugin-module examples/auth_plugins/login_bearer.py)
 
           knives-out run attacks.json "${args[@]}"
       - name: Render Markdown report

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
+Project wiki: [GitHub Wiki](https://github.com/keithwegner/knives-out/wiki)
+
 `knives-out` is a CLI for adversarial API testing from OpenAPI specs.
 
 It helps developers break their APIs on purpose before someone else does.
@@ -15,6 +17,7 @@ Given an OpenAPI document, `knives-out` can:
 - inspect the operations in the spec
 - generate replayable negative test cases
 - optionally chain setup requests into replayable workflow attacks
+- load auth/session plugins for bearer tokens, login flows, and shared sessions
 - run those attacks against a live base URL
 - produce a Markdown report that highlights suspicious outcomes
 
@@ -49,10 +52,10 @@ The project is split into three explicit phases:
 
 That makes the architecture easier to extend later with:
 
-- auth/session plugins
 - custom attack packs
 - schema-aware payload mutation
 - LLM application testing
+- GraphQL support
 - CI gating policies
 - regression suites for previously found bugs
 
@@ -93,6 +96,15 @@ knives-out run attacks.json \
   --out results.json
 ```
 
+Or load an auth/session plugin when static headers are not enough:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-plugin-module examples/auth_plugins/login_bearer.py \
+  --out results.json
+```
+
 Create a Markdown report:
 
 ```bash
@@ -122,6 +134,7 @@ It uses repository secrets instead of hard-coded targets:
 - `KNIVES_OUT_BASE_URL` for the dev or staging base URL
 - `KNIVES_OUT_AUTH_HEADER` for an optional header like `Authorization: Bearer ...`
 - `KNIVES_OUT_AUTH_QUERY` for an optional query credential like `api_key=...`
+- plugin-specific login or bearer env vars when you use `--auth-plugin` or `--auth-plugin-module`
 
 `knives-out run` currently exits with status `0` when the suite executes successfully, even if
 some findings are flagged in `results.json`. That keeps execution review-friendly:
@@ -131,8 +144,10 @@ For built-in gating, use `knives-out verify` after `run`. It can fail on qualify
 current run, or only on new qualifying findings when you also pass `--baseline previous-results.json`.
 When you want stateful coverage, generate with `--auto-workflows` first, then add
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
-you move from generic coverage to app-specific journeys. See `docs/ci.md` for the sample workflow,
-secret setup, and baseline-aware CI patterns.
+you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
+credentials on `--header` or `--query`, or move up to
+`--auth-plugin-module examples/auth_plugins/login_bearer.py` for login/session flows. See
+`docs/ci.md` for the sample workflow, secret setup, and baseline-aware CI patterns.
 
 ## CLI
 
@@ -191,6 +206,16 @@ knives-out run attacks.json \
   --base-url http://localhost:8000 \
   --header "Authorization: Bearer dev-token" \
   --query "api_key=dev-secret" \
+  --out results.json
+```
+
+You can also load auth/session plugins from entry points or local modules:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-plugin env-bearer \
+  --auth-plugin-module examples/auth_plugins/login_bearer.py \
   --out results.json
 ```
 
@@ -345,6 +370,51 @@ Then load it with:
 knives-out generate examples/openapi/petstore.yaml \
   --workflow-pack listed-id-lookup \
   --out attacks.json
+```
+
+## Auth/session plugins
+
+Auth/session plugins run at execution time and can mutate outgoing requests or establish shared
+runtime state before the suite or a workflow runs.
+
+They are a good fit when simple static credentials are not enough:
+
+- add a bearer token from an environment variable
+- log in once before the suite and inject the returned token into later requests
+- establish a session cookie before each workflow
+
+An auth plugin can be either:
+
+- an object exposed as `auth_plugin`
+- an object exposed as `plugin`
+- a zero-argument `build_plugin()` factory
+
+The easiest helper is `make_auth_plugin()` from `knives_out.auth_plugins`.
+
+Local module example:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-plugin-module examples/auth_plugins/login_bearer.py \
+  --out results.json
+```
+
+Installed entry point example:
+
+```toml
+[project.entry-points."knives_out.auth_plugins"]
+env-bearer = "my_package.auth_plugins:auth_plugin"
+```
+
+Then load it with:
+
+```bash
+export KNIVES_OUT_BEARER_TOKEN=dev-token
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-plugin env-bearer \
+  --out results.json
 ```
 
 ## Roadmap

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,11 +22,16 @@ Optional secrets:
 
 - `KNIVES_OUT_AUTH_HEADER`
 - `KNIVES_OUT_AUTH_QUERY`
+- plugin-specific login or bearer env vars if you use an auth plugin module
 
 The optional values should match the current CLI surface:
 
 - `KNIVES_OUT_AUTH_HEADER`: `Authorization: Bearer dev-token`
 - `KNIVES_OUT_AUTH_QUERY`: `api_key=dev-secret`
+
+For static credentials, `--header` and `--query` are still the simplest fit. Use auth/session
+plugins when your CI flow needs to log in, fetch a bearer token, or establish a shared session
+before the suite or each workflow runs.
 
 ## Expected exit behavior
 
@@ -101,6 +106,27 @@ You can add app-specific journeys by loading a workflow pack module or entry poi
       --workflow-pack-module examples/workflow_packs/listed_pet_lookup.py \
       --out attacks.json
 ```
+
+## Optional: auth/session plugins
+
+For login or shared-session flows, load a local auth plugin module during `run`:
+
+```yaml
+- name: Run suite with an auth plugin
+  run: |
+    knives-out run attacks.json \
+      --base-url "${KNIVES_OUT_BASE_URL}" \
+      --auth-plugin-module examples/auth_plugins/login_bearer.py \
+      --artifact-dir artifacts \
+      --out results.json
+```
+
+The sample `examples/auth_plugins/login_bearer.py` expects:
+
+- `KNIVES_OUT_LOGIN_USERNAME`
+- `KNIVES_OUT_LOGIN_PASSWORD`
+
+You can also install auth plugins as entry points and load them with `--auth-plugin env-bearer`.
 
 ## Optional: baseline-aware report
 

--- a/examples/auth_plugins/login_bearer.py
+++ b/examples/auth_plugins/login_bearer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+
+from knives_out.auth_plugins import (
+    PreparedRequest,
+    RuntimeContext,
+    RuntimePlugin,
+    extract_json_pointer,
+    make_auth_plugin,
+)
+
+
+class LoginBearerPlugin(RuntimePlugin):
+    def _login(self, context: RuntimeContext) -> None:
+        username = os.environ.get("KNIVES_OUT_LOGIN_USERNAME")
+        password = os.environ.get("KNIVES_OUT_LOGIN_PASSWORD")
+        if not username or not password:
+            raise RuntimeError(
+                "Set KNIVES_OUT_LOGIN_USERNAME and KNIVES_OUT_LOGIN_PASSWORD "
+                "before using the login-bearer auth plugin."
+            )
+
+        login_path = os.environ.get("KNIVES_OUT_LOGIN_PATH", "/login")
+        token_pointer = os.environ.get("KNIVES_OUT_LOGIN_TOKEN_POINTER", "/token")
+        response = context.client.request(
+            "POST",
+            context.build_url(login_path),
+            json={"username": username, "password": password},
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Login request to {login_path!r} failed with status {response.status_code}."
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RuntimeError(f"Login response was not valid JSON: {exc}") from exc
+
+        try:
+            token = extract_json_pointer(payload, token_pointer)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Could not extract bearer token from login response: {exc}"
+            ) from exc
+
+        context.state["bearer_token"] = token
+
+    def before_suite(self, context: RuntimeContext) -> None:
+        if "bearer_token" not in context.state:
+            self._login(context)
+
+    def before_request(self, request: PreparedRequest, context: RuntimeContext) -> None:
+        token = context.state.get("bearer_token")
+        if token is not None:
+            request.headers.setdefault("Authorization", f"Bearer {token}")
+
+
+auth_plugin = make_auth_plugin("login-bearer", LoginBearerPlugin())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ unexpected-header = "knives_out.example_packs:attack_pack"
 [project.entry-points."knives_out.workflow_packs"]
 listed-id-lookup = "knives_out.example_workflow_packs:workflow_pack"
 
+[project.entry-points."knives_out.auth_plugins"]
+env-bearer = "knives_out.example_auth_plugins:auth_plugin"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/knives_out"]
 

--- a/src/knives_out/auth_plugins.py
+++ b/src/knives_out/auth_plugins.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from importlib import util
+from importlib.metadata import entry_points
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import httpx
+
+from knives_out.models import WorkflowAttackCase
+
+ENTRY_POINT_GROUP = "knives_out.auth_plugins"
+
+
+@dataclass
+class RuntimeContext:
+    client: httpx.Client
+    base_url: str
+    scope: str
+    state: dict[str, Any] = field(default_factory=dict)
+    extracted_values: dict[str, Any] = field(default_factory=dict)
+    workflow_id: str | None = None
+
+    def build_url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        return self.base_url.rstrip("/") + path
+
+
+@dataclass
+class PreparedRequest:
+    phase: str
+    attack_id: str
+    name: str
+    kind: str
+    operation_id: str
+    method: str
+    path: str
+    description: str
+    path_params: dict[str, Any] = field(default_factory=dict)
+    query: dict[str, Any] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
+    body_json: Any | None = None
+    raw_body: str | None = None
+    content_type: str | None = None
+    omit_body: bool = False
+    omit_header_names: list[str] = field(default_factory=list)
+    omit_query_names: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RequestExecution:
+    url: str
+    headers: dict[str, str]
+    query: dict[str, Any]
+    response: httpx.Response | None
+    error: str | None
+    duration_ms: float
+    resolution_error: bool = False
+
+
+class PluginRuntimeError(RuntimeError):
+    pass
+
+
+class RuntimePlugin:
+    def before_suite(self, context: RuntimeContext) -> None:
+        return None
+
+    def before_workflow(self, workflow: WorkflowAttackCase, context: RuntimeContext) -> None:
+        return None
+
+    def before_request(self, request: PreparedRequest, context: RuntimeContext) -> None:
+        return None
+
+    def after_request(
+        self,
+        request: PreparedRequest,
+        context: RuntimeContext,
+        execution: RequestExecution,
+    ) -> None:
+        return None
+
+    def after_workflow(
+        self,
+        workflow: WorkflowAttackCase,
+        context: RuntimeContext,
+        result: Any,
+    ) -> None:
+        return None
+
+
+WorkflowHook = RuntimePlugin
+
+
+@dataclass(frozen=True)
+class LoadedAuthPlugin:
+    name: str
+    plugin: RuntimePlugin
+
+
+def make_auth_plugin(name: str, plugin: RuntimePlugin) -> LoadedAuthPlugin:
+    return LoadedAuthPlugin(name=name, plugin=plugin)
+
+
+def extract_json_pointer(value: Any, pointer: str) -> Any:
+    if pointer == "":
+        return value
+    if not pointer.startswith("/"):
+        raise ValueError(f"Invalid JSON pointer {pointer!r}.")
+
+    current = value
+    for token in pointer.split("/")[1:]:
+        token = token.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, list):
+            if not token.isdigit():
+                raise ValueError(f"Expected array index in JSON pointer {pointer!r}.")
+            index = int(token)
+            if index >= len(current):
+                raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
+            current = current[index]
+        elif isinstance(current, dict):
+            if token not in current:
+                raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
+            current = current[token]
+        else:
+            raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
+    return current
+
+
+AuthPluginFactory = Callable[[], RuntimePlugin | LoadedAuthPlugin]
+
+
+def _module_name_for_path(module_path: Path) -> str:
+    resolved = module_path.resolve()
+    digest = abs(hash(str(resolved)))
+    return f"knives_out_custom_auth_plugin_{digest}"
+
+
+def _looks_like_runtime_plugin(candidate: object) -> bool:
+    return any(
+        callable(getattr(candidate, method_name, None))
+        for method_name in (
+            "before_suite",
+            "before_workflow",
+            "before_request",
+            "after_request",
+            "after_workflow",
+        )
+    )
+
+
+def _coerce_auth_plugin(candidate: object, *, name_hint: str) -> LoadedAuthPlugin:
+    if isinstance(candidate, LoadedAuthPlugin):
+        return candidate
+    if isinstance(candidate, RuntimePlugin):
+        return make_auth_plugin(name_hint, candidate)
+    if isinstance(candidate, type) and issubclass(candidate, RuntimePlugin):
+        return make_auth_plugin(name_hint, candidate())
+    if _looks_like_runtime_plugin(candidate):
+        return make_auth_plugin(name_hint, candidate)
+    if callable(candidate):
+        built = candidate()
+        if isinstance(built, LoadedAuthPlugin):
+            return built
+        if isinstance(built, RuntimePlugin) or _looks_like_runtime_plugin(built):
+            return make_auth_plugin(name_hint, built)
+
+    raise ValueError(
+        f"Auth plugin {name_hint!r} must be a RuntimePlugin, plugin-like object, "
+        "or zero-argument factory returning one."
+    )
+
+
+def _auth_plugin_from_module(module: ModuleType, *, name_hint: str) -> LoadedAuthPlugin:
+    if hasattr(module, "auth_plugin"):
+        return _coerce_auth_plugin(module.auth_plugin, name_hint=name_hint)
+    if hasattr(module, "plugin"):
+        return _coerce_auth_plugin(module.plugin, name_hint=name_hint)
+    if hasattr(module, "build_plugin"):
+        return _coerce_auth_plugin(module.build_plugin, name_hint=name_hint)
+    raise ValueError(
+        f"Auth plugin module {name_hint!r} must define 'auth_plugin', 'plugin', or 'build_plugin'."
+    )
+
+
+def load_entry_point_auth_plugins(names: list[str] | None) -> list[LoadedAuthPlugin]:
+    if not names:
+        return []
+
+    selected_entry_points = {
+        entry_point.name: entry_point
+        for entry_point in entry_points().select(group=ENTRY_POINT_GROUP)
+    }
+    loaded: list[LoadedAuthPlugin] = []
+    for name in names:
+        entry_point = selected_entry_points.get(name)
+        if entry_point is None:
+            raise ValueError(
+                f"Unknown auth plugin entry point {name!r}. "
+                f"Install a package exposing [{ENTRY_POINT_GROUP}] {name}."
+            )
+        loaded.append(_coerce_auth_plugin(entry_point.load(), name_hint=name))
+    return loaded
+
+
+def load_module_auth_plugins(module_paths: list[Path] | None) -> list[LoadedAuthPlugin]:
+    if not module_paths:
+        return []
+
+    loaded: list[LoadedAuthPlugin] = []
+    for module_path in module_paths:
+        if not module_path.exists():
+            raise ValueError(f"Auth plugin module path does not exist: {module_path}")
+
+        spec = util.spec_from_file_location(_module_name_for_path(module_path), module_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Could not load auth plugin module from: {module_path}")
+
+        module = util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Failed to import auth plugin module {module_path}: {exc}") from exc
+
+        loaded.append(_auth_plugin_from_module(module, name_hint=module_path.stem))
+    return loaded
+
+
+def load_auth_plugins(
+    *,
+    entry_point_names: list[str] | None = None,
+    module_paths: list[Path] | None = None,
+) -> list[LoadedAuthPlugin]:
+    return load_entry_point_auth_plugins(entry_point_names) + load_module_auth_plugins(module_paths)

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from knives_out.attack_packs import load_attack_packs
+from knives_out.auth_plugins import PluginRuntimeError, load_auth_plugins
 from knives_out.filtering import filter_attack_suite
 from knives_out.generator import generate_attack_suite
 from knives_out.models import AttackResults, PreflightWarning
@@ -256,6 +257,16 @@ def run(
         Path | None,
         typer.Option(help="Optional directory for per-attack request/response artifacts."),
     ] = None,
+    auth_plugin: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Load auth/session plugins from installed entry point names. Repeatable."
+        ),
+    ] = None,
+    auth_plugin_module: Annotated[
+        list[Path] | None,
+        typer.Option(help="Load auth/session plugins from local Python module paths. Repeatable."),
+    ] = None,
     operation: Annotated[
         list[str] | None,
         typer.Option(help="Only run attacks for these operation ids. Repeatable."),
@@ -297,14 +308,27 @@ def run(
     )
     default_headers = _parse_key_value(header, separator=":")
     default_query = _parse_key_value(query, separator="=")
-    results = execute_attack_suite(
-        suite,
-        base_url=base_url,
-        default_headers=default_headers,
-        default_query=default_query,
-        timeout_seconds=timeout,
-        artifact_dir=artifact_dir,
-    )
+    try:
+        auth_plugins = load_auth_plugins(
+            entry_point_names=auth_plugin,
+            module_paths=auth_plugin_module,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    try:
+        results = execute_attack_suite(
+            suite,
+            base_url=base_url,
+            default_headers=default_headers,
+            default_query=default_query,
+            timeout_seconds=timeout,
+            artifact_dir=artifact_dir,
+            auth_plugins=auth_plugins,
+        )
+    except PluginRuntimeError as exc:
+        console.print(f"[red]Auth plugin error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
     out.write_text(results.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
 
     flagged = sum(1 for result in results.results if result.flagged)

--- a/src/knives_out/example_auth_plugins.py
+++ b/src/knives_out/example_auth_plugins.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+
+from knives_out.auth_plugins import PreparedRequest, RuntimeContext, RuntimePlugin, make_auth_plugin
+
+
+class EnvBearerPlugin(RuntimePlugin):
+    def before_request(self, request: PreparedRequest, context: RuntimeContext) -> None:
+        del context
+        token = os.environ.get("KNIVES_OUT_BEARER_TOKEN")
+        if not token:
+            raise RuntimeError(
+                "Set KNIVES_OUT_BEARER_TOKEN before using the 'env-bearer' auth plugin."
+            )
+        request.headers.setdefault("Authorization", f"Bearer {token}")
+
+
+auth_plugin = make_auth_plugin("env-bearer", EnvBearerPlugin())

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -3,13 +3,24 @@ from __future__ import annotations
 import json
 import re
 import time
-from dataclasses import dataclass, field
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
 import httpx
 
+from knives_out.auth_plugins import (
+    LoadedAuthPlugin,
+    PluginRuntimeError,
+    PreparedRequest,
+    RequestExecution,
+    RuntimeContext,
+    RuntimePlugin,
+    WorkflowHook,
+    extract_json_pointer,
+    make_auth_plugin,
+)
 from knives_out.models import (
     AttackCase,
     AttackResult,
@@ -35,45 +46,6 @@ _PLACEHOLDER_RE = re.compile(r"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}")
 _EXACT_PLACEHOLDER_RE = re.compile(r"^\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}$")
 
 
-@dataclass
-class _ExecutedRequest:
-    url: str
-    headers: dict[str, str]
-    query: dict[str, Any]
-    response: httpx.Response | None
-    error: str | None
-    duration_ms: float
-    resolution_error: bool = False
-
-
-@dataclass
-class WorkflowContext:
-    client: httpx.Client
-    extracted_values: dict[str, Any] = field(default_factory=dict)
-
-
-class WorkflowHook:
-    def before_workflow(self, workflow: WorkflowAttackCase, context: WorkflowContext) -> None:
-        return None
-
-    def before_step(
-        self,
-        workflow: WorkflowAttackCase,
-        step: WorkflowStep | AttackCase,
-        context: WorkflowContext,
-    ) -> None:
-        return None
-
-    def after_step(
-        self,
-        workflow: WorkflowAttackCase,
-        step: WorkflowStep | AttackCase,
-        context: WorkflowContext,
-        execution: _ExecutedRequest,
-    ) -> None:
-        return None
-
-
 class WorkflowResolutionError(ValueError):
     pass
 
@@ -81,6 +53,55 @@ class WorkflowResolutionError(ValueError):
 def load_attack_suite(path: str | Path) -> AttackSuite:
     raw = Path(path).read_text(encoding="utf-8")
     return AttackSuite.model_validate_json(raw)
+
+
+def _prepared_request_from_attack(attack: AttackCase, *, phase: str = "request") -> PreparedRequest:
+    return PreparedRequest(
+        phase=phase,
+        attack_id=attack.id,
+        name=attack.name,
+        kind=attack.kind,
+        operation_id=attack.operation_id,
+        method=attack.method,
+        path=attack.path,
+        description=attack.description,
+        path_params=deepcopy(attack.path_params),
+        query=deepcopy(attack.query),
+        headers=deepcopy(attack.headers),
+        body_json=deepcopy(attack.body_json),
+        raw_body=attack.raw_body,
+        content_type=attack.content_type,
+        omit_body=attack.omit_body,
+        omit_header_names=list(attack.omit_header_names),
+        omit_query_names=list(attack.omit_query_names),
+    )
+
+
+def _prepared_request_from_step(
+    workflow: WorkflowAttackCase,
+    step: WorkflowStep,
+    *,
+    step_index: int,
+) -> PreparedRequest:
+    return PreparedRequest(
+        phase="workflow_setup",
+        attack_id=f"{workflow.id}-step-{step_index:02d}",
+        name=step.name,
+        kind="workflow_setup",
+        operation_id=step.operation_id,
+        method=step.method,
+        path=step.path,
+        description=step.name,
+        path_params=deepcopy(step.path_params),
+        query=deepcopy(step.query),
+        headers=deepcopy(step.headers),
+        body_json=deepcopy(step.body_json),
+        raw_body=step.raw_body,
+        content_type=step.content_type,
+        omit_body=step.omit_body,
+        omit_header_names=list(step.omit_header_names),
+        omit_query_names=list(step.omit_query_names),
+    )
 
 
 def _render_path(path_template: str, path_params: dict[str, Any]) -> str:
@@ -127,17 +148,17 @@ def _excerpt(text: str, limit: int = 300) -> str:
 
 
 def _request_body_artifact(
-    attack: AttackCase | WorkflowStep,
+    request: PreparedRequest,
     headers: dict[str, str],
     request_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    if attack.omit_body:
+    if request.omit_body:
         return {"present": False}
     if request_kwargs and "content" in request_kwargs:
         return {
             "present": True,
             "kind": "raw",
-            "content_type": headers.get("Content-Type") or attack.content_type,
+            "content_type": headers.get("Content-Type") or request.content_type,
             "excerpt": _excerpt(str(request_kwargs["content"])),
         }
     if request_kwargs and "json" in request_kwargs:
@@ -148,15 +169,15 @@ def _request_body_artifact(
             "content_type": headers.get("Content-Type") or "application/json",
             "excerpt": _excerpt(serialized),
         }
-    if attack.raw_body is not None:
+    if request.raw_body is not None:
         return {
             "present": True,
             "kind": "raw",
-            "content_type": headers.get("Content-Type") or attack.content_type,
-            "excerpt": _excerpt(attack.raw_body),
+            "content_type": headers.get("Content-Type") or request.content_type,
+            "excerpt": _excerpt(request.raw_body),
         }
-    if attack.body_json is not None:
-        serialized = json.dumps(attack.body_json, sort_keys=True)
+    if request.body_json is not None:
+        serialized = json.dumps(request.body_json, sort_keys=True)
         return {
             "present": True,
             "kind": "json",
@@ -170,7 +191,7 @@ def _write_request_artifact(
     artifact_root: Path,
     *,
     filename: str,
-    request: AttackCase | WorkflowStep,
+    request: PreparedRequest,
     metadata: dict[str, Any],
     url: str,
     headers: dict[str, str],
@@ -449,33 +470,8 @@ def _status_matches_expected(status_code: int | None, expected_outcomes: list[st
     return False
 
 
-def _extract_json_pointer(value: Any, pointer: str) -> Any:
-    if pointer == "":
-        return value
-    if not pointer.startswith("/"):
-        raise ValueError(f"Invalid JSON pointer {pointer!r}.")
-
-    current = value
-    for token in pointer.split("/")[1:]:
-        token = token.replace("~1", "/").replace("~0", "~")
-        if isinstance(current, list):
-            if not token.isdigit():
-                raise ValueError(f"Expected array index in JSON pointer {pointer!r}.")
-            index = int(token)
-            if index >= len(current):
-                raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
-            current = current[index]
-        elif isinstance(current, dict):
-            if token not in current:
-                raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
-            current = current[token]
-        else:
-            raise ValueError(f"JSON pointer {pointer!r} did not match the response body.")
-    return current
-
-
 def _resolved_headers(
-    request: AttackCase | WorkflowStep,
+    request: PreparedRequest,
     *,
     default_headers: dict[str, str],
     extracted_values: dict[str, Any],
@@ -489,7 +485,7 @@ def _resolved_headers(
 
 
 def _resolved_query(
-    request: AttackCase | WorkflowStep,
+    request: PreparedRequest,
     *,
     default_query: dict[str, Any],
     extracted_values: dict[str, Any],
@@ -502,7 +498,7 @@ def _resolved_query(
 
 
 def _resolve_request_path(
-    request: AttackCase | WorkflowStep,
+    request: PreparedRequest,
     *,
     base_url: str,
     extracted_values: dict[str, Any],
@@ -512,54 +508,123 @@ def _resolve_request_path(
     return base_url.rstrip("/") + _render_path(resolved_path_template, resolved_path_params)
 
 
+def _invoke_auth_plugin_hook(
+    loaded_plugin: LoadedAuthPlugin,
+    hook_name: str,
+    *args: Any,
+) -> None:
+    hook = getattr(loaded_plugin.plugin, hook_name, None)
+    if not callable(hook):
+        return
+    try:
+        hook(*args)
+    except PluginRuntimeError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise PluginRuntimeError(
+            f"Auth plugin '{loaded_plugin.name}' failed during '{hook_name}': {exc}"
+        ) from exc
+
+
+def _invoke_auth_plugins(
+    loaded_plugins: list[LoadedAuthPlugin],
+    hook_name: str,
+    *args: Any,
+) -> None:
+    for loaded_plugin in loaded_plugins:
+        _invoke_auth_plugin_hook(loaded_plugin, hook_name, *args)
+
+
+def _coerce_loaded_auth_plugin(candidate: object, *, default_name: str) -> LoadedAuthPlugin:
+    if isinstance(candidate, LoadedAuthPlugin):
+        return candidate
+    if isinstance(candidate, RuntimePlugin):
+        plugin_name = getattr(candidate, "name", default_name)
+        return make_auth_plugin(str(plugin_name), candidate)
+    if isinstance(candidate, type) and issubclass(candidate, RuntimePlugin):
+        plugin_name = getattr(candidate, "name", default_name)
+        return make_auth_plugin(str(plugin_name), candidate())
+    raise TypeError(
+        "Auth plugins must be LoadedAuthPlugin instances, RuntimePlugin instances, "
+        "or RuntimePlugin subclasses."
+    )
+
+
+def _loaded_auth_plugins(
+    *,
+    auth_plugins: list[LoadedAuthPlugin | RuntimePlugin | type[RuntimePlugin]] | None,
+    workflow_hooks: list[WorkflowHook] | None,
+) -> list[LoadedAuthPlugin]:
+    loaded: list[LoadedAuthPlugin] = []
+    for index, plugin in enumerate(auth_plugins or [], start=1):
+        loaded.append(_coerce_loaded_auth_plugin(plugin, default_name=f"auth-plugin-{index}"))
+    for index, hook in enumerate(workflow_hooks or [], start=1):
+        loaded.append(_coerce_loaded_auth_plugin(hook, default_name=f"workflow-hook-{index}"))
+    return loaded
+
+
 def _execute_request(
     client: httpx.Client,
-    request: AttackCase | WorkflowStep,
+    request: PreparedRequest,
     *,
-    base_url: str,
+    context: RuntimeContext,
     default_headers: dict[str, str],
     default_query: dict[str, Any],
-    extracted_values: dict[str, Any],
     artifact_root: Path | None,
     artifact_filename: str | None,
     artifact_metadata: dict[str, Any] | None,
-) -> _ExecutedRequest:
+    auth_plugins: list[LoadedAuthPlugin],
+) -> RequestExecution:
+    _invoke_auth_plugins(auth_plugins, "before_request", request, context)
+
+    request_kwargs: dict[str, Any] | None = None
     try:
         url = _resolve_request_path(
             request,
-            base_url=base_url,
-            extracted_values=extracted_values,
+            base_url=context.base_url,
+            extracted_values=context.extracted_values,
         )
         headers = _resolved_headers(
             request,
             default_headers=default_headers,
-            extracted_values=extracted_values,
+            extracted_values=context.extracted_values,
         )
         query = _resolved_query(
             request,
             default_query=default_query,
-            extracted_values=extracted_values,
+            extracted_values=context.extracted_values,
         )
-        request_kwargs: dict[str, Any] = {
+        request_kwargs = {
             "params": query,
             "headers": headers,
         }
         if not request.omit_body:
             if request.raw_body is not None:
                 request_kwargs["content"] = str(
-                    _resolve_templates(request.raw_body, extracted_values)
+                    _resolve_templates(request.raw_body, context.extracted_values)
                 )
                 content_type = request.content_type
                 if content_type is not None:
-                    content_type = str(_resolve_templates(content_type, extracted_values))
+                    content_type = str(_resolve_templates(content_type, context.extracted_values))
                 if content_type and "Content-Type" not in headers:
                     request_kwargs["headers"] = {**headers, "Content-Type": content_type}
                     headers = request_kwargs["headers"]
             elif request.body_json is not None:
-                request_kwargs["json"] = _resolve_templates(request.body_json, extracted_values)
+                request_kwargs["json"] = _resolve_templates(
+                    request.body_json,
+                    context.extracted_values,
+                )
+        execution = RequestExecution(
+            url=url,
+            headers=headers,
+            query=query,
+            response=None,
+            error=None,
+            duration_ms=0.0,
+        )
     except WorkflowResolutionError as exc:
-        execution = _ExecutedRequest(
-            url=base_url.rstrip("/") + request.path,
+        execution = RequestExecution(
+            url=context.build_url(request.path),
             headers={},
             query={},
             response=None,
@@ -567,6 +632,7 @@ def _execute_request(
             duration_ms=0.0,
             resolution_error=True,
         )
+        _invoke_auth_plugins(auth_plugins, "after_request", request, context, execution)
         if (
             artifact_root is not None
             and artifact_filename is not None
@@ -588,14 +654,13 @@ def _execute_request(
         return execution
 
     start = time.perf_counter()
-    response: httpx.Response | None = None
-    error: str | None = None
     try:
-        response = client.request(request.method, url, **request_kwargs)
+        execution.response = client.request(request.method, execution.url, **request_kwargs)
     except Exception as exc:  # noqa: BLE001
-        error = str(exc)
-    duration_ms = (time.perf_counter() - start) * 1000.0
+        execution.error = str(exc)
+    execution.duration_ms = (time.perf_counter() - start) * 1000.0
 
+    _invoke_auth_plugins(auth_plugins, "after_request", request, context, execution)
     if (
         artifact_root is not None
         and artifact_filename is not None
@@ -606,28 +671,21 @@ def _execute_request(
             filename=artifact_filename,
             request=request,
             metadata=artifact_metadata,
-            url=url,
-            headers=headers,
-            query=query,
+            url=execution.url,
+            headers=execution.headers,
+            query=execution.query,
             request_kwargs=request_kwargs,
-            response=response,
-            error=error,
-            duration_ms=duration_ms,
+            response=execution.response,
+            error=execution.error,
+            duration_ms=execution.duration_ms,
         )
 
-    return _ExecutedRequest(
-        url=url,
-        headers=headers,
-        query=query,
-        response=response,
-        error=error,
-        duration_ms=duration_ms,
-    )
+    return execution
 
 
 def _request_result(
     attack: AttackCase,
-    execution: _ExecutedRequest,
+    execution: RequestExecution,
     *,
     attack_type: str,
     workflow_steps: list[WorkflowStepResult] | None = None,
@@ -678,7 +736,7 @@ def _request_result(
 
 def _workflow_step_result(
     step: WorkflowStep,
-    execution: _ExecutedRequest,
+    execution: RequestExecution,
 ) -> WorkflowStepResult:
     return WorkflowStepResult(
         name=step.name,
@@ -702,7 +760,10 @@ def _workflow_terminal_fallback_url(
 ) -> str:
     try:
         return _resolve_request_path(
-            workflow.terminal_attack,
+            _prepared_request_from_attack(
+                workflow.terminal_attack,
+                phase="workflow_terminal",
+            ),
             base_url=base_url,
             extracted_values=extracted_values,
         )
@@ -765,7 +826,7 @@ def _extract_step_values(
     extracted: dict[str, Any] = {}
     for extract in step.extracts:
         try:
-            extracted[extract.name] = _extract_json_pointer(payload, extract.json_pointer)
+            extracted[extract.name] = extract_json_pointer(payload, extract.json_pointer)
         except ValueError as exc:
             if extract.required:
                 raise WorkflowResolutionError(
@@ -782,26 +843,29 @@ def _execute_workflow_attack(
     default_query: dict[str, Any],
     timeout_seconds: float,
     artifact_root: Path | None,
-    workflow_hooks: list[WorkflowHook],
+    auth_plugins: list[LoadedAuthPlugin],
+    initial_state: dict[str, Any],
 ) -> AttackResult:
     total_duration_ms = 0.0
     with httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client:
-        context = WorkflowContext(client=client)
-        for hook in workflow_hooks:
-            hook.before_workflow(workflow, context)
+        context = RuntimeContext(
+            client=client,
+            base_url=base_url,
+            scope="workflow",
+            state=dict(initial_state),
+            extracted_values={},
+            workflow_id=workflow.id,
+        )
+        _invoke_auth_plugins(auth_plugins, "before_workflow", workflow, context)
 
         workflow_steps: list[WorkflowStepResult] = []
         for index, step in enumerate(workflow.setup_steps, start=1):
-            for hook in workflow_hooks:
-                hook.before_step(workflow, step, context)
-
             execution = _execute_request(
                 client,
-                step,
-                base_url=base_url,
+                _prepared_request_from_step(workflow, step, step_index=index),
+                context=context,
                 default_headers=default_headers,
                 default_query=default_query,
-                extracted_values=context.extracted_values,
                 artifact_root=artifact_root,
                 artifact_filename=f"{workflow.id}-step-{index:02d}.json" if artifact_root else None,
                 artifact_metadata=(
@@ -816,6 +880,7 @@ def _execute_workflow_attack(
                     if artifact_root
                     else None
                 ),
+                auth_plugins=auth_plugins,
             )
             total_duration_ms += execution.duration_ms
             step_result = _workflow_step_result(step, execution)
@@ -842,13 +907,10 @@ def _execute_workflow_attack(
                 except WorkflowResolutionError as exc:
                     setup_error = str(exc)
 
-            for hook in workflow_hooks:
-                hook.after_step(workflow, step, context, execution)
-
             if setup_error is not None:
                 if not setup_error.startswith("Workflow setup failed"):
                     setup_error = f"Workflow setup failed during '{step.name}': {setup_error}"
-                return _workflow_failure_result(
+                result = _workflow_failure_result(
                     workflow,
                     base_url=base_url,
                     error=setup_error,
@@ -862,17 +924,18 @@ def _execute_workflow_attack(
                     duration_ms=total_duration_ms,
                     extracted_values=context.extracted_values,
                 )
-
-        for hook in workflow_hooks:
-            hook.before_step(workflow, workflow.terminal_attack, context)
+                _invoke_auth_plugins(auth_plugins, "after_workflow", workflow, context, result)
+                return result
 
         terminal_execution = _execute_request(
             client,
-            workflow.terminal_attack,
-            base_url=base_url,
+            _prepared_request_from_attack(
+                workflow.terminal_attack,
+                phase="workflow_terminal",
+            ),
+            context=context,
             default_headers=default_headers,
             default_query=default_query,
-            extracted_values=context.extracted_values,
             artifact_root=artifact_root,
             artifact_filename=f"{workflow.id}.json" if artifact_root else None,
             artifact_metadata=(
@@ -887,13 +950,12 @@ def _execute_workflow_attack(
                 if artifact_root
                 else None
             ),
+            auth_plugins=auth_plugins,
         )
         total_duration_ms += terminal_execution.duration_ms
-        for hook in workflow_hooks:
-            hook.after_step(workflow, workflow.terminal_attack, context, terminal_execution)
 
         if terminal_execution.resolution_error:
-            return _workflow_failure_result(
+            result = _workflow_failure_result(
                 workflow,
                 base_url=base_url,
                 error=f"Workflow setup failed before terminal step: {terminal_execution.error}",
@@ -901,20 +963,23 @@ def _execute_workflow_attack(
                 duration_ms=total_duration_ms,
                 extracted_values=context.extracted_values,
             )
+            _invoke_auth_plugins(auth_plugins, "after_workflow", workflow, context, result)
+            return result
 
         result = _request_result(
             workflow.terminal_attack,
             terminal_execution,
             attack_type="workflow",
             workflow_steps=workflow_steps,
-        )
-        return result.model_copy(
+        ).model_copy(
             update={
                 "attack_id": workflow.id,
                 "name": workflow.name,
                 "duration_ms": round(total_duration_ms, 2),
             }
         )
+        _invoke_auth_plugins(auth_plugins, "after_workflow", workflow, context, result)
+        return result
 
 
 def execute_attack_suite(
@@ -925,6 +990,7 @@ def execute_attack_suite(
     default_query: dict[str, Any] | None = None,
     timeout_seconds: float = 10.0,
     artifact_dir: str | Path | None = None,
+    auth_plugins: list[LoadedAuthPlugin | RuntimePlugin | type[RuntimePlugin]] | None = None,
     workflow_hooks: list[WorkflowHook] | None = None,
 ) -> AttackResults:
     default_headers = dict(default_headers or {})
@@ -934,8 +1000,17 @@ def execute_attack_suite(
     if artifact_root is not None:
         artifact_root.mkdir(parents=True, exist_ok=True)
 
-    hooks = list(workflow_hooks or [])
+    loaded_plugins = _loaded_auth_plugins(
+        auth_plugins=auth_plugins,
+        workflow_hooks=workflow_hooks,
+    )
     with httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client:
+        suite_context = RuntimeContext(
+            client=client,
+            base_url=base_url,
+            scope="suite",
+        )
+        _invoke_auth_plugins(loaded_plugins, "before_suite", suite_context)
         for attack in suite.attacks:
             if isinstance(attack, WorkflowAttackCase):
                 results.append(
@@ -946,18 +1021,18 @@ def execute_attack_suite(
                         default_query=default_query,
                         timeout_seconds=timeout_seconds,
                         artifact_root=artifact_root,
-                        workflow_hooks=hooks,
+                        auth_plugins=loaded_plugins,
+                        initial_state=suite_context.state,
                     )
                 )
                 continue
 
             execution = _execute_request(
                 client,
-                attack,
-                base_url=base_url,
+                _prepared_request_from_attack(attack),
+                context=suite_context,
                 default_headers=default_headers,
                 default_query=default_query,
-                extracted_values={},
                 artifact_root=artifact_root,
                 artifact_filename=f"{attack.id}.json" if artifact_root else None,
                 artifact_metadata=(
@@ -971,6 +1046,7 @@ def execute_attack_suite(
                     if artifact_root
                     else None
                 ),
+                auth_plugins=loaded_plugins,
             )
             results.append(_request_result(attack, execution, attack_type="request"))
 

--- a/tests/test_auth_plugin_docs.py
+++ b/tests/test_auth_plugin_docs.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+CI_DOC = ROOT / "docs" / "ci.md"
+DEV_WORKFLOW = ROOT / ".github" / "workflows" / "dev-environment-example.yml"
+
+
+def test_readme_documents_auth_session_plugins() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "## Auth/session plugins" in readme
+    assert "examples/auth_plugins/login_bearer.py" in readme
+    assert "--auth-plugin env-bearer" in readme
+
+
+def test_dev_workflow_documents_auth_plugin_module_usage() -> None:
+    workflow = DEV_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--auth-plugin-module examples/auth_plugins/login_bearer.py" in workflow
+    assert "KNIVES_OUT_LOGIN_USERNAME" in workflow
+
+
+def test_ci_doc_includes_auth_plugin_guidance() -> None:
+    ci_doc = CI_DOC.read_text(encoding="utf-8")
+
+    assert "Optional: auth/session plugins" in ci_doc
+    assert "--auth-plugin-module examples/auth_plugins/login_bearer.py" in ci_doc

--- a/tests/test_auth_plugins.py
+++ b/tests/test_auth_plugins.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import httpx
+import pytest
+
+from knives_out.auth_plugins import (
+    ENTRY_POINT_GROUP,
+    PreparedRequest,
+    RuntimeContext,
+    RuntimePlugin,
+    load_auth_plugins,
+    load_entry_point_auth_plugins,
+    load_module_auth_plugins,
+    make_auth_plugin,
+)
+
+
+def test_load_module_auth_plugins_supports_local_modules(tmp_path: Path) -> None:
+    module_path = tmp_path / "custom_auth_plugin.py"
+    module_path.write_text(
+        dedent(
+            """
+            from knives_out.auth_plugins import RuntimePlugin, make_auth_plugin
+
+            class ModulePlugin(RuntimePlugin):
+                def before_request(self, request, context):
+                    request.headers["Authorization"] = "Bearer module-token"
+
+            auth_plugin = make_auth_plugin("module-auth-plugin", ModulePlugin())
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    plugins = load_module_auth_plugins([module_path])
+
+    assert [plugin.name for plugin in plugins] == ["module-auth-plugin"]
+
+
+def test_load_module_auth_plugins_reports_import_failures(tmp_path: Path) -> None:
+    module_path = tmp_path / "broken_auth_plugin.py"
+    module_path.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to import auth plugin module"):
+        load_module_auth_plugins([module_path])
+
+
+def test_load_entry_point_auth_plugins_supports_registered_names(monkeypatch) -> None:
+    class ExamplePlugin(RuntimePlugin):
+        pass
+
+    class _FakeEntryPoint:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def load(self):
+            return make_auth_plugin(self.name, ExamplePlugin())
+
+    class _FakeEntryPoints:
+        def select(self, *, group: str):
+            assert group == ENTRY_POINT_GROUP
+            return [_FakeEntryPoint("example-auth-plugin")]
+
+    monkeypatch.setattr("knives_out.auth_plugins.entry_points", lambda: _FakeEntryPoints())
+
+    plugins = load_entry_point_auth_plugins(["example-auth-plugin"])
+
+    assert [plugin.name for plugin in plugins] == ["example-auth-plugin"]
+
+
+def test_load_auth_plugins_raises_for_missing_entry_point() -> None:
+    with pytest.raises(ValueError, match="Unknown auth plugin entry point"):
+        load_auth_plugins(entry_point_names=["missing-auth-plugin"])
+
+
+def test_load_auth_plugins_supports_project_entry_point(monkeypatch) -> None:
+    monkeypatch.setenv("KNIVES_OUT_BEARER_TOKEN", "dev-token")
+    plugins = load_auth_plugins(entry_point_names=["env-bearer"])
+
+    request = PreparedRequest(
+        phase="request",
+        attack_id="atk_test",
+        name="Test attack",
+        kind="missing_auth",
+        operation_id="listPets",
+        method="GET",
+        path="/pets",
+        description="Test attack",
+    )
+
+    with httpx.Client() as client:
+        context = RuntimeContext(
+            client=client,
+            base_url="https://example.com",
+            scope="suite",
+        )
+        plugins[0].plugin.before_request(request, context)
+
+    assert request.headers["Authorization"] == "Bearer dev-token"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 from typer.testing import CliRunner
 
+from knives_out.auth_plugins import PluginRuntimeError
 from knives_out.cli import app
 from knives_out.models import (
     AttackCase,
@@ -198,11 +199,13 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
         default_query: dict[str, str],
         timeout_seconds: float,
         artifact_dir: Path | None,
+        auth_plugins=None,
         workflow_hooks=None,
     ) -> AttackResults:
         captured["suite_source"] = suite.source
         captured["base_url"] = base_url
         captured["artifact_dir"] = artifact_dir
+        captured["auth_plugins"] = auth_plugins
         return AttackResults(source=suite.source, base_url=base_url, results=[])
 
     monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
@@ -226,6 +229,7 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
     assert captured["suite_source"] == "unit"
     assert captured["base_url"] == "https://example.com"
     assert captured["artifact_dir"] == artifact_dir
+    assert captured["auth_plugins"] == []
 
 
 def test_verify_command_passes_without_baseline_when_no_qualifying_findings(tmp_path: Path) -> None:
@@ -534,9 +538,11 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
         default_query: dict[str, str],
         timeout_seconds: float,
         artifact_dir: Path | None,
+        auth_plugins=None,
         workflow_hooks=None,
     ) -> AttackResults:
         captured["attack_ids"] = [attack.id for attack in suite.attacks]
+        captured["auth_plugins"] = auth_plugins
         return AttackResults(source=suite.source, base_url=base_url, results=[])
 
     monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
@@ -557,6 +563,117 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
 
     assert result.exit_code == 0
     assert captured["attack_ids"] == ["atk_post"]
+    assert captured["auth_plugins"] == []
+
+
+def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    module_path = tmp_path / "auth_plugin.py"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    module_path.write_text(
+        dedent(
+            """
+            from knives_out.auth_plugins import RuntimePlugin, make_auth_plugin
+
+            class ModulePlugin(RuntimePlugin):
+                pass
+
+            auth_plugin = make_auth_plugin("module-auth-plugin", ModulePlugin())
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+        auth_plugins=None,
+        workflow_hooks=None,
+    ) -> AttackResults:
+        del default_headers, default_query, timeout_seconds, artifact_dir, workflow_hooks
+        captured["suite_source"] = suite.source
+        captured["base_url"] = base_url
+        captured["auth_plugin_names"] = [plugin.name for plugin in auth_plugins]
+        return AttackResults(source=suite.source, base_url=base_url, results=[])
+
+    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--auth-plugin-module",
+            str(module_path),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["suite_source"] == "unit"
+    assert captured["base_url"] == "https://example.com"
+    assert captured["auth_plugin_names"] == ["module-auth-plugin"]
+
+
+def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    def _fake_execute_attack_suite(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+        auth_plugins=None,
+        workflow_hooks=None,
+    ) -> AttackResults:
+        del (
+            suite,
+            base_url,
+            default_headers,
+            default_query,
+            timeout_seconds,
+            artifact_dir,
+            auth_plugins,
+            workflow_hooks,
+        )
+        raise PluginRuntimeError("boom")
+
+    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Auth plugin error:" in result.stdout
+    assert "boom" in result.stdout
 
 
 def test_generate_command_loads_local_attack_pack(tmp_path: Path) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,7 @@ import json
 
 import httpx
 
+from knives_out.auth_plugins import RuntimePlugin
 from knives_out.models import (
     AttackCase,
     AttackResult,
@@ -540,6 +541,115 @@ def test_execute_attack_suite_removes_only_declared_auth_query_param(monkeypatch
         "limit": 10,
         "page": "2",
     }
+
+
+def test_execute_attack_suite_applies_auth_plugin_before_omitting_auth_headers(monkeypatch) -> None:
+    class _BearerPlugin(RuntimePlugin):
+        def before_request(self, request, context) -> None:
+            del context
+            request.headers["Authorization"] = "Bearer plugin-token"
+            request.headers["X-Trace-Id"] = "trace-123"
+
+    response = httpx.Response(401, text="missing auth")
+    client = _install_recording_client(monkeypatch, response)
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_plugin_auth",
+                name="Missing plugin auth",
+                kind="missing_auth",
+                operation_id="listPets",
+                method="GET",
+                path="/pets",
+                description="Missing plugin auth",
+                omit_header_names=["Authorization"],
+            )
+        ],
+    )
+
+    execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        auth_plugins=[_BearerPlugin()],
+    )
+
+    request = client.requests[0]
+    assert request["headers"] == {
+        "X-Trace-Id": "trace-123",
+    }
+
+
+def test_execute_attack_suite_copies_suite_auth_state_into_workflows(monkeypatch) -> None:
+    class _SuiteTokenPlugin(RuntimePlugin):
+        def before_suite(self, context) -> None:
+            context.state["token"] = "suite-token"
+
+        def before_request(self, request, context) -> None:
+            token = context.state.get("token")
+            if token is not None:
+                request.headers["Authorization"] = f"Bearer {token}"
+
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        if request["url"] == "https://example.com/pets":
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "application/json"},
+                json=[{"id": 7}],
+            )
+        if request["url"] == "https://example.com/pets/7":
+            return httpx.Response(404, text="not found")
+        raise AssertionError(f"Unexpected request: {request}")
+
+    workflow_client = _HandlerClient(_handler)
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    suite = AttackSuite(source="unit", attacks=[_workflow_attack()])
+
+    results = execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        auth_plugins=[_SuiteTokenPlugin()],
+    )
+
+    assert results.results[0].type == "workflow"
+    assert workflow_client.requests[0]["headers"]["Authorization"] == "Bearer suite-token"
+    assert workflow_client.requests[1]["headers"]["Authorization"] == "Bearer suite-token"
+
+
+def test_execute_attack_suite_auth_plugin_can_create_workflow_session(monkeypatch) -> None:
+    class _LoginPlugin(RuntimePlugin):
+        def before_workflow(self, workflow, context) -> None:
+            del workflow
+            context.client.request("POST", context.build_url("/login"))
+
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        if request["url"] == "https://example.com/login":
+            return httpx.Response(200, headers={"set-cookie": "session=abc; Path=/"})
+        if request["url"] == "https://example.com/pets":
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "application/json"},
+                json=[{"id": 1}],
+            )
+        if request["url"] == "https://example.com/pets/1":
+            return httpx.Response(404, text="not found")
+        raise AssertionError(f"Unexpected request: {request}")
+
+    workflow_client = _HandlerClient(_handler)
+    _install_client_sequence(monkeypatch, [_NoopClient(), workflow_client])
+
+    suite = AttackSuite(source="unit", attacks=[_workflow_attack()])
+
+    execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        auth_plugins=[_LoginPlugin()],
+    )
+
+    assert workflow_client.requests[1]["headers"]["Cookie"] == "session=abc"
+    assert workflow_client.requests[2]["headers"]["Cookie"] == "session=abc"
 
 
 def test_execute_attack_suite_writes_artifacts(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add public auth/session plugin loading from entry points and local modules
- execute request and workflow attacks through runtime plugin hooks that can inject headers, tokens, and sessions
- document auth plugin usage in the README, CI docs, and sample workflow, with new loader and runner coverage

## Testing
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m pytest -q tests/test_auth_plugins.py tests/test_runner.py tests/test_cli.py tests/test_auth_plugin_docs.py` *(fails in this host Python 3.9 shell because project deps like `httpx` and `typer` are not installed here; rely on GitHub Actions for full test execution)*