### PR TITLE
[codex] Add tag and path filters

### DIFF
--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from knives_out.attack_packs import load_attack_packs
 from knives_out.auth_plugins import PluginRuntimeError, load_auth_plugins
-from knives_out.filtering import filter_attack_suite
+from knives_out.filtering import filter_attack_suite, filter_operations
 from knives_out.generator import generate_attack_suite
 from knives_out.models import AttackResults, PreflightWarning
 from knives_out.openapi_loader import load_operations_with_warnings
@@ -108,10 +108,34 @@ def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> Non
 
 
 @app.command()
-def inspect(spec: Path) -> None:
+def inspect(
+    spec: Path,
+    tag: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include operations with these tags. Repeatable."),
+    ] = None,
+    exclude_tag: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude operations with these tags. Repeatable."),
+    ] = None,
+    path: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include operations for these exact OpenAPI paths. Repeatable."),
+    ] = None,
+    exclude_path: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude operations for these exact OpenAPI paths. Repeatable."),
+    ] = None,
+) -> None:
     """Show the operations discovered in an OpenAPI spec."""
     loaded = load_operations_with_warnings(spec)
-    operations = loaded.operations
+    operations = filter_operations(
+        loaded.operations,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
+    )
 
     table = Table(title=f"knives-out inspect: {spec}")
     table.add_column("Operation ID")
@@ -167,6 +191,22 @@ def generate(
         list[str] | None,
         typer.Option(help="Exclude attacks for these attack kinds. Repeatable."),
     ] = None,
+    tag: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include attacks for these tags. Repeatable."),
+    ] = None,
+    exclude_tag: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these tags. Repeatable."),
+    ] = None,
+    path: Annotated[
+        list[str] | None,
+        typer.Option(help="Only include attacks for these exact OpenAPI paths. Repeatable."),
+    ] = None,
+    exclude_path: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these exact OpenAPI paths. Repeatable."),
+    ] = None,
     pack: Annotated[
         list[str] | None,
         typer.Option(help="Load custom attack packs from installed entry point names. Repeatable."),
@@ -219,6 +259,10 @@ def generate(
         exclude_methods=exclude_method,
         include_kinds=kind,
         exclude_kinds=exclude_kind,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
     )
     out.write_text(suite.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     workflow_count = sum(1 for attack in suite.attacks if attack.type == "workflow")
@@ -291,6 +335,22 @@ def run(
         list[str] | None,
         typer.Option(help="Exclude attacks for these attack kinds. Repeatable."),
     ] = None,
+    tag: Annotated[
+        list[str] | None,
+        typer.Option(help="Only run attacks for these tags. Repeatable."),
+    ] = None,
+    exclude_tag: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these tags. Repeatable."),
+    ] = None,
+    path: Annotated[
+        list[str] | None,
+        typer.Option(help="Only run attacks for these exact OpenAPI paths. Repeatable."),
+    ] = None,
+    exclude_path: Annotated[
+        list[str] | None,
+        typer.Option(help="Exclude attacks for these exact OpenAPI paths. Repeatable."),
+    ] = None,
 ) -> None:
     """Run a saved attack suite against a live API.
 
@@ -305,6 +365,10 @@ def run(
         exclude_methods=exclude_method,
         include_kinds=kind,
         exclude_kinds=exclude_kind,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
     )
     default_headers = _parse_key_value(header, separator=":")
     default_query = _parse_key_value(query, separator="=")

--- a/src/knives_out/example_packs.py
+++ b/src/knives_out/example_packs.py
@@ -19,6 +19,7 @@ def generate_unexpected_header_attack(operation: OperationSpec) -> list[AttackCa
             operation_id=operation.operation_id,
             method=operation.method,
             path=operation.path,
+            tags=list(operation.tags),
             description="Adds an unexpected header to probe strict header handling.",
             path_params=path_params,
             query=query,

--- a/src/knives_out/example_workflow_packs.py
+++ b/src/knives_out/example_workflow_packs.py
@@ -41,6 +41,7 @@ def generate_listed_id_lookup_workflows(
                 operation_id=attack.operation_id,
                 method=attack.method,
                 path=attack.path,
+                tags=list(attack.tags),
                 description=(
                     "Lists pets, extracts the first item id, then reuses that value "
                     "when executing the terminal attack."

--- a/src/knives_out/filtering.py
+++ b/src/knives_out/filtering.py
@@ -1,10 +1,34 @@
 from __future__ import annotations
 
-from knives_out.models import AttackCase, AttackSuite, WorkflowAttackCase
+from knives_out.models import AttackCase, AttackSuite, OperationSpec, WorkflowAttackCase
 
 
 def _normalized_values(values: list[str] | None) -> set[str]:
     return {value.strip().casefold() for value in values or [] if value.strip()}
+
+
+def _exact_values(values: list[str] | None) -> set[str]:
+    return {value.strip() for value in values or [] if value.strip()}
+
+
+def _matches_path_and_tags(
+    *,
+    path: str,
+    tags: list[str],
+    include_paths: set[str],
+    exclude_paths: set[str],
+    include_tags: set[str],
+    exclude_tags: set[str],
+) -> bool:
+    if include_paths and path not in include_paths:
+        return False
+    if path in exclude_paths:
+        return False
+    if include_tags and not any(tag in include_tags for tag in tags):
+        return False
+    if exclude_tags and any(tag in exclude_tags for tag in tags):
+        return False
+    return True
 
 
 def _matches_attack(
@@ -16,6 +40,10 @@ def _matches_attack(
     exclude_methods: set[str],
     include_kinds: set[str],
     exclude_kinds: set[str],
+    include_paths: set[str],
+    exclude_paths: set[str],
+    include_tags: set[str],
+    exclude_tags: set[str],
 ) -> bool:
     operation_id = attack.operation_id.casefold()
     method = attack.method.casefold()
@@ -33,7 +61,43 @@ def _matches_attack(
         return False
     if kind in exclude_kinds:
         return False
+    if not _matches_path_and_tags(
+        path=attack.path,
+        tags=attack.tags,
+        include_paths=include_paths,
+        exclude_paths=exclude_paths,
+        include_tags=include_tags,
+        exclude_tags=exclude_tags,
+    ):
+        return False
     return True
+
+
+def filter_operations(
+    operations: list[OperationSpec],
+    *,
+    include_paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
+    include_tags: list[str] | None = None,
+    exclude_tags: list[str] | None = None,
+) -> list[OperationSpec]:
+    include_path_set = _exact_values(include_paths)
+    exclude_path_set = _exact_values(exclude_paths)
+    include_tag_set = _exact_values(include_tags)
+    exclude_tag_set = _exact_values(exclude_tags)
+
+    return [
+        operation
+        for operation in operations
+        if _matches_path_and_tags(
+            path=operation.path,
+            tags=operation.tags,
+            include_paths=include_path_set,
+            exclude_paths=exclude_path_set,
+            include_tags=include_tag_set,
+            exclude_tags=exclude_tag_set,
+        )
+    ]
 
 
 def filter_attack_suite(
@@ -45,6 +109,10 @@ def filter_attack_suite(
     exclude_methods: list[str] | None = None,
     include_kinds: list[str] | None = None,
     exclude_kinds: list[str] | None = None,
+    include_paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
+    include_tags: list[str] | None = None,
+    exclude_tags: list[str] | None = None,
 ) -> AttackSuite:
     include_operation_set = _normalized_values(include_operations)
     exclude_operation_set = _normalized_values(exclude_operations)
@@ -52,6 +120,10 @@ def filter_attack_suite(
     exclude_method_set = _normalized_values(exclude_methods)
     include_kind_set = _normalized_values(include_kinds)
     exclude_kind_set = _normalized_values(exclude_kinds)
+    include_path_set = _exact_values(include_paths)
+    exclude_path_set = _exact_values(exclude_paths)
+    include_tag_set = _exact_values(include_tags)
+    exclude_tag_set = _exact_values(exclude_tags)
 
     filtered_attacks = [
         attack
@@ -64,6 +136,10 @@ def filter_attack_suite(
             exclude_methods=exclude_method_set,
             include_kinds=include_kind_set,
             exclude_kinds=exclude_kind_set,
+            include_paths=include_path_set,
+            exclude_paths=exclude_path_set,
+            include_tags=include_tag_set,
+            exclude_tags=exclude_tag_set,
         )
     ]
 

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -229,6 +229,10 @@ def _response_schemas_for_attack(operation: OperationSpec) -> dict[str, Any]:
     return deepcopy(operation.response_schemas)
 
 
+def _tags_for_attack(operation: OperationSpec) -> list[str]:
+    return list(operation.tags)
+
+
 def _schema_type(schema: dict[str, Any] | None) -> str | None:
     if not schema:
         return None
@@ -407,6 +411,7 @@ def _workflow_attack_from_assignments(
         operation_id=terminal_attack.operation_id,
         method=terminal_attack.method,
         path=terminal_attack.path,
+        tags=list(terminal_attack.tags),
         description=(
             f"Creates state with {producer.operation_id} before executing "
             f"the terminal attack '{terminal_attack.name}'."
@@ -508,6 +513,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                     operation_id=operation.operation_id,
                     method=operation.method,
                     path=operation.path,
+                    tags=_tags_for_attack(operation),
                     description=(
                         f"Omits required {parameter.location} parameter '{parameter.name}'."
                     ),
@@ -544,6 +550,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 operation_id=operation.operation_id,
                 method=operation.method,
                 path=operation.path,
+                tags=_tags_for_attack(operation),
                 description=(
                     f"Substitutes a wrong-type value for {parameter.location} "
                     f"parameter '{parameter.name}'."
@@ -582,6 +589,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                     operation_id=operation.operation_id,
                     method=operation.method,
                     path=operation.path,
+                    tags=_tags_for_attack(operation),
                     description=f"Uses a value outside the declared enum for '{parameter.name}'.",
                     path_params=path_params,
                     query=query_params,
@@ -603,6 +611,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 operation_id=operation.operation_id,
                 method=operation.method,
                 path=operation.path,
+                tags=_tags_for_attack(operation),
                 description="Omits the required request body.",
                 path_params=path_params,
                 query=query_params,
@@ -624,6 +633,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 operation_id=operation.operation_id,
                 method=operation.method,
                 path=operation.path,
+                tags=_tags_for_attack(operation),
                 description="Sends invalid JSON for a JSON request body.",
                 path_params=path_params,
                 query=query_params,
@@ -646,6 +656,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 operation_id=operation.operation_id,
                 method=operation.method,
                 path=operation.path,
+                tags=_tags_for_attack(operation),
                 description="Removes the declared auth credential from the request.",
                 path_params=path_params,
                 query=query_params,

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -27,6 +27,7 @@ class OperationSpec(BaseModel):
     method: str
     path: str
     summary: str | None = None
+    tags: list[str] = Field(default_factory=list)
     parameters: list[ParameterSpec] = Field(default_factory=list)
     request_body_required: bool = False
     request_body_schema: dict[str, Any] | None = None
@@ -58,6 +59,7 @@ class AttackCase(BaseModel):
     operation_id: str
     method: str
     path: str
+    tags: list[str] = Field(default_factory=list)
     description: str
     path_params: dict[str, Any] = Field(default_factory=dict)
     query: dict[str, Any] = Field(default_factory=dict)
@@ -104,6 +106,7 @@ class WorkflowAttackCase(BaseModel):
     operation_id: str
     method: str
     path: str
+    tags: list[str] = Field(default_factory=list)
     description: str
     setup_steps: list[WorkflowStep] = Field(default_factory=list)
     terminal_attack: AttackCase

--- a/src/knives_out/openapi_loader.py
+++ b/src/knives_out/openapi_loader.py
@@ -538,6 +538,7 @@ def load_operations_with_warnings(path: str | Path) -> LoadedOperations:
                     method=context["method"],
                     path=route,
                     summary=operation.get("summary") or operation.get("description"),
+                    tags=[tag for tag in operation.get("tags", []) if isinstance(tag, str)],
                     parameters=parsed_parameters,
                     request_body_required=request_body_required,
                     request_body_schema=request_body_schema,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,36 @@ def test_inspect_command_shows_preflight_warnings(monkeypatch) -> None:
     assert "createPet" in result.stdout
 
 
+def test_inspect_command_filters_operations_by_tag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "knives_out.cli.load_operations_with_warnings",
+        lambda spec: LoadedOperations(
+            operations=[
+                {
+                    "operation_id": "listPets",
+                    "method": "GET",
+                    "path": "/pets",
+                    "tags": ["pets", "read"],
+                },
+                {
+                    "operation_id": "createPet",
+                    "method": "POST",
+                    "path": "/pets",
+                    "tags": ["pets", "write"],
+                },
+            ],
+            warnings=[],
+        ),
+    )
+
+    result = runner.invoke(app, ["inspect", str(EXAMPLE_SPEC), "--tag", "write"])
+
+    assert result.exit_code == 0
+    assert "createPet" in result.stdout
+    assert "listPets" not in result.stdout
+    assert "Found 1 operations." in result.stdout
+
+
 def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
     out_path = tmp_path / "attacks.json"
     result = runner.invoke(app, ["generate", str(EXAMPLE_SPEC), "--out", str(out_path)])
@@ -427,6 +457,7 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
                         operation_id="listPets",
                         method="GET",
                         path="/pets",
+                        tags=["pets", "read"],
                         description="GET attack",
                     ),
                     AttackCase(
@@ -436,6 +467,7 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
                         operation_id="createPet",
                         method="POST",
                         path="/pets",
+                        tags=["pets", "write"],
                         description="POST attack",
                     ),
                 ],
@@ -458,6 +490,61 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
     assert result.exit_code == 0
     suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert [attack.id for attack in suite.attacks] == ["atk_post"]
+
+
+def test_generate_command_filters_attacks_by_tag(tmp_path: Path, monkeypatch) -> None:
+    out_path = tmp_path / "attacks.json"
+
+    monkeypatch.setattr(
+        "knives_out.cli.load_operations_with_warnings",
+        lambda spec: LoadedOperations(operations=[], warnings=[]),
+    )
+    monkeypatch.setattr(
+        "knives_out.cli.generate_attack_suite",
+        lambda operations, source, extra_packs=None, auto_workflows=False, workflow_packs=None: (
+            AttackSuite(
+                source=source,
+                attacks=[
+                    AttackCase(
+                        id="atk_read",
+                        name="Read attack",
+                        kind="missing_auth",
+                        operation_id="listPets",
+                        method="GET",
+                        path="/pets",
+                        tags=["pets", "read"],
+                        description="Read attack",
+                    ),
+                    AttackCase(
+                        id="atk_write",
+                        name="Write attack",
+                        kind="missing_request_body",
+                        operation_id="createPet",
+                        method="POST",
+                        path="/pets",
+                        tags=["pets", "write"],
+                        description="Write attack",
+                    ),
+                ],
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(EXAMPLE_SPEC),
+            "--out",
+            str(out_path),
+            "--tag",
+            "write",
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert [attack.id for attack in suite.attacks] == ["atk_write"]
 
 
 def test_generate_command_echoes_preflight_warnings(tmp_path: Path, monkeypatch) -> None:
@@ -512,6 +599,7 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
                     operation_id="listPets",
                     method="GET",
                     path="/pets",
+                    tags=["pets", "read"],
                     description="GET attack",
                 ),
                 AttackCase(
@@ -521,6 +609,7 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
                     operation_id="createPet",
                     method="POST",
                     path="/pets",
+                    tags=["pets", "write"],
                     description="POST attack",
                 ),
             ],
@@ -564,6 +653,83 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
     assert result.exit_code == 0
     assert captured["attack_ids"] == ["atk_post"]
     assert captured["auth_plugins"] == []
+
+
+def test_run_command_filters_attacks_by_path_before_execution(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    attacks_path.write_text(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_get",
+                    name="GET attack",
+                    kind="missing_auth",
+                    operation_id="listPets",
+                    method="GET",
+                    path="/pets",
+                    tags=["pets", "read"],
+                    description="GET attack",
+                ),
+                AttackCase(
+                    id="atk_post",
+                    name="POST attack",
+                    kind="missing_request_body",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets/{petId}",
+                    tags=["pets", "write"],
+                    description="POST attack",
+                ),
+            ],
+        ).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+        auth_plugins=None,
+        workflow_hooks=None,
+    ) -> AttackResults:
+        del (
+            base_url,
+            default_headers,
+            default_query,
+            timeout_seconds,
+            artifact_dir,
+            auth_plugins,
+            workflow_hooks,
+        )
+        captured["attack_ids"] = [attack.id for attack in suite.attacks]
+        return AttackResults(source=suite.source, base_url="https://example.com", results=[])
+
+    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--path",
+            "/pets/{petId}",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["attack_ids"] == ["atk_post"]
 
 
 def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -13,6 +13,7 @@ def _suite() -> AttackSuite:
                 operation_id="listPets",
                 method="GET",
                 path="/pets",
+                tags=["pets", "read"],
                 description="GET missing auth",
             ),
             AttackCase(
@@ -22,6 +23,7 @@ def _suite() -> AttackSuite:
                 operation_id="createPet",
                 method="POST",
                 path="/pets",
+                tags=["pets", "write"],
                 description="POST malformed body",
             ),
             AttackCase(
@@ -31,6 +33,7 @@ def _suite() -> AttackSuite:
                 operation_id="createPet",
                 method="POST",
                 path="/pets",
+                tags=["pets", "write"],
                 description="POST missing auth",
             ),
         ],
@@ -66,6 +69,31 @@ def test_filter_attack_suite_combines_include_and_exclude_filters() -> None:
     assert [attack.id for attack in suite.attacks] == ["atk_post_auth"]
 
 
+def test_filter_attack_suite_by_exact_tag() -> None:
+    suite = filter_attack_suite(_suite(), include_tags=["write"])
+
+    assert [attack.id for attack in suite.attacks] == [
+        "atk_post_body",
+        "atk_post_auth",
+    ]
+
+
+def test_filter_attack_suite_by_exact_path() -> None:
+    suite = filter_attack_suite(_suite(), include_paths=["/pets"])
+
+    assert [attack.id for attack in suite.attacks] == [
+        "atk_get_missing",
+        "atk_post_body",
+        "atk_post_auth",
+    ]
+
+
+def test_filter_attack_suite_treats_tags_as_case_sensitive() -> None:
+    suite = filter_attack_suite(_suite(), include_tags=["WRITE"])
+
+    assert suite.attacks == []
+
+
 def test_filter_attack_suite_matches_workflow_terminal_metadata() -> None:
     suite = AttackSuite(
         source="unit",
@@ -77,6 +105,7 @@ def test_filter_attack_suite_matches_workflow_terminal_metadata() -> None:
                 operation_id="createPet",
                 method="POST",
                 path="/pets",
+                tags=["pets", "write"],
                 description="Workflow missing auth",
                 terminal_attack=AttackCase(
                     id="atk_post_auth",
@@ -85,6 +114,7 @@ def test_filter_attack_suite_matches_workflow_terminal_metadata() -> None:
                     operation_id="createPet",
                     method="POST",
                     path="/pets",
+                    tags=["pets", "write"],
                     description="POST missing auth",
                 ),
             )
@@ -96,6 +126,42 @@ def test_filter_attack_suite_matches_workflow_terminal_metadata() -> None:
         include_operations=["createPet"],
         include_methods=["post"],
         include_kinds=["missing_auth"],
+    )
+
+    assert [attack.id for attack in filtered.attacks] == ["wf_post_auth"]
+
+
+def test_filter_attack_suite_matches_workflow_tags_and_paths() -> None:
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            WorkflowAttackCase(
+                id="wf_post_auth",
+                name="Workflow missing auth",
+                kind="missing_auth",
+                operation_id="createPet",
+                method="POST",
+                path="/pets/{petId}",
+                tags=["pets", "write"],
+                description="Workflow missing auth",
+                terminal_attack=AttackCase(
+                    id="atk_post_auth",
+                    name="POST missing auth",
+                    kind="missing_auth",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets/{petId}",
+                    tags=["pets", "write"],
+                    description="POST missing auth",
+                ),
+            )
+        ],
+    )
+
+    filtered = filter_attack_suite(
+        suite,
+        include_paths=["/pets/{petId}"],
+        include_tags=["write"],
     )
 
     assert [attack.id for attack in filtered.attacks] == ["wf_post_auth"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -257,6 +257,94 @@ def test_generate_attack_suite_can_emit_built_in_workflows() -> None:
     assert get_pet_workflow.terminal_attack.path_params["petId"] == "{{id}}"
 
 
+def test_generate_attack_suite_copies_operation_tags_to_attacks_and_workflows(
+    tmp_path: Path,
+) -> None:
+    spec = tmp_path / "tagged-workflows.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Tagged workflow spec
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  tags: [pets, read]
+                  responses:
+                    '200':
+                      description: Pets
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+                post:
+                  operationId: createPet
+                  tags: [pets, write]
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [name]
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '201':
+                      description: created
+              /pets/{petId}:
+                get:
+                  operationId: getPet
+                  tags: [pets, read]
+                  parameters:
+                    - name: petId
+                      in: path
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: Pet
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    operations = load_operations(spec)
+    suite = generate_attack_suite(operations, source=str(spec), auto_workflows=True)
+
+    create_pet_attack = next(
+        attack
+        for attack in suite.attacks
+        if attack.type == "request" and attack.operation_id == "createPet"
+    )
+    get_pet_workflow = next(
+        attack
+        for attack in suite.attacks
+        if isinstance(attack, WorkflowAttackCase) and attack.operation_id == "getPet"
+    )
+
+    assert create_pet_attack.tags == ["pets", "write"]
+    assert get_pet_workflow.tags == ["pets", "read"]
+    assert get_pet_workflow.terminal_attack.tags == ["pets", "read"]
+
+
 def test_generate_attack_suite_skips_ambiguous_workflow_producers(tmp_path: Path) -> None:
     spec = tmp_path / "ambiguous-workflows.yaml"
     spec.write_text(

--- a/tests/test_openapi_loader.py
+++ b/tests/test_openapi_loader.py
@@ -249,6 +249,40 @@ def test_load_operations_extracts_api_key_auth_from_components(tmp_path) -> None
     assert operations["optionalAuth"].auth_header_names == ["X-API-Key"]
 
 
+def test_load_operations_extracts_tags(tmp_path) -> None:
+    spec = tmp_path / "operation-tags.yaml"
+    spec.write_text(
+        dedent(
+            """
+            openapi: 3.0.3
+            info:
+              title: Tag extraction test
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  tags: [pets, read]
+                  responses:
+                    "200":
+                      description: ok
+              /health:
+                get:
+                  operationId: healthcheck
+                  responses:
+                    "200":
+                      description: ok
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    operations = {operation.operation_id: operation for operation in load_operations(spec)}
+
+    assert operations["listPets"].tags == ["pets", "read"]
+    assert operations["healthcheck"].tags == []
+
+
 def test_load_operations_with_warnings_reports_missing_request_schema_and_vague_security(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add exact tag and path filters to inspect, generate, and run
- persist operation tags through loaded specs, generated attacks, and workflows
- add CLI and filtering tests for request and workflow filtering behavior

## Testing
- `python3 -m ruff check src/knives_out/filtering.py src/knives_out/models.py src/knives_out/openapi_loader.py src/knives_out/generator.py src/knives_out/example_packs.py src/knives_out/example_workflow_packs.py src/knives_out/cli.py tests/test_filtering.py tests/test_openapi_loader.py tests/test_cli.py tests/test_generator.py`
- `python3 -m ruff format --check src/knives_out/filtering.py src/knives_out/models.py src/knives_out/openapi_loader.py src/knives_out/generator.py src/knives_out/example_packs.py src/knives_out/example_workflow_packs.py src/knives_out/cli.py tests/test_filtering.py tests/test_openapi_loader.py tests/test_cli.py tests/test_generator.py`
- `./.venv/bin/python -m pytest -q tests/test_filtering.py tests/test_openapi_loader.py tests/test_cli.py tests/test_generator.py` *(fails in this host environment because pytest is not installed in .venv)*