### PR TITLE
[codex] Expand examples and CI coverage docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
           ruff check .
           ruff format --check .
       - name: Pytest
-        run: pytest
+        run: pytest --cov=src/knives_out --cov-report=term-missing

--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  SPEC_PATH: examples/openapi/petstore.yaml
+  SPEC_PATH: examples/openapi/storefront.yaml
 
 jobs:
   knives-out-dev:
@@ -23,9 +23,16 @@ jobs:
           pip install -e ".[dev]"
       - name: Generate attack suite
         run: |
-          knives-out generate "$SPEC_PATH" --out attacks.json
+          knives-out generate "$SPEC_PATH" --tag orders --out attacks.json
+          # Path filters are exact matches against the OpenAPI path template:
+          # knives-out generate "$SPEC_PATH" \
+          #   --path /draft-orders/{draftId} \
+          #   --out attacks.json
           # For stateful coverage, opt in to built-in workflows:
-          # knives-out generate "$SPEC_PATH" --auto-workflows --out attacks.json
+          # knives-out generate "$SPEC_PATH" \
+          #   --tag orders \
+          #   --auto-workflows \
+          #   --out attacks.json
           # For app-specific journeys, add a workflow pack module:
           # knives-out generate "$SPEC_PATH" \
           #   --auto-workflows \
@@ -49,6 +56,7 @@ jobs:
             --base-url "${KNIVES_OUT_BASE_URL}"
             --artifact-dir artifacts
             --out results.json
+            --tag orders
           )
 
           if [[ -n "${KNIVES_OUT_AUTH_HEADER}" ]]; then
@@ -65,11 +73,30 @@ jobs:
           knives-out run attacks.json "${args[@]}"
       - name: Render Markdown report
         run: knives-out report results.json --out report.md
+      - name: Render baseline-aware report
+        if: ${{ hashFiles('previous-results.json') != '' }}
+        run: |
+          knives-out report results.json \
+            --baseline previous-results.json \
+            --out regression-report.md
       - name: Verify findings against CI policy
         run: |
           knives-out verify results.json \
             --min-severity high \
             --min-confidence medium
+          # To fail only on new qualifying regressions:
+          # knives-out verify results.json \
+          #   --baseline previous-results.json \
+          #   --min-severity high \
+          #   --min-confidence medium
+      - name: Promote qualifying findings into a regression suite
+        if: always()
+        run: |
+          knives-out promote results.json \
+            --attacks attacks.json \
+            --out regression-attacks.json
+          # For baseline-aware promotion, add:
+          #   --baseline previous-results.json
       - name: Upload run artifacts
         if: always()
         uses: actions/upload-artifact@v6
@@ -78,6 +105,8 @@ jobs:
           if-no-files-found: ignore
           path: |
             attacks.json
+            regression-attacks.json
             results.json
             report.md
+            regression-report.md
             artifacts/

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Given an OpenAPI document, `knives-out` can:
 
 - inspect the operations in the spec
 - generate replayable negative test cases
+- generate schema-aware mutation attacks from declared constraints
 - optionally chain setup requests into replayable workflow attacks
 - load auth/session plugins for bearer tokens, login flows, and shared sessions
 - run those attacks against a live base URL
 - produce a Markdown report that highlights suspicious outcomes
+- verify findings for CI gating
+- promote qualifying findings back into a reusable regression suite
 
 The initial focus is narrow by design:
 
@@ -35,12 +38,17 @@ The starter scaffold generates a first wave of useful negative tests:
 - missing required query/header parameters
 - wrong-type parameter values
 - invalid enum values
+- below-minimum and above-maximum numeric values
+- too-short and too-long string values
+- too-few and too-many array items
+- invalid `uuid`, `email`, `date`, `date-time`, and `uri` formats
+- unexpected JSON properties and missing required JSON properties
 - missing request bodies
 - malformed JSON bodies
 - missing auth headers or query credentials when the spec declares security
 - opt-in setup-plus-terminal workflow attacks that reuse extracted response values
 
-This is not a full fuzzing engine yet. It is a structured attack generator and runner.
+This is not a full fuzzing engine yet. It is a structured attack generator, runner, and CI gate.
 
 ## Why this shape
 
@@ -50,14 +58,14 @@ The project is split into three explicit phases:
 2. **Run** those attack cases against a target.
 3. **Report** findings in a stable, reviewable format.
 
-That makes the architecture easier to extend later with:
+That makes the architecture easier to evolve further with:
 
 - custom attack packs
-- schema-aware payload mutation
+- deeper stateful workflows
 - LLM application testing
 - GraphQL support
-- CI gating policies
-- regression suites for previously found bugs
+- richer CI policies
+- protocol expansion beyond OpenAPI REST
 
 ## Quick start
 
@@ -67,25 +75,31 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-Inspect the sample spec:
+Inspect the sample specs:
 
 ```bash
 knives-out inspect examples/openapi/petstore.yaml
+knives-out inspect examples/openapi/storefront.yaml --tag orders
 ```
 
 Generate attacks:
 
 ```bash
 knives-out generate examples/openapi/petstore.yaml --out attacks.json
+knives-out generate examples/openapi/storefront.yaml --tag orders --out attacks.json
 ```
 
 Opt in to built-in stateful workflows:
 
 ```bash
-knives-out generate examples/openapi/petstore.yaml \
+knives-out generate examples/openapi/storefront.yaml \
+  --tag orders \
   --auto-workflows \
   --out attacks.json
 ```
+
+The checked-in `examples/openapi/storefront.yaml` demonstrates exact tag/path filters, schema
+constraints, and a producer/consumer workflow chain via `createDraftOrder` -> `getDraftOrder`.
 
 Run them against a live API:
 
@@ -117,6 +131,12 @@ Verify findings against the default CI policy:
 knives-out verify results.json
 ```
 
+Promote qualifying findings back into a reusable regression suite:
+
+```bash
+knives-out promote results.json --attacks attacks.json --out regression-attacks.json
+```
+
 ## CI usage
 
 `knives-out` works well in CI when you follow the same generate/run/report flow and add a final
@@ -126,7 +146,8 @@ verification step:
 2. run them against a dev or staging environment
 3. render a Markdown report for review
 4. verify the results against a CI policy
-5. upload the JSON results, request artifacts, and Markdown report for triage
+5. optionally promote qualifying findings into a smaller regression suite
+6. upload the JSON results, request artifacts, and Markdown report for triage
 
 A ready-to-adapt GitHub Actions example lives at `.github/workflows/dev-environment-example.yml`.
 It uses repository secrets instead of hard-coded targets:
@@ -146,8 +167,10 @@ When you want stateful coverage, generate with `--auto-workflows` first, then ad
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
 you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
 credentials on `--header` or `--query`, or move up to
-`--auth-plugin-module examples/auth_plugins/login_bearer.py` for login/session flows. See
-`docs/ci.md` for the sample workflow, secret setup, and baseline-aware CI patterns.
+`--auth-plugin-module examples/auth_plugins/login_bearer.py` for login/session flows. When you want
+to keep only the highest-signal regressions around, follow `verify` with
+`knives-out promote results.json --attacks attacks.json`. See `docs/ci.md` for the sample
+workflow, secret setup, filtering patterns, and baseline-aware CI flows.
 
 ## CLI
 
@@ -161,6 +184,14 @@ knives-out inspect path/to/openapi.yaml
 
 `inspect` surfaces preflight warnings for spec gaps such as missing request schemas, vague
 security declarations, and broken `$ref` pointers.
+
+You can filter inspection to exact tags or paths:
+
+```bash
+knives-out inspect examples/openapi/storefront.yaml \
+  --tag orders \
+  --path /draft-orders/{draftId}
+```
 
 ### `generate`
 
@@ -191,6 +222,19 @@ knives-out generate path/to/openapi.yaml \
   --out attacks.json
 ```
 
+Filters are also available during generation:
+
+```bash
+knives-out generate examples/openapi/storefront.yaml \
+  --tag orders \
+  --path /draft-orders/{draftId} \
+  --out attacks.json
+```
+
+When the spec declares constraints, `generate` now emits additive schema-aware mutations such as
+`below_minimum`, `too_long`, `too_many_items`, `invalid_format`,
+`unexpected_property`, and `missing_required_property`.
+
 ### `run`
 
 Executes a saved attack suite against a base URL.
@@ -216,6 +260,16 @@ knives-out run attacks.json \
   --base-url http://localhost:8000 \
   --auth-plugin env-bearer \
   --auth-plugin-module examples/auth_plugins/login_bearer.py \
+  --out results.json
+```
+
+Run-time filters match the same exact tag/path semantics:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --tag orders \
+  --path /draft-orders/{draftId} \
   --out results.json
 ```
 
@@ -249,6 +303,26 @@ knives-out verify results.json \
   --baseline previous-results.json \
   --min-severity high \
   --min-confidence medium
+```
+
+### `promote`
+
+Turns qualifying findings from `results.json` back into a replayable `AttackSuite`.
+
+```bash
+knives-out promote results.json \
+  --attacks attacks.json \
+  --out regression-attacks.json
+```
+
+For baseline-aware regression promotion, pass the same prior `results.json` you would use with
+`verify`:
+
+```bash
+knives-out promote results.json \
+  --attacks attacks.json \
+  --baseline previous-results.json \
+  --out regression-attacks.json
 ```
 
 ## Development

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,7 +7,8 @@
 3. run that suite against a dev or staging deployment
 4. render a Markdown report for review
 5. verify the results against a CI policy
-6. publish the JSON results, Markdown report, and per-attack artifacts
+6. optionally promote qualifying findings into a smaller regression suite
+7. publish the JSON results, Markdown report, regression suite, and per-attack artifacts
 
 The repository includes a ready-to-adapt GitHub Actions example at
 `.github/workflows/dev-environment-example.yml`.
@@ -32,6 +33,9 @@ The optional values should match the current CLI surface:
 For static credentials, `--header` and `--query` are still the simplest fit. Use auth/session
 plugins when your CI flow needs to log in, fetch a bearer token, or establish a shared session
 before the suite or each workflow runs.
+
+For richer checked-in examples, the repo now includes `examples/openapi/storefront.yaml`, which
+combines exact tags, path filters, schema constraints, and a producer/consumer workflow chain.
 
 ## Expected exit behavior
 
@@ -107,6 +111,29 @@ You can add app-specific journeys by loading a workflow pack module or entry poi
       --out attacks.json
 ```
 
+## Optional: tag and path filtering
+
+The same exact-match filters work in `inspect`, `generate`, and `run`:
+
+```yaml
+- name: Generate only order-related attacks
+  run: |
+    knives-out generate "$SPEC_PATH" \
+      --tag orders \
+      --path /draft-orders/{draftId} \
+      --out attacks.json
+```
+
+```yaml
+- name: Run only order-related attacks
+  run: |
+    knives-out run attacks.json \
+      --base-url "${KNIVES_OUT_BASE_URL}" \
+      --tag orders \
+      --path /draft-orders/{draftId} \
+      --out results.json
+```
+
 ## Optional: auth/session plugins
 
 For login or shared-session flows, load a local auth plugin module during `run`:
@@ -139,3 +166,38 @@ You can also render a Markdown report that highlights new, resolved, and persist
       --baseline previous-results.json \
       --out report.md
 ```
+
+## Optional: promote a regression suite
+
+When you want to preserve only qualifying findings as a smaller replayable suite, use `promote`:
+
+```yaml
+- name: Promote qualifying findings
+  if: always()
+  run: |
+    knives-out promote results.json \
+      --attacks attacks.json \
+      --out regression-attacks.json
+```
+
+To promote only new regressions, pass the same baseline file you use with `verify`:
+
+```yaml
+- name: Promote new qualifying regressions
+  if: always()
+  run: |
+    knives-out promote results.json \
+      --attacks attacks.json \
+      --baseline previous-results.json \
+      --out regression-attacks.json
+```
+
+## Coverage in repository CI
+
+The repository's own `ci.yml` now runs:
+
+- `ruff check .`
+- `ruff format --check .`
+- `pytest --cov=src/knives_out --cov-report=term-missing`
+
+Coverage is printed in CI for visibility, but there is no hard percentage gate yet.

--- a/examples/openapi/storefront.yaml
+++ b/examples/openapi/storefront.yaml
@@ -1,0 +1,115 @@
+openapi: 3.0.3
+info:
+  title: Storefront API
+  version: 1.0.0
+paths:
+  /catalog/items:
+    get:
+      operationId: listCatalogItems
+      tags: [catalog, read]
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+        - name: X-Trace
+          in: header
+          required: false
+          schema:
+            type: string
+            minLength: 6
+            maxLength: 12
+      responses:
+        '200':
+          description: Catalog items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [sku, name]
+                  properties:
+                    sku:
+                      type: string
+                      format: uuid
+                    name:
+                      type: string
+  /draft-orders:
+    post:
+      operationId: createDraftOrder
+      tags: [orders, write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [customerEmail, note, lineItems]
+              properties:
+                customerEmail:
+                  type: string
+                  format: email
+                note:
+                  type: string
+                  minLength: 5
+                  maxLength: 40
+                lineItems:
+                  type: array
+                  minItems: 1
+                  maxItems: 3
+                  items:
+                    type: object
+                    required: [sku, quantity]
+                    properties:
+                      sku:
+                        type: string
+                        format: uuid
+                      quantity:
+                        type: integer
+                        minimum: 1
+                        maximum: 5
+      responses:
+        '201':
+          description: Draft order created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [draftId, customerEmail]
+                properties:
+                  draftId:
+                    type: string
+                    format: uuid
+                  customerEmail:
+                    type: string
+                    format: email
+  /draft-orders/{draftId}:
+    get:
+      operationId: getDraftOrder
+      tags: [orders, read]
+      parameters:
+        - name: draftId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Draft order details
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [draftId, customerEmail]
+                properties:
+                  draftId:
+                    type: string
+                    format: uuid
+                  customerEmail:
+                    type: string
+                    format: email

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.3.0",
+  "pytest-cov>=5.0.0",
   "ruff>=0.6.0",
 ]
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -17,7 +17,11 @@ def test_readme_includes_ci_guidance() -> None:
     assert "KNIVES_OUT_BASE_URL" in readme
     assert "`knives-out run` currently exits with status `0`" in readme
     assert "knives-out verify results.json" in readme
+    assert "knives-out promote results.json" in readme
     assert "--auto-workflows" in readme
+    assert "--tag orders" in readme
+    assert "--path /draft-orders/{draftId}" in readme
+    assert "examples/openapi/storefront.yaml" in readme
     assert "examples/workflow_packs/listed_pet_lookup.py" in readme
 
 
@@ -28,12 +32,16 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "actions/checkout@v5" in workflow
     assert "actions/setup-python@v6" in workflow
     assert "actions/upload-artifact@v6" in workflow
-    assert 'knives-out generate "$SPEC_PATH" --out attacks.json' in workflow
+    assert "SPEC_PATH: examples/openapi/storefront.yaml" in workflow
+    assert 'knives-out generate "$SPEC_PATH" --tag orders --out attacks.json' in workflow
+    assert "--path /draft-orders/{draftId}" in workflow
     assert "--auto-workflows" in workflow
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
     assert "knives-out report results.json --out report.md" in workflow
+    assert "knives-out report results.json \\" in workflow
     assert "knives-out verify results.json" in workflow
+    assert "knives-out promote results.json" in workflow
     assert "KNIVES_OUT_BASE_URL" in workflow
 
 
@@ -47,6 +55,10 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Baseline-aware gating" in ci_doc
     assert "--baseline previous-results.json" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
+    assert "--tag orders" in ci_doc
+    assert "--path /draft-orders/{draftId}" in ci_doc
+    assert "Promote qualifying findings" in ci_doc
+    assert "pytest --cov=src/knives_out --cov-report=term-missing" in ci_doc
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in ci_doc
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from knives_out.attack_packs import load_module_attack_packs
+from knives_out.auth_plugins import load_module_auth_plugins
+from knives_out.generator import generate_attack_suite
+from knives_out.openapi_loader import load_operations
+from knives_out.workflow_packs import load_module_workflow_packs
+
+ROOT = Path(__file__).resolve().parents[1]
+PETSTORE_SPEC = ROOT / "examples" / "openapi" / "petstore.yaml"
+STOREFRONT_SPEC = ROOT / "examples" / "openapi" / "storefront.yaml"
+ATTACK_PACK_MODULE = ROOT / "examples" / "custom_packs" / "unexpected_header.py"
+WORKFLOW_PACK_MODULE = ROOT / "examples" / "workflow_packs" / "listed_pet_lookup.py"
+AUTH_PLUGIN_MODULE = ROOT / "examples" / "auth_plugins" / "login_bearer.py"
+
+
+def test_checked_in_openapi_examples_load() -> None:
+    for spec in (PETSTORE_SPEC, STOREFRONT_SPEC):
+        operations = load_operations(spec)
+        assert operations
+
+
+def test_storefront_example_emits_workflows_and_schema_mutations() -> None:
+    suite = generate_attack_suite(
+        load_operations(STOREFRONT_SPEC),
+        source=str(STOREFRONT_SPEC),
+        auto_workflows=True,
+    )
+
+    assert any(attack.kind == "too_long" for attack in suite.attacks)
+    assert any(attack.kind == "invalid_format" for attack in suite.attacks)
+    assert any(
+        attack.type == "workflow" and attack.operation_id == "getDraftOrder"
+        for attack in suite.attacks
+    )
+
+
+def test_checked_in_example_modules_load() -> None:
+    attack_packs = load_module_attack_packs([ATTACK_PACK_MODULE])
+    workflow_packs = load_module_workflow_packs([WORKFLOW_PACK_MODULE])
+    auth_plugins = load_module_auth_plugins([AUTH_PLUGIN_MODULE])
+
+    assert [pack.name for pack in attack_packs] == ["unexpected-header"]
+    assert [pack.name for pack in workflow_packs] == ["listed-id-lookup"]
+    assert [plugin.name for plugin in auth_plugins] == ["login-bearer"]


### PR DESCRIPTION
## Summary
- add a richer storefront OpenAPI example plus smoke tests for checked-in examples and modules
- expand README and CI docs to cover tag/path filters, schema-aware mutations, and regression promotion
- print coverage in repository CI and show regression-promotion steps in the sample workflow

## Testing
- `python3 -m ruff check tests/test_examples.py tests/test_docs.py`
- `python3 -m ruff format --check tests/test_examples.py tests/test_docs.py`
- `pytest` unavailable in this host Python 3.9 environment; rely on GitHub Actions for full validation