### PR TITLE
[codex] Add finding suppressions and triage

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -72,7 +72,12 @@ jobs:
 
           knives-out run attacks.json "${args[@]}"
       - name: Render Markdown report
-        run: knives-out report results.json --out report.md
+        run: |
+          knives-out report results.json --out report.md
+          # If you keep a checked-in .knives-out-ignore.yml file in the repo root,
+          # report, verify, and promote will load it automatically.
+          # To use a different file explicitly, add:
+          #   --suppressions path/to/suppressions.yml
       - name: Render baseline-aware report
         if: ${{ hashFiles('previous-results.json') != '' }}
         run: |
@@ -89,6 +94,8 @@ jobs:
           #   --baseline previous-results.json \
           #   --min-severity high \
           #   --min-confidence medium
+          # To seed a new suppression file for review outside CI, run:
+          # knives-out triage results.json --out .knives-out-ignore.yml
       - name: Promote qualifying findings into a regression suite
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Given an OpenAPI document, `knives-out` can:
 - produce a Markdown report that highlights suspicious outcomes
 - verify findings for CI gating
 - promote qualifying findings back into a reusable regression suite
+- suppress or triage known findings so CI stays focused on active risk
 
 The initial focus is narrow by design:
 
@@ -137,6 +138,12 @@ Promote qualifying findings back into a reusable regression suite:
 knives-out promote results.json --attacks attacks.json --out regression-attacks.json
 ```
 
+Generate a review-ready suppressions file for known findings:
+
+```bash
+knives-out triage results.json --out .knives-out-ignore.yml
+```
+
 ## CI usage
 
 `knives-out` works well in CI when you follow the same generate/run/report flow and add a final
@@ -170,7 +177,10 @@ credentials on `--header` or `--query`, or move up to
 `--auth-plugin-module examples/auth_plugins/login_bearer.py` for login/session flows. When you want
 to keep only the highest-signal regressions around, follow `verify` with
 `knives-out promote results.json --attacks attacks.json`. See `docs/ci.md` for the sample
-workflow, secret setup, filtering patterns, and baseline-aware CI flows.
+workflow, secret setup, filtering patterns, baseline-aware CI flows, and checked-in suppressions.
+If you keep a `.knives-out-ignore.yml` file in the repo root, `report`, `verify`, and `promote`
+will load it automatically. Use `knives-out triage results.json` to seed new entries when you want
+to capture known findings without hand-writing YAML.
 
 ## CLI
 
@@ -288,6 +298,9 @@ and persisting findings:
 knives-out report results.json --baseline previous-results.json --out report.md
 ```
 
+If `.knives-out-ignore.yml` exists in the repo root, `report` will automatically show suppressed
+findings separately. You can also point at another file explicitly with `--suppressions path/to.yml`.
+
 ### `verify`
 
 Checks a results JSON file against a CI policy and exits non-zero when the policy fails.
@@ -304,6 +317,9 @@ knives-out verify results.json \
   --min-severity high \
   --min-confidence medium
 ```
+
+`verify` also auto-loads `.knives-out-ignore.yml` when present, so known accepted findings do not
+fail CI. Use `--suppressions path/to.yml` when you want a different file.
 
 ### `promote`
 
@@ -323,6 +339,38 @@ knives-out promote results.json \
   --attacks attacks.json \
   --baseline previous-results.json \
   --out regression-attacks.json
+```
+
+`promote` uses the same suppression behavior as `verify`, so suppressed findings stay out of the
+generated regression suite.
+
+### `triage`
+
+Generates review-ready suppression entries for the current active findings.
+
+```bash
+knives-out triage results.json --out .knives-out-ignore.yml
+```
+
+If the output file already exists, `triage` appends only new selector entries and keeps the
+existing rules intact. The generated YAML includes placeholder `reason` and `owner` fields so the
+team can review and fill them in before committing.
+
+Example suppression file:
+
+```yaml
+suppressions:
+  - attack_id: atk_create_pet_missing_body
+    issue: server_error
+    operation_id: createPet
+    method: POST
+    path: /pets
+    tags:
+      - pets
+      - write
+    reason: Known issue tracked in API backlog
+    owner: api-team
+    expires_on: 2026-06-30
 ```
 
 ## Development

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,8 @@
 4. render a Markdown report for review
 5. verify the results against a CI policy
 6. optionally promote qualifying findings into a smaller regression suite
-7. publish the JSON results, Markdown report, regression suite, and per-attack artifacts
+7. optionally maintain a checked-in suppressions file for accepted findings
+8. publish the JSON results, Markdown report, regression suite, and per-attack artifacts
 
 The repository includes a ready-to-adapt GitHub Actions example at
 `.github/workflows/dev-environment-example.yml`.
@@ -55,6 +56,9 @@ confidence thresholds, and exits with:
 - `0` when the policy passes
 - `1` when the policy fails
 
+If `.knives-out-ignore.yml` exists in the repository root, `report`, `verify`, and `promote` load
+it automatically. Use `--suppressions path/to/file.yml` to point at a different suppression file.
+
 ## Simple gating with no baseline
 
 Use this when you want CI to fail on qualifying findings in the current run:
@@ -83,6 +87,53 @@ findings:
 
 The tool does not fetch that baseline for you. Your workflow is responsible for placing
 `previous-results.json` in the workspace before this step.
+
+## Optional: checked-in suppressions
+
+Use suppressions when the team has reviewed a finding and wants CI to stay focused on active,
+unsuppressed regressions.
+
+Seed a review-ready file from the current active findings:
+
+```yaml
+- name: Seed or refresh suppressions for review
+  if: always()
+  run: knives-out triage results.json --out .knives-out-ignore.yml
+```
+
+The generated file includes placeholder `reason` and `owner` fields so a reviewer can edit the
+entries before committing them. A typical checked-in file looks like:
+
+```yaml
+suppressions:
+  - attack_id: atk_create_pet_missing_body
+    issue: server_error
+    operation_id: createPet
+    method: POST
+    path: /pets
+    tags:
+      - pets
+      - write
+    reason: Known issue tracked in API backlog
+    owner: api-team
+    expires_on: 2026-06-30
+```
+
+If you keep that file at the repo root, the standard commands pick it up automatically:
+
+```yaml
+- name: Verify findings with checked-in suppressions
+  run: knives-out verify results.json
+```
+
+```yaml
+- name: Promote qualifying findings with checked-in suppressions
+  if: always()
+  run: |
+    knives-out promote results.json \
+      --attacks attacks.json \
+      --out regression-attacks.json
+```
 
 ## Optional: stateful workflow coverage
 

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -18,7 +18,20 @@ from knives_out.openapi_loader import load_operations_with_warnings
 from knives_out.promotion import PromotionError, promote_attack_suite
 from knives_out.reporting import load_attack_results, render_markdown_report
 from knives_out.runner import execute_attack_suite, load_attack_suite
-from knives_out.verification import ComparedFinding, evaluate_verification
+from knives_out.suppressions import (
+    DEFAULT_SUPPRESSIONS_PATH,
+    SuppressionRule,
+    SuppressionsFile,
+    load_suppressions,
+    merge_suppressions,
+    triage_rule_for_result,
+    write_suppressions,
+)
+from knives_out.verification import (
+    ComparedFinding,
+    compare_attack_results,
+    evaluate_verification,
+)
 from knives_out.workflow_packs import load_workflow_packs
 
 app = typer.Typer(no_args_is_help=True, help="Adversarial API testing from OpenAPI specs.")
@@ -81,6 +94,34 @@ def _load_attack_results_or_error(path: Path, *, label: str) -> AttackResults:
         return load_attack_results(path)
     except (OSError, ValidationError, ValueError) as exc:
         raise typer.BadParameter(f"Could not read {label} results file '{path}': {exc}") from exc
+
+
+def _load_suppressions_or_error(
+    path: Path | None,
+) -> tuple[Path | None, list[SuppressionRule]]:
+    resolved_path = path
+    if resolved_path is None and DEFAULT_SUPPRESSIONS_PATH.exists():
+        resolved_path = DEFAULT_SUPPRESSIONS_PATH
+    if resolved_path is None:
+        return None, []
+
+    try:
+        suppressions_file = load_suppressions(resolved_path)
+    except (OSError, ValueError) as exc:
+        raise typer.BadParameter(
+            f"Could not read suppressions file '{resolved_path}': {exc}"
+        ) from exc
+
+    return resolved_path, suppressions_file.suppressions
+
+
+def _print_suppression_summary(
+    path: Path | None,
+    suppressions: list[SuppressionRule],
+) -> None:
+    if path is None:
+        return
+    console.print(f"Applied {len(suppressions)} suppression rule(s) from [bold]{path}[/bold].")
 
 
 def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> None:
@@ -411,6 +452,12 @@ def report(
         Path | None,
         typer.Option(help="Optional baseline results file for regression comparison."),
     ] = None,
+    suppressions: Annotated[
+        Path | None,
+        typer.Option(
+            help="Optional suppressions file. Defaults to .knives-out-ignore.yml if present."
+        ),
+    ] = None,
     out: Annotated[
         Path | None,
         typer.Option(help="Optional Markdown output file."),
@@ -421,13 +468,20 @@ def report(
     baseline_results = (
         _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
     )
-    markdown = render_markdown_report(attack_results, baseline=baseline_results)
+    suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
+    markdown = render_markdown_report(
+        attack_results,
+        baseline=baseline_results,
+        suppressions=suppression_rules,
+    )
 
     if out is None:
+        _print_suppression_summary(suppressions_path, suppression_rules)
         console.print(markdown)
         return
 
     out.write_text(markdown, encoding="utf-8")
+    _print_suppression_summary(suppressions_path, suppression_rules)
     console.print(f"Wrote report to [bold]{out}[/bold].")
 
 
@@ -437,6 +491,12 @@ def verify(
     baseline: Annotated[
         Path | None,
         typer.Option(help="Optional baseline results file for regression comparison."),
+    ] = None,
+    suppressions: Annotated[
+        Path | None,
+        typer.Option(
+            help="Optional suppressions file. Defaults to .knives-out-ignore.yml if present."
+        ),
     ] = None,
     min_severity: Annotated[
         SeverityThresholdOption,
@@ -452,11 +512,13 @@ def verify(
     baseline_results = (
         _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
     )
+    suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
     verification = evaluate_verification(
         attack_results,
         baseline=baseline_results,
         min_severity=min_severity.value,
         min_confidence=min_confidence.value,
+        suppressions=suppression_rules,
     )
     comparison = verification.comparison
 
@@ -465,12 +527,14 @@ def verify(
         f"severity >= [bold]{min_severity.value}[/bold], "
         f"confidence >= [bold]{min_confidence.value}[/bold]."
     )
+    _print_suppression_summary(suppressions_path, suppression_rules)
     if verification.baseline_used:
         console.print(
             "Compared current findings against a baseline. "
             f"New: {len(comparison.new_findings)}, "
             f"Resolved: {len(comparison.resolved_findings)}, "
-            f"Persisting: {len(comparison.persisting_findings)}."
+            f"Persisting: {len(comparison.persisting_findings)}, "
+            f"Suppressed current: {len(comparison.suppressed_current_findings)}."
         )
         _print_compared_findings(
             "New findings meeting policy",
@@ -479,7 +543,8 @@ def verify(
     else:
         console.print(
             "Evaluated current flagged findings only. "
-            f"Flagged: {len(comparison.current_findings)}, "
+            f"Active flagged: {len(comparison.current_findings)}, "
+            f"suppressed: {len(comparison.suppressed_current_findings)}, "
             f"meeting policy: {len(verification.failing_findings)}."
         )
         _print_compared_findings(
@@ -510,6 +575,12 @@ def promote(
         Path | None,
         typer.Option(help="Optional baseline results file for regression comparison."),
     ] = None,
+    suppressions: Annotated[
+        Path | None,
+        typer.Option(
+            help="Optional suppressions file. Defaults to .knives-out-ignore.yml if present."
+        ),
+    ] = None,
     min_severity: Annotated[
         SeverityThresholdOption,
         typer.Option(help="Minimum severity that should be promoted."),
@@ -524,6 +595,7 @@ def promote(
     baseline_results = (
         _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
     )
+    suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
 
     try:
         attack_suite = load_attack_suite(attacks)
@@ -537,6 +609,7 @@ def promote(
             baseline=baseline_results,
             min_severity=min_severity.value,
             min_confidence=min_confidence.value,
+            suppressions=suppression_rules,
         )
     except PromotionError as exc:
         console.print(f"[red]Promotion error:[/red] {exc}")
@@ -552,6 +625,7 @@ def promote(
         f"severity >= [bold]{min_severity.value}[/bold], "
         f"confidence >= [bold]{min_confidence.value}[/bold]."
     )
+    _print_suppression_summary(suppressions_path, suppression_rules)
     if promotion.verification.baseline_used:
         console.print(
             "Promoted new qualifying attacks against a baseline. "
@@ -565,6 +639,41 @@ def promote(
     console.print(
         f"Wrote {len(promotion.promoted_suite.attacks)} promoted attack(s) to [bold]{out}[/bold]."
     )
+
+
+@app.command()
+def triage(
+    results: Path,
+    out: Annotated[
+        Path,
+        typer.Option(help="Where to write the suppressions file."),
+    ] = DEFAULT_SUPPRESSIONS_PATH,
+) -> None:
+    """Append review-ready suppressions for current active findings."""
+    current_results = _load_attack_results_or_error(results, label="current")
+
+    existing_file = SuppressionsFile()
+    if out.exists():
+        try:
+            existing_file = load_suppressions(out)
+        except (OSError, ValueError) as exc:
+            raise typer.BadParameter(f"Could not read suppressions file '{out}': {exc}") from exc
+
+    comparison = compare_attack_results(
+        current_results,
+        suppressions=existing_file.suppressions,
+    )
+    generated_rules = [triage_rule_for_result(result) for result in comparison.current_findings]
+    merged_rules = merge_suppressions(existing_file.suppressions, generated_rules)
+    added_count = len(merged_rules) - len(existing_file.suppressions)
+
+    write_suppressions(out, SuppressionsFile(suppressions=merged_rules))
+
+    console.print(
+        f"Triaged {len(comparison.current_findings)} active finding(s). "
+        f"Added {added_count} suppression rule(s)."
+    )
+    console.print(f"Wrote suppressions to [bold]{out}[/bold].")
 
 
 def main() -> None:

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -170,6 +170,8 @@ class AttackResult(BaseModel):
     kind: str
     name: str
     method: str
+    path: str | None = None
+    tags: list[str] = Field(default_factory=list)
     url: str
     status_code: int | None = None
     error: str | None = None

--- a/src/knives_out/promotion.py
+++ b/src/knives_out/promotion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from knives_out.models import AttackResults, AttackSuite
+from knives_out.suppressions import SuppressionRule
 from knives_out.verification import (
     ConfidenceThreshold,
     SeverityThreshold,
@@ -51,12 +52,14 @@ def promote_attack_suite(
     baseline: AttackResults | None = None,
     min_severity: SeverityThreshold = "high",
     min_confidence: ConfidenceThreshold = "medium",
+    suppressions: list[SuppressionRule] | None = None,
 ) -> PromotionResult:
     verification = evaluate_verification(
         current,
         baseline=baseline,
         min_severity=min_severity,
         min_confidence=min_confidence,
+        suppressions=suppressions,
     )
 
     available_ids = {attack.id for attack in attacks.attacks}

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -4,9 +4,9 @@ from collections import Counter
 from pathlib import Path
 
 from knives_out.models import AttackResults
+from knives_out.suppressions import SuppressedFinding, SuppressionRule
 from knives_out.verification import (
     ComparedFinding,
-    attack_result_sort_key,
     compare_attack_results,
 )
 
@@ -30,6 +30,18 @@ def _finding_table_rows(findings: list[ComparedFinding]) -> list[str]:
     return rows
 
 
+def _suppressed_table_rows(findings: list[SuppressedFinding]) -> list[str]:
+    rows: list[str] = []
+    for finding in findings:
+        result = finding.result
+        rule = finding.rule
+        expires = rule.expires_on.isoformat() if rule.expires_on is not None else "-"
+        rows.append(
+            f"| {result.name} | {result.issue or '-'} | {rule.reason} | {rule.owner} | {expires} |"
+        )
+    return rows
+
+
 def _workflow_phase(result) -> str:
     if result.type != "workflow":
         return "request"
@@ -42,9 +54,13 @@ def render_markdown_report(
     results: AttackResults,
     *,
     baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
 ) -> str:
+    comparison = compare_attack_results(results, baseline, suppressions=suppressions)
+
     total = len(results.results)
-    flagged = sum(1 for result in results.results if result.flagged)
+    flagged = len(comparison.current_findings)
+    suppressed_flagged = len(comparison.suppressed_current_findings)
     response_schema_mismatches = sum(
         1 for result in results.results if result.response_schema_valid is False
     )
@@ -57,7 +73,8 @@ def render_markdown_report(
     lines.append(f"- Base URL: `{results.base_url}`")
     lines.append(f"- Executed at: `{results.executed_at.isoformat()}`")
     lines.append(f"- Total attacks: **{total}**")
-    lines.append(f"- Flagged results: **{flagged}**")
+    lines.append(f"- Active flagged results: **{flagged}**")
+    lines.append(f"- Suppressed flagged results: **{suppressed_flagged}**")
     lines.append(f"- Response schema mismatches: **{response_schema_mismatches}**")
     lines.append("")
     lines.append("## Outcome summary")
@@ -74,11 +91,7 @@ def render_markdown_report(
     lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
 
     found_flagged = False
-    flagged_results = sorted(
-        (result for result in results.results if result.flagged),
-        key=attack_result_sort_key,
-    )
-    for result in flagged_results:
+    for result in comparison.current_findings:
         found_flagged = True
         status = str(result.status_code) if result.status_code is not None else "-"
         schema = "mismatch" if result.response_schema_valid is False else "-"
@@ -91,9 +104,16 @@ def render_markdown_report(
     if not found_flagged:
         lines.append("| None | - | - | - | - | - | - | - |")
 
-    if baseline is not None:
-        comparison = compare_attack_results(results, baseline)
+    lines.append("")
+    lines.append("## Suppressed findings")
+    lines.append("")
+    lines.append("| Attack | Issue | Reason | Owner | Expires |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    lines.extend(_suppressed_table_rows(comparison.suppressed_current_findings))
+    if not comparison.suppressed_current_findings:
+        lines.append("| None | - | - | - | - |")
 
+    if baseline is not None:
         lines.append("")
         lines.append("## Verification summary")
         lines.append("")
@@ -101,6 +121,9 @@ def render_markdown_report(
         lines.append(f"- New findings: **{len(comparison.new_findings)}**")
         lines.append(f"- Resolved findings: **{len(comparison.resolved_findings)}**")
         lines.append(f"- Persisting findings: **{len(comparison.persisting_findings)}**")
+        lines.append(
+            f"- Suppressed current findings: **{len(comparison.suppressed_current_findings)}**"
+        )
 
         lines.append("")
         lines.append("## New findings")

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -716,6 +716,8 @@ def _request_result(
         kind=attack.kind,
         name=attack.name,
         method=attack.method,
+        path=attack.path,
+        tags=list(attack.tags),
         url=execution.url,
         status_code=execution.response.status_code if execution.response else None,
         error=execution.error,
@@ -789,6 +791,8 @@ def _workflow_failure_result(
         kind=workflow.kind,
         name=workflow.name,
         method=workflow.method,
+        path=workflow.path,
+        tags=list(workflow.tags),
         url=_workflow_terminal_fallback_url(
             workflow,
             base_url=base_url,

--- a/src/knives_out/suppressions.py
+++ b/src/knives_out/suppressions.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+from knives_out.models import AttackResult
+
+DEFAULT_SUPPRESSIONS_PATH = Path(".knives-out-ignore.yml")
+
+
+class SuppressionRule(BaseModel):
+    attack_id: str | None = None
+    issue: str | None = None
+    operation_id: str | None = None
+    method: str | None = None
+    path: str | None = None
+    kind: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    reason: str
+    owner: str
+    expires_on: date | None = None
+
+    @model_validator(mode="after")
+    def _validate_selectors(self) -> SuppressionRule:
+        if not any(
+            [
+                self.attack_id,
+                self.issue,
+                self.operation_id,
+                self.method,
+                self.path,
+                self.kind,
+                self.tags,
+            ]
+        ):
+            raise ValueError("Suppression rules require at least one matching selector.")
+        return self
+
+    def is_active(self, *, today: date | None = None) -> bool:
+        if self.expires_on is None:
+            return True
+        return self.expires_on >= (today or date.today())
+
+    def matches(self, result: AttackResult) -> bool:
+        if not self.is_active():
+            return False
+        if self.attack_id is not None and result.attack_id != self.attack_id:
+            return False
+        if self.issue is not None and result.issue != self.issue:
+            return False
+        if self.operation_id is not None and result.operation_id != self.operation_id:
+            return False
+        if self.method is not None and result.method.casefold() != self.method.casefold():
+            return False
+        if self.path is not None and result.path != self.path:
+            return False
+        if self.kind is not None and result.kind != self.kind:
+            return False
+        if self.tags and not set(self.tags).issubset(set(result.tags)):
+            return False
+        return True
+
+
+class SuppressionsFile(BaseModel):
+    suppressions: list[SuppressionRule] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SuppressedFinding:
+    result: AttackResult
+    rule: SuppressionRule
+
+
+def load_suppressions(path: str | Path) -> SuppressionsFile:
+    raw = Path(path).read_text(encoding="utf-8")
+    data = yaml.safe_load(raw) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Suppression file must contain a top-level mapping.")
+    try:
+        return SuppressionsFile.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def write_suppressions(path: str | Path, suppressions_file: SuppressionsFile) -> None:
+    rendered = yaml.safe_dump(
+        suppressions_file.model_dump(mode="json", exclude_none=True),
+        sort_keys=False,
+        allow_unicode=False,
+    )
+    Path(path).write_text(rendered, encoding="utf-8")
+
+
+def suppression_identity(rule: SuppressionRule) -> tuple[str | None, ...]:
+    return (
+        rule.attack_id,
+        rule.issue,
+        rule.operation_id,
+        rule.method.casefold() if rule.method is not None else None,
+        rule.path,
+        rule.kind,
+        ",".join(rule.tags),
+    )
+
+
+def triage_rule_for_result(result: AttackResult) -> SuppressionRule:
+    return SuppressionRule(
+        attack_id=result.attack_id,
+        issue=result.issue,
+        operation_id=result.operation_id,
+        method=result.method,
+        path=result.path,
+        kind=result.kind,
+        tags=list(result.tags),
+        reason="TODO: explain why this finding is suppressed",
+        owner="TODO: assign an owner",
+    )
+
+
+def merge_suppressions(
+    existing: list[SuppressionRule],
+    additions: list[SuppressionRule],
+) -> list[SuppressionRule]:
+    merged = list(existing)
+    seen = {suppression_identity(rule) for rule in existing}
+    for rule in additions:
+        identity = suppression_identity(rule)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        merged.append(rule)
+    return merged

--- a/src/knives_out/verification.py
+++ b/src/knives_out/verification.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from knives_out.models import AttackResult, AttackResults
+from knives_out.suppressions import SuppressedFinding, SuppressionRule
 
 SeverityThreshold = Literal["low", "medium", "high", "critical"]
 ConfidenceThreshold = Literal["low", "medium", "high"]
@@ -57,6 +58,8 @@ class ResultComparison:
     baseline: AttackResults | None
     current_findings: list[AttackResult]
     baseline_findings: list[AttackResult]
+    suppressed_current_findings: list[SuppressedFinding]
+    suppressed_baseline_findings: list[SuppressedFinding]
     new_findings: list[ComparedFinding]
     resolved_findings: list[ComparedFinding]
     persisting_findings: list[ComparedFinding]
@@ -91,21 +94,53 @@ def compared_finding_sort_key(finding: ComparedFinding) -> tuple[int, int, str, 
     return attack_result_sort_key(finding.result)
 
 
-def _flagged_findings(results: AttackResults) -> dict[tuple[str, str], AttackResult]:
+def suppressed_finding_sort_key(finding: SuppressedFinding) -> tuple[int, int, str, str]:
+    return attack_result_sort_key(finding.result)
+
+
+def _matching_suppression(
+    result: AttackResult,
+    suppressions: list[SuppressionRule],
+) -> SuppressionRule | None:
+    for rule in suppressions:
+        if rule.matches(result):
+            return rule
+    return None
+
+
+def _flagged_findings(
+    results: AttackResults,
+    *,
+    suppressions: list[SuppressionRule] | None = None,
+) -> tuple[dict[tuple[str, str], AttackResult], list[SuppressedFinding]]:
     flagged: dict[tuple[str, str], AttackResult] = {}
+    suppressed: list[SuppressedFinding] = []
+    active_suppressions = list(suppressions or [])
     for result in results.results:
         if not result.flagged or result.issue is None:
             continue
+        matched_rule = _matching_suppression(result, active_suppressions)
+        if matched_rule is not None:
+            suppressed.append(SuppressedFinding(result=result, rule=matched_rule))
+            continue
         flagged[(result.attack_id, result.issue)] = result
-    return flagged
+    return flagged, sorted(suppressed, key=suppressed_finding_sort_key)
 
 
 def compare_attack_results(
     current: AttackResults,
     baseline: AttackResults | None = None,
+    *,
+    suppressions: list[SuppressionRule] | None = None,
 ) -> ResultComparison:
-    current_flagged = _flagged_findings(current)
-    baseline_flagged = _flagged_findings(baseline) if baseline is not None else {}
+    current_flagged, suppressed_current = _flagged_findings(current, suppressions=suppressions)
+    if baseline is not None:
+        baseline_flagged, suppressed_baseline = _flagged_findings(
+            baseline,
+            suppressions=suppressions,
+        )
+    else:
+        baseline_flagged, suppressed_baseline = {}, []
 
     current_keys = set(current_flagged)
     baseline_keys = set(baseline_flagged)
@@ -141,6 +176,8 @@ def compare_attack_results(
         baseline=baseline,
         current_findings=sorted(current_flagged.values(), key=attack_result_sort_key),
         baseline_findings=sorted(baseline_flagged.values(), key=attack_result_sort_key),
+        suppressed_current_findings=suppressed_current,
+        suppressed_baseline_findings=suppressed_baseline,
         new_findings=new_findings,
         resolved_findings=resolved_findings,
         persisting_findings=persisting_findings,
@@ -165,8 +202,9 @@ def evaluate_verification(
     baseline: AttackResults | None = None,
     min_severity: SeverityThreshold = "high",
     min_confidence: ConfidenceThreshold = "medium",
+    suppressions: list[SuppressionRule] | None = None,
 ) -> VerificationResult:
-    comparison = compare_attack_results(current, baseline)
+    comparison = compare_attack_results(current, baseline, suppressions=suppressions)
     if baseline is None:
         failing_findings = [
             ComparedFinding(change="new", current=result, baseline=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from textwrap import dedent
 
@@ -29,6 +30,10 @@ def _results_with_findings(*results: AttackResult) -> AttackResults:
         base_url="https://example.com",
         results=list(results),
     )
+
+
+def _normalized_output(output: str) -> str:
+    return re.sub(r"\s+", " ", output).strip()
 
 
 def test_inspect_command_runs() -> None:
@@ -345,9 +350,9 @@ def test_verify_command_passes_with_baseline_when_findings_only_persist(tmp_path
     )
 
     assert result.exit_code == 0
-    assert "Persisting:" in result.stdout
-    assert "1." in result.stdout
-    assert "Verification passed." in result.stdout
+    normalized = _normalized_output(result.stdout)
+    assert "Persisting: 1" in normalized
+    assert "Verification passed." in normalized
 
 
 def test_verify_command_fails_with_baseline_when_new_qualifying_findings_appear(
@@ -759,7 +764,8 @@ def test_promote_command_respects_suppressions(tmp_path: Path) -> None:
     assert result.exit_code == 0
     suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert suite.attacks == []
-    assert "Qualifying attacks: 0." in result.stdout
+    normalized = _normalized_output(result.stdout)
+    assert "Qualifying attacks: 0." in normalized
 
 
 def test_triage_command_writes_review_ready_suppressions(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from knives_out.models import (
     LoadedOperations,
     PreflightWarning,
 )
+from knives_out.suppressions import load_suppressions
 
 runner = CliRunner()
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
@@ -646,6 +647,209 @@ def test_promote_command_reports_missing_attack_ids(tmp_path: Path) -> None:
     assert result.exit_code == 1
     assert "Promotion error:" in result.stdout
     assert "atk_missing" in result.stdout
+
+
+def test_verify_command_applies_suppressions(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    suppressions_path = tmp_path / ".knives-out-ignore.yml"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_server",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                path="/pets",
+                tags=["pets", "write"],
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+    suppressions_path.write_text(
+        "suppressions:\n"
+        "  - attack_id: atk_server\n"
+        "    issue: server_error\n"
+        "    reason: known issue\n"
+        "    owner: api-team\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["verify", str(results_path), "--suppressions", str(suppressions_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Applied 1 suppression rule" in result.stdout
+    assert "suppressed: 1" in result.stdout
+
+
+def test_promote_command_respects_suppressions(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    attacks_path = tmp_path / "attacks.json"
+    suppressions_path = tmp_path / ".knives-out-ignore.yml"
+    out_path = tmp_path / "regression-attacks.json"
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_two",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                path="/pets",
+                tags=["pets", "write"],
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+    attacks_path.write_text(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_two",
+                    name="Attack two",
+                    kind="missing_request_body",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                    description="Attack two",
+                ),
+            ],
+        ).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    suppressions_path.write_text(
+        "suppressions:\n"
+        "  - attack_id: atk_two\n"
+        "    issue: server_error\n"
+        "    reason: known issue\n"
+        "    owner: api-team\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            str(current_path),
+            "--attacks",
+            str(attacks_path),
+            "--suppressions",
+            str(suppressions_path),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert suite.attacks == []
+    assert "Qualifying attacks: 0." in result.stdout
+
+
+def test_triage_command_writes_review_ready_suppressions(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    suppressions_path = tmp_path / ".knives-out-ignore.yml"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_one",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                path="/pets",
+                tags=["pets", "write"],
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["triage", str(results_path), "--out", str(suppressions_path)],
+    )
+
+    assert result.exit_code == 0
+    suppressions = load_suppressions(suppressions_path)
+    assert len(suppressions.suppressions) == 1
+    suppression = suppressions.suppressions[0]
+    assert suppression.attack_id == "atk_one"
+    assert suppression.issue == "server_error"
+    assert suppression.reason.startswith("TODO:")
+    assert suppression.owner.startswith("TODO:")
+
+
+def test_report_command_applies_suppressions(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    suppressions_path = tmp_path / ".knives-out-ignore.yml"
+    report_path = tmp_path / "report.md"
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_one",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                path="/pets",
+                tags=["pets", "write"],
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+    suppressions_path.write_text(
+        "suppressions:\n"
+        "  - attack_id: atk_one\n"
+        "    issue: server_error\n"
+        "    reason: known issue\n"
+        "    owner: api-team\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            str(current_path),
+            "--suppressions",
+            str(suppressions_path),
+            "--out",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "## Suppressed findings" in report
+    assert "known issue" in report
 
 
 def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -18,6 +18,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert "`knives-out run` currently exits with status `0`" in readme
     assert "knives-out verify results.json" in readme
     assert "knives-out promote results.json" in readme
+    assert "knives-out triage results.json" in readme
+    assert ".knives-out-ignore.yml" in readme
     assert "--auto-workflows" in readme
     assert "--tag orders" in readme
     assert "--path /draft-orders/{draftId}" in readme
@@ -41,6 +43,8 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "knives-out report results.json --out report.md" in workflow
     assert "knives-out report results.json \\" in workflow
     assert "knives-out verify results.json" in workflow
+    assert "knives-out triage results.json --out .knives-out-ignore.yml" in workflow
+    assert ".knives-out-ignore.yml" in workflow
     assert "knives-out promote results.json" in workflow
     assert "KNIVES_OUT_BASE_URL" in workflow
 
@@ -53,6 +57,9 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "artifacts/" in ci_doc
     assert "Simple gating with no baseline" in ci_doc
     assert "Baseline-aware gating" in ci_doc
+    assert "Optional: checked-in suppressions" in ci_doc
+    assert "knives-out triage results.json --out .knives-out-ignore.yml" in ci_doc
+    assert ".knives-out-ignore.yml" in ci_doc
     assert "--baseline previous-results.json" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
     assert "--tag orders" in ci_doc

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -17,6 +17,7 @@ from knives_out.models import (
 )
 from knives_out.reporting import render_markdown_report
 from knives_out.runner import execute_attack_suite
+from knives_out.suppressions import SuppressionRule
 
 
 class _StubClient:
@@ -218,6 +219,8 @@ def test_execute_attack_suite_flags_response_schema_mismatch(monkeypatch) -> Non
     assert result.issue == "response_schema_mismatch"
     assert result.severity == "medium"
     assert result.confidence == "high"
+    assert result.path == "/pets"
+    assert result.tags == []
     assert result.response_schema_status == "201"
     assert result.response_schema_valid is False
     assert result.response_schema_error == "$.id: expected integer, got string"
@@ -466,6 +469,48 @@ def test_render_markdown_report_with_baseline_shows_regression_sections() -> Non
     assert "New server failure" in report
     assert "Resolved auth failure" in report
     assert "Persisting mismatch" in report
+
+
+def test_render_markdown_report_shows_suppressed_findings() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_suppressed",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Suppressed failure",
+                method="POST",
+                path="/pets",
+                tags=["pets", "write"],
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ],
+    )
+
+    report = render_markdown_report(
+        results,
+        suppressions=[
+            SuppressionRule(
+                attack_id="atk_suppressed",
+                issue="server_error",
+                reason="known issue",
+                owner="api-team",
+            )
+        ],
+    )
+
+    assert "## Suppressed findings" in report
+    assert "Suppressed failure" in report
+    assert "known issue" in report
+    assert "Active flagged results: **0**" in report
+    assert "Suppressed flagged results: **1**" in report
 
 
 def test_execute_attack_suite_removes_only_declared_auth_header(monkeypatch) -> None:

--- a/tests/test_suppressions.py
+++ b/tests/test_suppressions.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from knives_out.models import AttackResult
+from knives_out.suppressions import (
+    SuppressionRule,
+    merge_suppressions,
+    suppression_identity,
+    triage_rule_for_result,
+)
+
+
+def _result() -> AttackResult:
+    return AttackResult(
+        attack_id="atk_widget",
+        operation_id="createWidget",
+        kind="missing_request_body",
+        name="Widget failure",
+        method="POST",
+        path="/widgets",
+        tags=["widgets", "write"],
+        url="https://example.com/widgets",
+        status_code=500,
+        flagged=True,
+        issue="server_error",
+        severity="high",
+        confidence="high",
+    )
+
+
+def test_suppression_rule_requires_a_selector() -> None:
+    with pytest.raises(ValueError, match="at least one matching selector"):
+        SuppressionRule(reason="known issue", owner="api-team")
+
+
+def test_suppression_rule_matches_exact_path_and_tags() -> None:
+    rule = SuppressionRule(
+        issue="server_error",
+        method="POST",
+        path="/widgets",
+        tags=["widgets"],
+        reason="known issue",
+        owner="api-team",
+    )
+
+    assert rule.matches(_result()) is True
+
+
+def test_suppression_rule_does_not_match_when_expired() -> None:
+    rule = SuppressionRule(
+        attack_id="atk_widget",
+        reason="known issue",
+        owner="api-team",
+        expires_on=date.today() - timedelta(days=1),
+    )
+
+    assert rule.matches(_result()) is False
+
+
+def test_merge_suppressions_deduplicates_generated_entries() -> None:
+    rule = triage_rule_for_result(_result())
+
+    merged = merge_suppressions([rule], [rule])
+
+    assert len(merged) == 1
+    assert suppression_identity(merged[0]) == suppression_identity(rule)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from knives_out.models import AttackResult, AttackResults
+from knives_out.suppressions import SuppressionRule
 from knives_out.verification import compare_attack_results, evaluate_verification
 
 
@@ -125,3 +126,51 @@ def test_evaluate_verification_with_baseline_fails_only_on_new_findings() -> Non
 
     assert verification.passed is False
     assert [finding.attack_id for finding in verification.failing_findings] == ["atk_new"]
+
+
+def test_compare_attack_results_excludes_suppressed_findings() -> None:
+    current = _results(
+        _finding("atk_suppressed", issue="server_error", severity="high", confidence="high"),
+        _finding("atk_visible", issue="server_error", severity="high", confidence="high"),
+    )
+
+    comparison = compare_attack_results(
+        current,
+        suppressions=[
+            SuppressionRule(
+                attack_id="atk_suppressed",
+                issue="server_error",
+                reason="known issue",
+                owner="api-team",
+            )
+        ],
+    )
+
+    assert [result.attack_id for result in comparison.current_findings] == ["atk_visible"]
+    assert [finding.result.attack_id for finding in comparison.suppressed_current_findings] == [
+        "atk_suppressed"
+    ]
+
+
+def test_evaluate_verification_respects_suppressions() -> None:
+    current = _results(
+        _finding("atk_suppressed", issue="server_error", severity="high", confidence="high"),
+    )
+
+    verification = evaluate_verification(
+        current,
+        suppressions=[
+            SuppressionRule(
+                attack_id="atk_suppressed",
+                issue="server_error",
+                reason="known issue",
+                owner="api-team",
+            )
+        ],
+    )
+
+    assert verification.passed is True
+    assert verification.comparison.current_findings == []
+    assert [
+        finding.result.attack_id for finding in verification.comparison.suppressed_current_findings
+    ] == ["atk_suppressed"]


### PR DESCRIPTION
## Summary
- add first-class suppression rules plus a triage command that generates review-ready .knives-out-ignore.yml entries
- apply suppressions consistently across report, verify, and promote, including separate suppressed-finding reporting
- document the suppression workflow in the README, CI guide, and sample GitHub Actions workflow

## Testing
- `python3 -m ruff check src/knives_out/models.py src/knives_out/suppressions.py src/knives_out/runner.py src/knives_out/verification.py src/knives_out/reporting.py src/knives_out/promotion.py src/knives_out/cli.py tests/test_suppressions.py tests/test_verification.py tests/test_runner.py tests/test_cli.py tests/test_docs.py`
- `python3 -m ruff format --check src/knives_out/models.py src/knives_out/suppressions.py src/knives_out/runner.py src/knives_out/verification.py src/knives_out/reporting.py src/knives_out/promotion.py src/knives_out/cli.py tests/test_suppressions.py tests/test_verification.py tests/test_runner.py tests/test_cli.py tests/test_docs.py`
- `pytest` unavailable in this host Python 3.9 environment; rely on GitHub Actions for full validation