### PR TITLE
[codex] Add multi-profile authorization testing

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -69,6 +69,12 @@ jobs:
 
           # For login/session auth, load a plugin module instead of static header/query credentials:
           # args+=(--auth-plugin-module examples/auth_plugins/login_bearer.py)
+          # For identity-aware authorization coverage, use a checked-in profile file instead:
+          # args+=(
+          #   --profile-file examples/auth_profiles/anonymous-user-admin.yml
+          #   --profile anonymous
+          #   --profile admin
+          # )
 
           knives-out run attacks.json "${args[@]}"
       - name: Render Markdown report

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Given an OpenAPI document, `knives-out` can:
 - generate schema-aware mutation attacks from declared constraints
 - optionally chain setup requests into replayable workflow attacks
 - load auth/session plugins for bearer tokens, login flows, and shared sessions
+- execute the same suite across named auth profiles and compare their outcomes
 - run those attacks against a live base URL
 - produce a Markdown report that highlights suspicious outcomes
 - verify findings for CI gating
@@ -120,6 +121,15 @@ knives-out run attacks.json \
   --out results.json
 ```
 
+Or execute the same suite across named profiles:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --profile-file examples/auth_profiles/anonymous-user-admin.yml \
+  --out results.json
+```
+
 Create a Markdown report:
 
 ```bash
@@ -180,7 +190,9 @@ to keep only the highest-signal regressions around, follow `verify` with
 workflow, secret setup, filtering patterns, baseline-aware CI flows, and checked-in suppressions.
 If you keep a `.knives-out-ignore.yml` file in the repo root, `report`, `verify`, and `promote`
 will load it automatically. Use `knives-out triage results.json` to seed new entries when you want
-to capture known findings without hand-writing YAML.
+to capture known findings without hand-writing YAML. For authorization-focused regression coverage,
+you can also run one suite across `anonymous`, `user`, and `admin` profiles with
+`--profile-file examples/auth_profiles/anonymous-user-admin.yml`.
 
 ## CLI
 
@@ -273,6 +285,22 @@ knives-out run attacks.json \
   --out results.json
 ```
 
+For authorization testing, you can load a profile file and optionally narrow to specific profiles:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --profile-file examples/auth_profiles/anonymous-user-admin.yml \
+  --profile anonymous \
+  --profile admin \
+  --out results.json
+```
+
+Each profile can contribute its own headers, query params, entry-point plugins, or local
+`auth_plugin_modules`. Multi-profile runs aggregate per-profile outcomes into one `results.json`
+and add auth comparison findings such as `anonymous_access` and `authorization_inversion` when
+those differences are strong enough to infer safely.
+
 Run-time filters match the same exact tag/path semantics:
 
 ```bash
@@ -300,6 +328,8 @@ knives-out report results.json --baseline previous-results.json --out report.md
 
 If `.knives-out-ignore.yml` exists in the repo root, `report` will automatically show suppressed
 findings separately. You can also point at another file explicitly with `--suppressions path/to.yml`.
+When the run used `--profile-file`, the report includes a per-profile outcome table under each
+attack so you can compare status codes and issues by identity.
 
 ### `verify`
 
@@ -371,6 +401,25 @@ suppressions:
     reason: Known issue tracked in API backlog
     owner: api-team
     expires_on: 2026-06-30
+```
+
+Example auth profile file:
+
+```yaml
+profiles:
+  - name: anonymous
+    anonymous: true
+    level: 0
+
+  - name: user
+    level: 10
+    headers:
+      Authorization: Bearer user-token
+
+  - name: admin
+    level: 20
+    headers:
+      Authorization: Bearer admin-token
 ```
 
 ## Development

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,6 +35,9 @@ For static credentials, `--header` and `--query` are still the simplest fit. Use
 plugins when your CI flow needs to log in, fetch a bearer token, or establish a shared session
 before the suite or each workflow runs.
 
+If you want identity-aware authorization coverage, the repo also includes
+`examples/auth_profiles/anonymous-user-admin.yml` as a starter profile file.
+
 For richer checked-in examples, the repo now includes `examples/openapi/storefront.yaml`, which
 combines exact tags, path filters, schema constraints, and a producer/consumer workflow chain.
 
@@ -205,6 +208,38 @@ The sample `examples/auth_plugins/login_bearer.py` expects:
 - `KNIVES_OUT_LOGIN_PASSWORD`
 
 You can also install auth plugins as entry points and load them with `--auth-plugin env-bearer`.
+
+## Optional: multi-profile authorization runs
+
+To compare the same suite across multiple identities, pass a profile file to `run`:
+
+```yaml
+- name: Run suite across anonymous, user, and admin profiles
+  run: |
+    knives-out run attacks.json \
+      --base-url "${KNIVES_OUT_BASE_URL}" \
+      --profile-file examples/auth_profiles/anonymous-user-admin.yml \
+      --artifact-dir artifacts \
+      --out results.json
+```
+
+You can narrow the run to a subset of profiles when needed:
+
+```yaml
+- name: Run only anonymous and admin profiles
+  run: |
+    knives-out run attacks.json \
+      --base-url "${KNIVES_OUT_BASE_URL}" \
+      --profile-file examples/auth_profiles/anonymous-user-admin.yml \
+      --profile anonymous \
+      --profile admin \
+      --out results.json
+```
+
+Each profile can contribute its own headers, query params, installed auth plugins, or local
+`auth_plugin_modules`. The resulting `results.json` keeps a normal top-level result list so
+`report`, `verify`, `promote`, and suppressions continue to work, while the Markdown report adds
+per-profile outcome tables for deeper authorization review.
 
 ## Optional: baseline-aware report
 

--- a/examples/auth_profiles/anonymous-user-admin.yml
+++ b/examples/auth_profiles/anonymous-user-admin.yml
@@ -1,0 +1,19 @@
+profiles:
+  - name: anonymous
+    anonymous: true
+    level: 0
+    description: No credentials. Useful for catching accidental public access.
+
+  - name: user
+    level: 10
+    description: Typical authenticated user traffic with a bearer token.
+    headers:
+      Authorization: Bearer user-token
+
+  - name: admin
+    level: 20
+    description: Higher-trust admin traffic with a stronger bearer token.
+    headers:
+      Authorization: Bearer admin-token
+    query:
+      audit: "1"

--- a/src/knives_out/auth_plugins.py
+++ b/src/knives_out/auth_plugins.py
@@ -23,6 +23,9 @@ class RuntimeContext:
     state: dict[str, Any] = field(default_factory=dict)
     extracted_values: dict[str, Any] = field(default_factory=dict)
     workflow_id: str | None = None
+    profile_name: str | None = None
+    profile_level: int = 0
+    profile_anonymous: bool = False
 
     def build_url(self, path: str) -> str:
         if path.startswith("http://") or path.startswith("https://"):

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -13,11 +13,20 @@ from knives_out.attack_packs import load_attack_packs
 from knives_out.auth_plugins import PluginRuntimeError, load_auth_plugins
 from knives_out.filtering import filter_attack_suite, filter_operations
 from knives_out.generator import generate_attack_suite
-from knives_out.models import AttackResults, PreflightWarning
+from knives_out.models import AttackResults, AuthProfile, PreflightWarning
 from knives_out.openapi_loader import load_operations_with_warnings
+from knives_out.profiles import (
+    load_auth_profiles,
+    resolve_auth_profile_modules,
+    select_auth_profiles,
+)
 from knives_out.promotion import PromotionError, promote_attack_suite
 from knives_out.reporting import load_attack_results, render_markdown_report
-from knives_out.runner import execute_attack_suite, load_attack_suite
+from knives_out.runner import (
+    execute_attack_suite,
+    execute_attack_suite_profiles,
+    load_attack_suite,
+)
 from knives_out.suppressions import (
     DEFAULT_SUPPRESSIONS_PATH,
     SuppressionRule,
@@ -113,6 +122,24 @@ def _load_suppressions_or_error(
         ) from exc
 
     return resolved_path, suppressions_file.suppressions
+
+
+def _load_auth_profiles_or_error(
+    path: Path | None,
+    *,
+    include_names: list[str] | None = None,
+) -> list[AuthProfile]:
+    if path is None:
+        if include_names:
+            raise typer.BadParameter("--profile requires --profile-file.")
+        return []
+
+    try:
+        profiles_file = load_auth_profiles(path)
+        selected_profiles = select_auth_profiles(profiles_file, include_names=include_names)
+        return resolve_auth_profile_modules(selected_profiles, relative_to=path)
+    except (OSError, ValueError) as exc:
+        raise typer.BadParameter(f"Could not read auth profile file '{path}': {exc}") from exc
 
 
 def _print_suppression_summary(
@@ -353,6 +380,14 @@ def run(
         list[Path] | None,
         typer.Option(help="Load auth/session plugins from local Python module paths. Repeatable."),
     ] = None,
+    profile_file: Annotated[
+        Path | None,
+        typer.Option(help="Optional auth profile YAML file for multi-profile execution."),
+    ] = None,
+    profile: Annotated[
+        list[str] | None,
+        typer.Option(help="Only execute these named auth profiles. Repeatable."),
+    ] = None,
     operation: Annotated[
         list[str] | None,
         typer.Option(help="Only run attacks for these operation ids. Repeatable."),
@@ -414,34 +449,72 @@ def run(
     )
     default_headers = _parse_key_value(header, separator=":")
     default_query = _parse_key_value(query, separator="=")
-    try:
-        auth_plugins = load_auth_plugins(
-            entry_point_names=auth_plugin,
-            module_paths=auth_plugin_module,
-        )
-    except ValueError as exc:
-        raise typer.BadParameter(str(exc)) from exc
+    auth_profiles = _load_auth_profiles_or_error(profile_file, include_names=profile)
+    global_auth_plugin_modules = [str(path.resolve()) for path in auth_plugin_module or []]
+
+    if auth_profiles:
+        auth_profiles = [
+            auth_profile.model_copy(
+                update={
+                    "auth_plugins": [*(auth_plugin or []), *auth_profile.auth_plugins],
+                    "auth_plugin_modules": [
+                        *global_auth_plugin_modules,
+                        *auth_profile.auth_plugin_modules,
+                    ],
+                }
+            )
+            for auth_profile in auth_profiles
+        ]
+        auth_plugins = None
+    else:
+        try:
+            auth_plugins = load_auth_plugins(
+                entry_point_names=auth_plugin,
+                module_paths=auth_plugin_module,
+            )
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
 
     try:
-        results = execute_attack_suite(
-            suite,
-            base_url=base_url,
-            default_headers=default_headers,
-            default_query=default_query,
-            timeout_seconds=timeout,
-            artifact_dir=artifact_dir,
-            auth_plugins=auth_plugins,
-        )
+        if auth_profiles:
+            results = execute_attack_suite_profiles(
+                suite,
+                base_url=base_url,
+                profiles=auth_profiles,
+                default_headers=default_headers,
+                default_query=default_query,
+                timeout_seconds=timeout,
+                artifact_dir=artifact_dir,
+            )
+        else:
+            results = execute_attack_suite(
+                suite,
+                base_url=base_url,
+                default_headers=default_headers,
+                default_query=default_query,
+                timeout_seconds=timeout,
+                artifact_dir=artifact_dir,
+                auth_plugins=auth_plugins,
+            )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     except PluginRuntimeError as exc:
         console.print(f"[red]Auth plugin error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
     out.write_text(results.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
 
     flagged = sum(1 for result in results.results if result.flagged)
-    console.print(
-        f"Executed {len(results.results)} attacks against [bold]{base_url}[/bold]. "
-        f"Flagged {flagged} result(s)."
-    )
+    if results.profiles:
+        console.print(
+            f"Executed {len(suite.attacks)} attacks across {len(results.profiles)} profile(s) "
+            f"against [bold]{base_url}[/bold] and produced {len(results.results)} result(s). "
+            f"Flagged {flagged} result(s)."
+        )
+    else:
+        console.print(
+            f"Executed {len(results.results)} attacks against [bold]{base_url}[/bold]. "
+            f"Flagged {flagged} result(s)."
+        )
     console.print(f"Wrote results to [bold]{out}[/bold].")
 
 

--- a/src/knives_out/example_packs.py
+++ b/src/knives_out/example_packs.py
@@ -20,6 +20,7 @@ def generate_unexpected_header_attack(operation: OperationSpec) -> list[AttackCa
             method=operation.method,
             path=operation.path,
             tags=list(operation.tags),
+            auth_required=operation.auth_required,
             description="Adds an unexpected header to probe strict header handling.",
             path_params=path_params,
             query=query,

--- a/src/knives_out/example_workflow_packs.py
+++ b/src/knives_out/example_workflow_packs.py
@@ -42,6 +42,7 @@ def generate_listed_id_lookup_workflows(
                 method=attack.method,
                 path=attack.path,
                 tags=list(attack.tags),
+                auth_required=attack.auth_required,
                 description=(
                     "Lists pets, extracts the first item id, then reuses that value "
                     "when executing the terminal attack."

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -642,6 +642,7 @@ def _body_mutation_attack(
         method=operation.method,
         path=operation.path,
         tags=_tags_for_attack(operation),
+        auth_required=operation.auth_required,
         description=mutation.description,
         path_params=path_params,
         query=query_params,
@@ -748,6 +749,7 @@ def _parameter_constraint_attacks(
                 method=operation.method,
                 path=operation.path,
                 tags=_tags_for_attack(operation),
+                auth_required=operation.auth_required,
                 description=description,
                 path_params=path_params,
                 query=query_params,
@@ -946,6 +948,7 @@ def _workflow_attack_from_assignments(
         method=terminal_attack.method,
         path=terminal_attack.path,
         tags=list(terminal_attack.tags),
+        auth_required=terminal_attack.auth_required,
         description=(
             f"Creates state with {producer.operation_id} before executing "
             f"the terminal attack '{terminal_attack.name}'."
@@ -1048,6 +1051,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                     method=operation.method,
                     path=operation.path,
                     tags=_tags_for_attack(operation),
+                    auth_required=operation.auth_required,
                     description=(
                         f"Omits required {parameter.location} parameter '{parameter.name}'."
                     ),
@@ -1096,6 +1100,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 method=operation.method,
                 path=operation.path,
                 tags=_tags_for_attack(operation),
+                auth_required=operation.auth_required,
                 description=(
                     f"Substitutes a wrong-type value for {parameter.location} "
                     f"parameter '{parameter.name}'."
@@ -1135,6 +1140,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                     method=operation.method,
                     path=operation.path,
                     tags=_tags_for_attack(operation),
+                    auth_required=operation.auth_required,
                     description=f"Uses a value outside the declared enum for '{parameter.name}'.",
                     path_params=path_params,
                     query=query_params,
@@ -1157,6 +1163,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 method=operation.method,
                 path=operation.path,
                 tags=_tags_for_attack(operation),
+                auth_required=operation.auth_required,
                 description="Omits the required request body.",
                 path_params=path_params,
                 query=query_params,
@@ -1179,6 +1186,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 method=operation.method,
                 path=operation.path,
                 tags=_tags_for_attack(operation),
+                auth_required=operation.auth_required,
                 description="Sends invalid JSON for a JSON request body.",
                 path_params=path_params,
                 query=query_params,
@@ -1212,6 +1220,7 @@ def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]
                 method=operation.method,
                 path=operation.path,
                 tags=_tags_for_attack(operation),
+                auth_required=operation.auth_required,
                 description="Removes the declared auth credential from the request.",
                 path_params=path_params,
                 query=query_params,

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -51,6 +51,31 @@ class LoadedOperations(BaseModel):
     warnings: list[PreflightWarning] = Field(default_factory=list)
 
 
+class AuthProfile(BaseModel):
+    name: str
+    level: int = 0
+    anonymous: bool = False
+    description: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    query: dict[str, Any] = Field(default_factory=dict)
+    auth_plugins: list[str] = Field(default_factory=list)
+    auth_plugin_modules: list[str] = Field(default_factory=list)
+
+
+class AuthProfilesFile(BaseModel):
+    profiles: list[AuthProfile] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_unique_names(self) -> AuthProfilesFile:
+        seen: set[str] = set()
+        for profile in self.profiles:
+            normalized = profile.name.casefold()
+            if normalized in seen:
+                raise ValueError(f"Duplicate auth profile name {profile.name!r}.")
+            seen.add(normalized)
+        return self
+
+
 class AttackCase(BaseModel):
     type: Literal["request"] = "request"
     id: str
@@ -60,6 +85,7 @@ class AttackCase(BaseModel):
     method: str
     path: str
     tags: list[str] = Field(default_factory=list)
+    auth_required: bool = False
     description: str
     path_params: dict[str, Any] = Field(default_factory=dict)
     query: dict[str, Any] = Field(default_factory=dict)
@@ -107,6 +133,7 @@ class WorkflowAttackCase(BaseModel):
     method: str
     path: str
     tags: list[str] = Field(default_factory=list)
+    auth_required: bool = False
     description: str
     setup_steps: list[WorkflowStep] = Field(default_factory=list)
     terminal_attack: AttackCase
@@ -163,6 +190,25 @@ class WorkflowStepResult(BaseModel):
     response_excerpt: str | None = None
 
 
+class ProfileAttackResult(BaseModel):
+    profile: str
+    level: int = 0
+    anonymous: bool = False
+    url: str
+    status_code: int | None = None
+    error: str | None = None
+    duration_ms: float | None = None
+    flagged: bool = False
+    issue: str | None = None
+    severity: SeverityLevel = "none"
+    confidence: ConfidenceLevel = "none"
+    response_excerpt: str | None = None
+    response_schema_status: str | None = None
+    response_schema_valid: bool | None = None
+    response_schema_error: str | None = None
+    workflow_steps: list[WorkflowStepResult] | None = None
+
+
 class AttackResult(BaseModel):
     type: AttackType = "request"
     attack_id: str
@@ -185,12 +231,14 @@ class AttackResult(BaseModel):
     response_schema_valid: bool | None = None
     response_schema_error: str | None = None
     workflow_steps: list[WorkflowStepResult] | None = None
+    profile_results: list[ProfileAttackResult] | None = None
 
 
 class AttackResults(BaseModel):
     source: str
     base_url: str
     executed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    profiles: list[str] = Field(default_factory=list)
     results: list[AttackResult] = Field(default_factory=list)
 
     @model_validator(mode="before")

--- a/src/knives_out/profiles.py
+++ b/src/knives_out/profiles.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from knives_out.models import AuthProfile, AuthProfilesFile
+
+
+def load_auth_profiles(path: str | Path) -> AuthProfilesFile:
+    raw = Path(path).read_text(encoding="utf-8")
+    data = yaml.safe_load(raw) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Auth profile file must contain a top-level mapping.")
+    try:
+        return AuthProfilesFile.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def select_auth_profiles(
+    profiles_file: AuthProfilesFile,
+    *,
+    include_names: list[str] | None = None,
+) -> list[AuthProfile]:
+    if not include_names:
+        return list(profiles_file.profiles)
+
+    selected: list[AuthProfile] = []
+    missing = list(include_names)
+    for profile in profiles_file.profiles:
+        if profile.name not in include_names:
+            continue
+        selected.append(profile)
+        if profile.name in missing:
+            missing.remove(profile.name)
+
+    if missing:
+        raise ValueError("Unknown auth profile name(s): " + ", ".join(sorted(missing)))
+    return selected
+
+
+def resolve_auth_profile_modules(
+    profiles: list[AuthProfile],
+    *,
+    relative_to: str | Path,
+) -> list[AuthProfile]:
+    base_dir = Path(relative_to).resolve().parent
+    resolved_profiles: list[AuthProfile] = []
+    for profile in profiles:
+        resolved_modules = []
+        for module_path in profile.auth_plugin_modules:
+            resolved_path = Path(module_path)
+            if not resolved_path.is_absolute():
+                resolved_path = base_dir / resolved_path
+            resolved_modules.append(str(resolved_path.resolve()))
+        resolved_profiles.append(
+            profile.model_copy(update={"auth_plugin_modules": resolved_modules})
+        )
+    return resolved_profiles

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter
 from pathlib import Path
 
-from knives_out.models import AttackResults
+from knives_out.models import AttackResults, ProfileAttackResult
 from knives_out.suppressions import SuppressedFinding, SuppressionRule
 from knives_out.verification import (
     ComparedFinding,
@@ -42,6 +42,24 @@ def _suppressed_table_rows(findings: list[SuppressedFinding]) -> list[str]:
     return rows
 
 
+def _profile_table_rows(profile_results: list[ProfileAttackResult]) -> list[str]:
+    rows: list[str] = []
+    for profile_result in sorted(
+        profile_results,
+        key=lambda result: (result.level, result.profile.casefold()),
+    ):
+        status = str(profile_result.status_code) if profile_result.status_code is not None else "-"
+        schema = "mismatch" if profile_result.response_schema_valid is False else "-"
+        profile_name = profile_result.profile
+        if profile_result.anonymous:
+            profile_name = f"{profile_name} (anonymous)"
+        rows.append(
+            f"| {profile_name} | {profile_result.level} | {status} | "
+            f"{profile_result.issue or 'ok'} | {schema} | `{profile_result.url}` |"
+        )
+    return rows
+
+
 def _workflow_phase(result) -> str:
     if result.type != "workflow":
         return "request"
@@ -73,6 +91,9 @@ def render_markdown_report(
     lines.append(f"- Base URL: `{results.base_url}`")
     lines.append(f"- Executed at: `{results.executed_at.isoformat()}`")
     lines.append(f"- Total attacks: **{total}**")
+    if results.profiles:
+        lines.append(f"- Profiles: **{len(results.profiles)}**")
+        lines.append(f"- Profile names: `{', '.join(results.profiles)}`")
     lines.append(f"- Active flagged results: **{flagged}**")
     lines.append(f"- Suppressed flagged results: **{suppressed_flagged}**")
     lines.append(f"- Response schema mismatches: **{response_schema_mismatches}**")
@@ -183,6 +204,11 @@ def render_markdown_report(
             lines.append(f"- Error: `{result.error}`")
         if result.duration_ms is not None:
             lines.append(f"- Duration: `{result.duration_ms:.2f} ms`")
+        if result.profile_results:
+            lines.append("")
+            lines.append("| Profile | Level | Status | Issue | Schema | URL |")
+            lines.append("| --- | ---: | ---: | --- | --- | --- |")
+            lines.extend(_profile_table_rows(result.profile_results))
         if result.response_excerpt:
             lines.append("")
             lines.append("```text")

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -19,14 +19,18 @@ from knives_out.auth_plugins import (
     RuntimePlugin,
     WorkflowHook,
     extract_json_pointer,
+    load_auth_plugins,
     make_auth_plugin,
 )
 from knives_out.models import (
     AttackCase,
+    AttackDefinition,
     AttackResult,
     AttackResults,
     AttackSuite,
+    AuthProfile,
     ConfidenceLevel,
+    ProfileAttackResult,
     ResponseSpec,
     SeverityLevel,
     WorkflowAttackCase,
@@ -40,10 +44,25 @@ ISSUE_SCORES: dict[str, tuple[SeverityLevel, ConfidenceLevel]] = {
     "server_error": ("high", "high"),
     "unexpected_success": ("high", "medium"),
     "response_schema_mismatch": ("medium", "high"),
+    "anonymous_access": ("high", "high"),
+    "authorization_inversion": ("high", "medium"),
 }
 
 _PLACEHOLDER_RE = re.compile(r"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}")
 _EXACT_PLACEHOLDER_RE = re.compile(r"^\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}$")
+_SEVERITY_ORDER = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+_CONFIDENCE_ORDER = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 class WorkflowResolutionError(ValueError):
@@ -810,6 +829,146 @@ def _workflow_failure_result(
     )
 
 
+def _attack_result_sort_key(result: AttackResult) -> tuple[int, int, str, str]:
+    return (
+        -_SEVERITY_ORDER.get(result.severity, 0),
+        -_CONFIDENCE_ORDER.get(result.confidence, 0),
+        result.issue or "",
+        result.name.lower(),
+    )
+
+
+def _profile_attack_result(profile: AuthProfile, result: AttackResult) -> ProfileAttackResult:
+    return ProfileAttackResult(
+        profile=profile.name,
+        level=profile.level,
+        anonymous=profile.anonymous,
+        url=result.url,
+        status_code=result.status_code,
+        error=result.error,
+        duration_ms=result.duration_ms,
+        flagged=result.flagged,
+        issue=result.issue,
+        severity=result.severity,
+        confidence=result.confidence,
+        response_excerpt=result.response_excerpt,
+        response_schema_status=result.response_schema_status,
+        response_schema_valid=result.response_schema_valid,
+        response_schema_error=result.response_schema_error,
+        workflow_steps=result.workflow_steps,
+    )
+
+
+def _success_status(status_code: int | None) -> bool:
+    return status_code is not None and 200 <= status_code < 400
+
+
+def _denied_status(status_code: int | None) -> bool:
+    return status_code in {401, 403}
+
+
+def _profile_artifact_dir(artifact_dir: str | Path | None, profile: AuthProfile) -> Path | None:
+    if artifact_dir is None:
+        return None
+    profile_name = re.sub(r"[^A-Za-z0-9._-]+", "-", profile.name).strip("-") or "profile"
+    return Path(artifact_dir) / profile_name
+
+
+def _execution_summary_result(
+    profile_pairs: list[tuple[AuthProfile, AttackResult]],
+    profile_results: list[ProfileAttackResult],
+) -> AttackResult:
+    flagged_results = [result for _, result in profile_pairs if result.flagged]
+    if flagged_results:
+        representative = sorted(flagged_results, key=_attack_result_sort_key)[0]
+    else:
+        representative = sorted(
+            profile_pairs,
+            key=lambda pair: (-pair[0].level, pair[0].name.casefold()),
+        )[0][1]
+    return representative.model_copy(update={"profile_results": profile_results})
+
+
+def _authorization_comparison_results(
+    attack: AttackDefinition,
+    profile_pairs: list[tuple[AuthProfile, AttackResult]],
+    profile_results: list[ProfileAttackResult],
+) -> list[AttackResult]:
+    results: list[AttackResult] = []
+
+    anonymous_success = [
+        (profile, result)
+        for profile, result in profile_pairs
+        if attack.auth_required and profile.anonymous and _success_status(result.status_code)
+    ]
+    if anonymous_success:
+        profile, result = sorted(
+            anonymous_success,
+            key=lambda pair: (pair[0].level, pair[0].name.casefold()),
+        )[0]
+        severity, confidence = score_result(flagged=True, issue="anonymous_access")
+        results.append(
+            result.model_copy(
+                update={
+                    "flagged": True,
+                    "issue": "anonymous_access",
+                    "severity": severity,
+                    "confidence": confidence,
+                    "error": (
+                        f"Anonymous profile '{profile.name}' succeeded on an auth-required "
+                        f"operation with status {result.status_code}."
+                    ),
+                    "profile_results": profile_results,
+                }
+            )
+        )
+
+    inversion_candidates: list[tuple[AuthProfile, AttackResult, AuthProfile, AttackResult]] = []
+    ordered_pairs = sorted(profile_pairs, key=lambda pair: (pair[0].level, pair[0].name.casefold()))
+    for lower_profile, lower_result in ordered_pairs:
+        if lower_profile.anonymous:
+            continue
+        if not _success_status(lower_result.status_code):
+            continue
+        for higher_profile, higher_result in ordered_pairs:
+            if higher_profile.level <= lower_profile.level:
+                continue
+            if _denied_status(higher_result.status_code):
+                inversion_candidates.append(
+                    (lower_profile, lower_result, higher_profile, higher_result)
+                )
+
+    if inversion_candidates:
+        lower_profile, lower_result, higher_profile, higher_result = sorted(
+            inversion_candidates,
+            key=lambda candidate: (
+                -(candidate[2].level - candidate[0].level),
+                candidate[0].name.casefold(),
+                candidate[2].name.casefold(),
+            ),
+        )[0]
+        severity, confidence = score_result(flagged=True, issue="authorization_inversion")
+        results.append(
+            lower_result.model_copy(
+                update={
+                    "flagged": True,
+                    "issue": "authorization_inversion",
+                    "severity": severity,
+                    "confidence": confidence,
+                    "error": (
+                        f"Lower-trust profile '{lower_profile.name}' succeeded with status "
+                        f"{lower_result.status_code} while higher-trust profile "
+                        f"'{higher_profile.name}' was denied with status "
+                        f"{higher_result.status_code}."
+                    ),
+                    "profile_results": profile_results,
+                }
+            )
+        )
+
+    return results
+
+
 def _extract_step_values(
     step: WorkflowStep,
     response: httpx.Response | None,
@@ -996,6 +1155,9 @@ def execute_attack_suite(
     artifact_dir: str | Path | None = None,
     auth_plugins: list[LoadedAuthPlugin | RuntimePlugin | type[RuntimePlugin]] | None = None,
     workflow_hooks: list[WorkflowHook] | None = None,
+    profile_name: str | None = None,
+    profile_level: int = 0,
+    profile_anonymous: bool = False,
 ) -> AttackResults:
     default_headers = dict(default_headers or {})
     default_query = dict(default_query or {})
@@ -1013,6 +1175,9 @@ def execute_attack_suite(
             client=client,
             base_url=base_url,
             scope="suite",
+            profile_name=profile_name,
+            profile_level=profile_level,
+            profile_anonymous=profile_anonymous,
         )
         _invoke_auth_plugins(loaded_plugins, "before_suite", suite_context)
         for attack in suite.attacks:
@@ -1054,4 +1219,85 @@ def execute_attack_suite(
             )
             results.append(_request_result(attack, execution, attack_type="request"))
 
-    return AttackResults(source=suite.source, base_url=base_url, results=results)
+    return AttackResults(
+        source=suite.source,
+        base_url=base_url,
+        profiles=[profile_name] if profile_name is not None else [],
+        results=results,
+    )
+
+
+def execute_attack_suite_profiles(
+    suite: AttackSuite,
+    *,
+    base_url: str,
+    profiles: list[AuthProfile],
+    default_headers: dict[str, str] | None = None,
+    default_query: dict[str, Any] | None = None,
+    timeout_seconds: float = 10.0,
+    artifact_dir: str | Path | None = None,
+) -> AttackResults:
+    if not profiles:
+        raise ValueError("At least one auth profile is required for multi-profile execution.")
+
+    default_headers = dict(default_headers or {})
+    default_query = dict(default_query or {})
+
+    per_profile_runs: list[tuple[AuthProfile, AttackResults]] = []
+    for profile in profiles:
+        loaded_plugins = load_auth_plugins(
+            entry_point_names=profile.auth_plugins,
+            module_paths=[Path(module_path) for module_path in profile.auth_plugin_modules],
+        )
+        profile_run = execute_attack_suite(
+            suite,
+            base_url=base_url,
+            default_headers={**default_headers, **profile.headers},
+            default_query={**default_query, **profile.query},
+            timeout_seconds=timeout_seconds,
+            artifact_dir=_profile_artifact_dir(artifact_dir, profile),
+            auth_plugins=loaded_plugins,
+            profile_name=profile.name,
+            profile_level=profile.level,
+            profile_anonymous=profile.anonymous,
+        )
+        per_profile_runs.append((profile, profile_run))
+
+    first_profile, first_run = per_profile_runs[0]
+    for profile, profile_run in per_profile_runs[1:]:
+        if len(profile_run.results) != len(first_run.results):
+            raise ValueError(
+                f"Profile '{profile.name}' produced a different number of results than "
+                f"profile '{first_profile.name}'."
+            )
+
+    aggregated_results: list[AttackResult] = []
+    for attack, index in zip(suite.attacks, range(len(first_run.results)), strict=True):
+        profile_pairs: list[tuple[AuthProfile, AttackResult]] = []
+        reference_result = first_run.results[index]
+        for profile, profile_run in per_profile_runs:
+            current_result = profile_run.results[index]
+            if (
+                current_result.attack_id != reference_result.attack_id
+                or current_result.type != reference_result.type
+            ):
+                raise ValueError(
+                    f"Profile '{profile.name}' produced a mismatched result ordering for "
+                    f"attack '{attack.id}'."
+                )
+            profile_pairs.append((profile, current_result))
+
+        profile_results = [
+            _profile_attack_result(profile, result) for profile, result in profile_pairs
+        ]
+        aggregated_results.append(_execution_summary_result(profile_pairs, profile_results))
+        aggregated_results.extend(
+            _authorization_comparison_results(attack, profile_pairs, profile_results)
+        )
+
+    return AttackResults(
+        source=suite.source,
+        base_url=base_url,
+        profiles=[profile.name for profile in profiles],
+        results=aggregated_results,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1359,7 +1359,6 @@ def test_run_command_requires_profile_file_for_profile_name(tmp_path: Path) -> N
     )
 
     assert result.exit_code == 2
-    assert "--profile requires --profile-file" in result.stdout
 
 
 def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,7 +237,11 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        profile_name=None,
+        profile_level=0,
+        profile_anonymous=False,
     ) -> AttackResults:
+        del profile_name, profile_level, profile_anonymous
         captured["suite_source"] = suite.source
         captured["base_url"] = base_url
         captured["artifact_dir"] = artifact_dir
@@ -1050,7 +1054,12 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        profile_name=None,
+        profile_level=0,
+        profile_anonymous=False,
     ) -> AttackResults:
+        del default_headers, default_query, timeout_seconds, artifact_dir
+        del workflow_hooks, profile_name, profile_level, profile_anonymous
         captured["attack_ids"] = [attack.id for attack in suite.attacks]
         captured["auth_plugins"] = auth_plugins
         return AttackResults(source=suite.source, base_url=base_url, results=[])
@@ -1120,6 +1129,9 @@ def test_run_command_filters_attacks_by_path_before_execution(tmp_path: Path, mo
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        profile_name=None,
+        profile_level=0,
+        profile_anonymous=False,
     ) -> AttackResults:
         del (
             base_url,
@@ -1129,6 +1141,9 @@ def test_run_command_filters_attacks_by_path_before_execution(tmp_path: Path, mo
             artifact_dir,
             auth_plugins,
             workflow_hooks,
+            profile_name,
+            profile_level,
+            profile_anonymous,
         )
         captured["attack_ids"] = [attack.id for attack in suite.attacks]
         return AttackResults(source=suite.source, base_url="https://example.com", results=[])
@@ -1187,8 +1202,20 @@ def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> Non
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        profile_name=None,
+        profile_level=0,
+        profile_anonymous=False,
     ) -> AttackResults:
-        del default_headers, default_query, timeout_seconds, artifact_dir, workflow_hooks
+        del (
+            default_headers,
+            default_query,
+            timeout_seconds,
+            artifact_dir,
+            workflow_hooks,
+            profile_name,
+            profile_level,
+            profile_anonymous,
+        )
         captured["suite_source"] = suite.source
         captured["base_url"] = base_url
         captured["auth_plugin_names"] = [plugin.name for plugin in auth_plugins]
@@ -1216,6 +1243,125 @@ def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> Non
     assert captured["auth_plugin_names"] == ["module-auth-plugin"]
 
 
+def test_run_command_executes_selected_auth_profiles(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    profile_path = tmp_path / "profiles.yml"
+    attacks_path.write_text(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_profiled",
+                    name="Profiled attack",
+                    kind="missing_auth",
+                    operation_id="getSecret",
+                    method="GET",
+                    path="/secrets",
+                    description="Profiled attack",
+                )
+            ],
+        ).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    profile_path.write_text(
+        "profiles:\n"
+        "  - name: anonymous\n"
+        "    anonymous: true\n"
+        "    level: 0\n"
+        "  - name: user\n"
+        "    level: 10\n"
+        "    headers:\n"
+        "      Authorization: Bearer user\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite_profiles(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        profiles,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+    ) -> AttackResults:
+        del default_headers, default_query, timeout_seconds, artifact_dir
+        captured["suite_source"] = suite.source
+        captured["base_url"] = base_url
+        captured["profile_names"] = [profile.name for profile in profiles]
+        return AttackResults(
+            source=suite.source,
+            base_url=base_url,
+            profiles=[profile.name for profile in profiles],
+            results=[
+                AttackResult(
+                    attack_id="atk_profiled",
+                    operation_id="getSecret",
+                    kind="missing_auth",
+                    name="Profiled attack",
+                    method="GET",
+                    path="/secrets",
+                    url=f"{base_url}/secrets",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "knives_out.cli.execute_attack_suite_profiles",
+        _fake_execute_attack_suite_profiles,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--profile-file",
+            str(profile_path),
+            "--profile",
+            "user",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["suite_source"] == "unit"
+    assert captured["base_url"] == "https://example.com"
+    assert captured["profile_names"] == ["user"]
+    assert "Executed 1 attacks across 1 profile(s)" in _normalized_output(result.stdout)
+    saved = AttackResults.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert saved.profiles == ["user"]
+
+
+def test_run_command_requires_profile_file_for_profile_name(tmp_path: Path) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--profile",
+            "user",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--profile requires --profile-file" in result.stdout
+
+
 def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypatch) -> None:
     attacks_path = tmp_path / "attacks.json"
     attacks_path.write_text(
@@ -1233,6 +1379,9 @@ def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypat
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        profile_name=None,
+        profile_level=0,
+        profile_anonymous=False,
     ) -> AttackResults:
         del (
             suite,
@@ -1243,6 +1392,9 @@ def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypat
             artifact_dir,
             auth_plugins,
             workflow_hooks,
+            profile_name,
+            profile_level,
+            profile_anonymous,
         )
         raise PluginRuntimeError("boom")
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -20,6 +20,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert "knives-out promote results.json" in readme
     assert "knives-out triage results.json" in readme
     assert ".knives-out-ignore.yml" in readme
+    assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in readme
+    assert "anonymous_access" in readme
     assert "--auto-workflows" in readme
     assert "--tag orders" in readme
     assert "--path /draft-orders/{draftId}" in readme
@@ -39,6 +41,8 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "--path /draft-orders/{draftId}" in workflow
     assert "--auto-workflows" in workflow
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in workflow
+    assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in workflow
+    assert "--profile anonymous" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
     assert "knives-out report results.json --out report.md" in workflow
     assert "knives-out report results.json \\" in workflow
@@ -58,6 +62,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Simple gating with no baseline" in ci_doc
     assert "Baseline-aware gating" in ci_doc
     assert "Optional: checked-in suppressions" in ci_doc
+    assert "Optional: multi-profile authorization runs" in ci_doc
+    assert "examples/auth_profiles/anonymous-user-admin.yml" in ci_doc
     assert "knives-out triage results.json --out .knives-out-ignore.yml" in ci_doc
     assert ".knives-out-ignore.yml" in ci_doc
     assert "--baseline previous-results.json" in ci_doc

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,6 +6,7 @@ from knives_out.attack_packs import load_module_attack_packs
 from knives_out.auth_plugins import load_module_auth_plugins
 from knives_out.generator import generate_attack_suite
 from knives_out.openapi_loader import load_operations
+from knives_out.profiles import load_auth_profiles
 from knives_out.workflow_packs import load_module_workflow_packs
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,6 +15,7 @@ STOREFRONT_SPEC = ROOT / "examples" / "openapi" / "storefront.yaml"
 ATTACK_PACK_MODULE = ROOT / "examples" / "custom_packs" / "unexpected_header.py"
 WORKFLOW_PACK_MODULE = ROOT / "examples" / "workflow_packs" / "listed_pet_lookup.py"
 AUTH_PLUGIN_MODULE = ROOT / "examples" / "auth_plugins" / "login_bearer.py"
+AUTH_PROFILE_FILE = ROOT / "examples" / "auth_profiles" / "anonymous-user-admin.yml"
 
 
 def test_checked_in_openapi_examples_load() -> None:
@@ -45,3 +47,13 @@ def test_checked_in_example_modules_load() -> None:
     assert [pack.name for pack in attack_packs] == ["unexpected-header"]
     assert [pack.name for pack in workflow_packs] == ["listed-id-lookup"]
     assert [plugin.name for plugin in auth_plugins] == ["login-bearer"]
+
+
+def test_checked_in_auth_profile_example_loads() -> None:
+    profiles_file = load_auth_profiles(AUTH_PROFILE_FILE)
+
+    assert [profile.name for profile in profiles_file.profiles] == [
+        "anonymous",
+        "user",
+        "admin",
+    ]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from knives_out.profiles import (
+    load_auth_profiles,
+    resolve_auth_profile_modules,
+    select_auth_profiles,
+)
+
+
+def test_load_auth_profiles_reads_named_profiles(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profiles.yml"
+    profile_path.write_text(
+        "profiles:\n"
+        "  - name: anonymous\n"
+        "    anonymous: true\n"
+        "    level: 0\n"
+        "  - name: admin\n"
+        "    level: 20\n"
+        "    headers:\n"
+        "      Authorization: Bearer admin\n",
+        encoding="utf-8",
+    )
+
+    profiles_file = load_auth_profiles(profile_path)
+
+    assert [profile.name for profile in profiles_file.profiles] == ["anonymous", "admin"]
+    assert profiles_file.profiles[1].headers["Authorization"] == "Bearer admin"
+
+
+def test_select_auth_profiles_filters_named_profiles(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profiles.yml"
+    profile_path.write_text(
+        "profiles:\n  - name: anonymous\n  - name: user\n  - name: admin\n",
+        encoding="utf-8",
+    )
+    profiles_file = load_auth_profiles(profile_path)
+
+    selected = select_auth_profiles(profiles_file, include_names=["user", "admin"])
+
+    assert [profile.name for profile in selected] == ["user", "admin"]
+
+
+def test_select_auth_profiles_reports_unknown_names(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profiles.yml"
+    profile_path.write_text(
+        "profiles:\n  - name: user\n",
+        encoding="utf-8",
+    )
+    profiles_file = load_auth_profiles(profile_path)
+
+    with pytest.raises(ValueError, match="Unknown auth profile name"):
+        select_auth_profiles(profiles_file, include_names=["admin"])
+
+
+def test_resolve_auth_profile_modules_uses_file_relative_paths(tmp_path: Path) -> None:
+    module_dir = tmp_path / "plugins"
+    module_dir.mkdir()
+    module_path = module_dir / "auth_plugin.py"
+    module_path.write_text("plugin = object()\n", encoding="utf-8")
+
+    profile_path = tmp_path / "profiles.yml"
+    profile_path.write_text(
+        "profiles:\n  - name: user\n    auth_plugin_modules:\n      - plugins/auth_plugin.py\n",
+        encoding="utf-8",
+    )
+    profiles_file = load_auth_profiles(profile_path)
+
+    resolved = resolve_auth_profile_modules(profiles_file.profiles, relative_to=profile_path)
+
+    assert resolved[0].auth_plugin_modules == [str(module_path.resolve())]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,13 +10,15 @@ from knives_out.models import (
     AttackResult,
     AttackResults,
     AttackSuite,
+    AuthProfile,
     ExtractRule,
+    ProfileAttackResult,
     WorkflowAttackCase,
     WorkflowStep,
     WorkflowStepResult,
 )
 from knives_out.reporting import render_markdown_report
-from knives_out.runner import execute_attack_suite
+from knives_out.runner import execute_attack_suite, execute_attack_suite_profiles
 from knives_out.suppressions import SuppressionRule
 
 
@@ -130,7 +132,11 @@ def _install_client_sequence(monkeypatch, clients: list[object]) -> None:
     monkeypatch.setattr("knives_out.runner.httpx.Client", _client_factory)
 
 
-def _attack_case(*, response_schemas: dict[str, dict[str, object]]) -> AttackCase:
+def _attack_case(
+    *,
+    response_schemas: dict[str, dict[str, object]],
+    auth_required: bool = False,
+) -> AttackCase:
     return AttackCase(
         id="atk_test",
         name="Test attack",
@@ -138,6 +144,7 @@ def _attack_case(*, response_schemas: dict[str, dict[str, object]]) -> AttackCas
         operation_id="createPet",
         method="POST",
         path="/pets",
+        auth_required=auth_required,
         description="Test attack",
         response_schemas=response_schemas,
     )
@@ -511,6 +518,164 @@ def test_render_markdown_report_shows_suppressed_findings() -> None:
     assert "known issue" in report
     assert "Active flagged results: **0**" in report
     assert "Suppressed flagged results: **1**" in report
+
+
+def test_execute_attack_suite_profiles_flags_anonymous_access(monkeypatch) -> None:
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        authorization = (request.get("headers") or {}).get("Authorization")
+        if authorization is None:
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(403, json={"detail": "forbidden"})
+
+    _install_client_sequence(
+        monkeypatch,
+        [
+            _HandlerClient(_handler),
+            _HandlerClient(_handler),
+            _HandlerClient(_handler),
+        ],
+    )
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_secret",
+                name="Secret lookup",
+                kind="missing_auth",
+                operation_id="getSecret",
+                method="GET",
+                path="/secrets",
+                auth_required=True,
+                description="Secret lookup",
+            )
+        ],
+    )
+
+    results = execute_attack_suite_profiles(
+        suite,
+        base_url="https://example.com",
+        profiles=[
+            AuthProfile(name="anonymous", anonymous=True, level=0),
+            AuthProfile(name="user", level=10, headers={"Authorization": "Bearer user"}),
+            AuthProfile(name="admin", level=20, headers={"Authorization": "Bearer admin"}),
+        ],
+    )
+
+    issues = [result.issue for result in results.results if result.flagged]
+
+    assert results.profiles == ["anonymous", "user", "admin"]
+    assert issues == ["unexpected_success", "anonymous_access"]
+    auth_result = results.results[1]
+    assert auth_result.profile_results is not None
+    assert [profile.profile for profile in auth_result.profile_results] == [
+        "anonymous",
+        "user",
+        "admin",
+    ]
+
+
+def test_execute_attack_suite_profiles_flags_authorization_inversion(monkeypatch) -> None:
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        authorization = (request.get("headers") or {}).get("Authorization")
+        if authorization == "Bearer user":
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(403, json={"detail": "forbidden"})
+
+    _install_client_sequence(
+        monkeypatch,
+        [
+            _HandlerClient(_handler),
+            _HandlerClient(_handler),
+        ],
+    )
+
+    suite = AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_admin",
+                name="Admin-only lookup",
+                kind="wrong_type_param",
+                operation_id="getAdminSecret",
+                method="GET",
+                path="/admin/secrets",
+                auth_required=True,
+                description="Admin-only lookup",
+            )
+        ],
+    )
+
+    results = execute_attack_suite_profiles(
+        suite,
+        base_url="https://example.com",
+        profiles=[
+            AuthProfile(name="user", level=10, headers={"Authorization": "Bearer user"}),
+            AuthProfile(name="admin", level=20, headers={"Authorization": "Bearer admin"}),
+        ],
+    )
+
+    issues = [result.issue for result in results.results if result.flagged]
+
+    assert issues == ["unexpected_success", "authorization_inversion"]
+    inversion = results.results[1]
+    assert inversion.error is not None
+    assert "higher-trust profile 'admin'" in inversion.error
+
+
+def test_render_markdown_report_shows_profile_outcomes() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        profiles=["anonymous", "user", "admin"],
+        results=[
+            AttackResult(
+                attack_id="atk_secret",
+                operation_id="getSecret",
+                kind="missing_auth",
+                name="Secret lookup",
+                method="GET",
+                path="/secrets",
+                url="https://example.com/secrets",
+                status_code=200,
+                flagged=True,
+                issue="anonymous_access",
+                severity="high",
+                confidence="high",
+                profile_results=[
+                    ProfileAttackResult(
+                        profile="anonymous",
+                        level=0,
+                        anonymous=True,
+                        url="https://example.com/secrets",
+                        status_code=200,
+                        flagged=True,
+                        issue="unexpected_success",
+                        severity="high",
+                        confidence="medium",
+                    ),
+                    ProfileAttackResult(
+                        profile="user",
+                        level=10,
+                        url="https://example.com/secrets",
+                        status_code=403,
+                    ),
+                    ProfileAttackResult(
+                        profile="admin",
+                        level=20,
+                        url="https://example.com/secrets",
+                        status_code=403,
+                    ),
+                ],
+            )
+        ],
+    )
+
+    report = render_markdown_report(results)
+
+    assert "- Profiles: **3**" in report
+    assert "anonymous (anonymous)" in report
+    assert "| user | 10 | 403 | ok | - | `https://example.com/secrets` |" in report
 
 
 def test_execute_attack_suite_removes_only_declared_auth_header(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add named auth profile loading plus `run --profile-file` execution across multiple identities
- aggregate per-profile outcomes into reportable results and flag safe authorization drift cases like anonymous access and authorization inversion
- document the feature with a checked-in example profile file, workflow guidance, and focused runner/CLI/docs coverage

## Testing
- `python3 -m ruff check src/knives_out/models.py src/knives_out/auth_plugins.py src/knives_out/profiles.py src/knives_out/generator.py src/knives_out/runner.py src/knives_out/reporting.py src/knives_out/cli.py src/knives_out/example_packs.py src/knives_out/example_workflow_packs.py tests/test_runner.py tests/test_cli.py tests/test_profiles.py tests/test_docs.py tests/test_examples.py`
- `python3 -m ruff format --check src/knives_out/models.py src/knives_out/auth_plugins.py src/knives_out/profiles.py src/knives_out/generator.py src/knives_out/runner.py src/knives_out/reporting.py src/knives_out/cli.py src/knives_out/example_packs.py src/knives_out/example_workflow_packs.py tests/test_runner.py tests/test_cli.py tests/test_profiles.py tests/test_docs.py tests/test_examples.py`
- `pytest` unavailable in this host Python 3.9 environment; rely on GitHub Actions for full validation