### PR TITLE
[codex] Add HTML report and artifact index

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -84,6 +84,9 @@ jobs:
           # report, verify, and promote will load it automatically.
           # To use a different file explicitly, add:
           #   --suppressions path/to/suppressions.yml
+      - name: Render HTML report
+        run: |
+          knives-out report results.json --format html --artifact-root artifacts --out report.html
       - name: Render baseline-aware report
         if: ${{ hashFiles('previous-results.json') != '' }}
         run: |
@@ -121,5 +124,6 @@ jobs:
             regression-attacks.json
             results.json
             report.md
+            report.html
             regression-report.md
             artifacts/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Given an OpenAPI document, `knives-out` can:
 - execute the same suite across named auth profiles and compare their outcomes
 - run those attacks against a live base URL
 - produce a Markdown report that highlights suspicious outcomes
+- produce an HTML report with linked request and response artifacts
 - verify findings for CI gating
 - promote qualifying findings back into a reusable regression suite
 - suppress or triage known findings so CI stays focused on active risk
@@ -136,6 +137,12 @@ Create a Markdown report:
 knives-out report results.json --out report.md
 ```
 
+Or render an HTML report with an artifact index for CI review:
+
+```bash
+knives-out report results.json --format html --artifact-root artifacts --out report.html
+```
+
 Verify findings against the default CI policy:
 
 ```bash
@@ -162,9 +169,10 @@ verification step:
 1. generate attacks from a checked-in OpenAPI spec
 2. run them against a dev or staging environment
 3. render a Markdown report for review
-4. verify the results against a CI policy
-5. optionally promote qualifying findings into a smaller regression suite
-6. upload the JSON results, request artifacts, and Markdown report for triage
+4. optionally render an HTML report with linked artifacts
+5. verify the results against a CI policy
+6. optionally promote qualifying findings into a smaller regression suite
+7. upload the JSON results, reports, and request artifacts for triage
 
 A ready-to-adapt GitHub Actions example lives at `.github/workflows/dev-environment-example.yml`.
 It uses repository secrets instead of hard-coded targets:
@@ -177,6 +185,8 @@ It uses repository secrets instead of hard-coded targets:
 `knives-out run` currently exits with status `0` when the suite executes successfully, even if
 some findings are flagged in `results.json`. That keeps execution review-friendly:
 teams can always upload `results.json`, `report.md`, and per-attack artifacts for triage.
+For faster review inside CI artifacts, `knives-out report --format html --artifact-root artifacts`
+also produces a linked `report.html` with an artifact index and detailed result cards.
 
 For built-in gating, use `knives-out verify` after `run`. It can fail on qualifying findings in the
 current run, or only on new qualifying findings when you also pass `--baseline previous-results.json`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,10 +6,11 @@
 2. optionally opt in to workflow generation for stateful coverage
 3. run that suite against a dev or staging deployment
 4. render a Markdown report for review
-5. verify the results against a CI policy
-6. optionally promote qualifying findings into a smaller regression suite
-7. optionally maintain a checked-in suppressions file for accepted findings
-8. publish the JSON results, Markdown report, regression suite, and per-attack artifacts
+5. optionally render an HTML report with linked artifacts
+6. verify the results against a CI policy
+7. optionally promote qualifying findings into a smaller regression suite
+8. optionally maintain a checked-in suppressions file for accepted findings
+9. publish the JSON results, reports, regression suite, and per-attack artifacts
 
 The repository includes a ready-to-adapt GitHub Actions example at
 `.github/workflows/dev-environment-example.yml`.
@@ -51,6 +52,7 @@ That default behavior is intentional for review-first workflows:
 
 - `results.json` stays available for automation
 - `report.md` stays available for humans
+- `report.html` can present a linked artifact index for faster triage
 - `artifacts/` keeps one request/response record per attack for debugging
 
 `knives-out verify` is the built-in gating step. It reads `results.json`, applies severity and
@@ -251,6 +253,20 @@ You can also render a Markdown report that highlights new, resolved, and persist
     knives-out report results.json \
       --baseline previous-results.json \
       --out report.md
+```
+
+## Optional: HTML report and artifact index
+
+When you already capture per-attack request and response artifacts, `report` can also emit an
+HTML view with linked artifacts, detailed result cards, and profile/workflow sections:
+
+```yaml
+- name: Render HTML report
+  run: |
+    knives-out report results.json \
+      --format html \
+      --artifact-root artifacts \
+      --out report.html
 ```
 
 ## Optional: promote a regression suite

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -21,7 +21,11 @@ from knives_out.profiles import (
     select_auth_profiles,
 )
 from knives_out.promotion import PromotionError, promote_attack_suite
-from knives_out.reporting import load_attack_results, render_markdown_report
+from knives_out.reporting import (
+    load_attack_results,
+    render_html_report,
+    render_markdown_report,
+)
 from knives_out.runner import (
     execute_attack_suite,
     execute_attack_suite_profiles,
@@ -58,6 +62,11 @@ class ConfidenceThresholdOption(StrEnum):
     low = "low"
     medium = "medium"
     high = "high"
+
+
+class ReportFormatOption(StrEnum):
+    markdown = "markdown"
+    html = "html"
 
 
 def _parse_key_value(items: list[str] | None, *, separator: str) -> dict[str, Any]:
@@ -533,27 +542,44 @@ def report(
     ] = None,
     out: Annotated[
         Path | None,
-        typer.Option(help="Optional Markdown output file."),
+        typer.Option(help="Optional report output file."),
+    ] = None,
+    format: Annotated[
+        ReportFormatOption,
+        typer.Option(help="Report output format."),
+    ] = ReportFormatOption.markdown,
+    artifact_root: Annotated[
+        Path | None,
+        typer.Option(help="Optional artifact directory to index and link in HTML reports."),
     ] = None,
 ) -> None:
-    """Render a Markdown report from a results file."""
+    """Render a report from a results file."""
     attack_results = _load_attack_results_or_error(results, label="current")
     baseline_results = (
         _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
     )
     suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
-    markdown = render_markdown_report(
-        attack_results,
-        baseline=baseline_results,
-        suppressions=suppression_rules,
-    )
+
+    if format is ReportFormatOption.html:
+        rendered = render_html_report(
+            attack_results,
+            baseline=baseline_results,
+            suppressions=suppression_rules,
+            artifact_root=artifact_root,
+        )
+    else:
+        rendered = render_markdown_report(
+            attack_results,
+            baseline=baseline_results,
+            suppressions=suppression_rules,
+        )
 
     if out is None:
         _print_suppression_summary(suppressions_path, suppression_rules)
-        console.print(markdown)
+        console.print(rendered)
         return
 
-    out.write_text(markdown, encoding="utf-8")
+    out.write_text(rendered, encoding="utf-8")
     _print_suppression_summary(suppressions_path, suppression_rules)
     console.print(f"Wrote report to [bold]{out}[/bold].")
 

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from collections import Counter
+from html import escape
 from pathlib import Path
 
 from knives_out.models import AttackResults, ProfileAttackResult
@@ -229,3 +231,491 @@ def render_markdown_report(
         lines.append("")
 
     return "\n".join(lines).strip() + "\n"
+
+
+def _profile_artifact_segment(profile_name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", profile_name).strip("-") or "profile"
+
+
+def _artifact_candidates(
+    result,
+    *,
+    artifact_root: Path | None,
+) -> list[tuple[str, Path]]:
+    if artifact_root is None or not artifact_root.exists():
+        return []
+
+    candidates: list[tuple[str, Path]] = []
+    if result.profile_results:
+        for profile_result in result.profile_results:
+            profile_root = artifact_root / _profile_artifact_segment(profile_result.profile)
+            artifact_path = profile_root / f"{result.attack_id}.json"
+            if artifact_path.exists():
+                candidates.append((f"{profile_result.profile} artifact", artifact_path))
+            for index, _ in enumerate(profile_result.workflow_steps or [], start=1):
+                step_path = profile_root / f"{result.attack_id}-step-{index:02d}.json"
+                if step_path.exists():
+                    candidates.append((f"{profile_result.profile} step {index}", step_path))
+        return candidates
+
+    artifact_path = artifact_root / f"{result.attack_id}.json"
+    if artifact_path.exists():
+        candidates.append(("artifact", artifact_path))
+    for index, _ in enumerate(result.workflow_steps or [], start=1):
+        step_path = artifact_root / f"{result.attack_id}-step-{index:02d}.json"
+        if step_path.exists():
+            candidates.append((f"step {index}", step_path))
+    return candidates
+
+
+def _artifact_links_html(result, *, artifact_root: Path | None) -> str:
+    candidates = _artifact_candidates(result, artifact_root=artifact_root)
+    if not candidates:
+        return "<span class='muted'>No linked artifact</span>"
+    return "<br>".join(
+        f"<a href='{escape(path.as_posix(), quote=True)}'>{escape(label)}</a>"
+        for label, path in candidates
+    )
+
+
+def _issue_badge_class(issue: str | None) -> str:
+    if issue in {"anonymous_access", "authorization_inversion", "server_error"}:
+        return "critical"
+    if issue in {"unexpected_success", "response_schema_mismatch"}:
+        return "warning"
+    return "neutral"
+
+
+def _summary_card_html(label: str, value: str) -> str:
+    return (
+        "<div class='summary-card'>"
+        f"<span class='label'>{escape(label)}</span>"
+        f"<strong>{escape(value)}</strong>"
+        "</div>"
+    )
+
+
+def _result_meta_item_html(label: str, value: str) -> str:
+    return f"<div><span class='label'>{escape(label)}</span><strong>{escape(value)}</strong></div>"
+
+
+def _suppressed_finding_row_html(finding: SuppressedFinding) -> str:
+    expires = finding.rule.expires_on.isoformat() if finding.rule.expires_on else "-"
+    return (
+        "<tr>"
+        f"<td>{escape(finding.result.name)}</td>"
+        f"<td>{escape(finding.result.issue or '-')}</td>"
+        f"<td>{escape(finding.rule.reason)}</td>"
+        f"<td>{escape(finding.rule.owner)}</td>"
+        f"<td>{escape(expires)}</td>"
+        "</tr>"
+    )
+
+
+def _result_card_html(result, *, artifact_root: Path | None) -> str:
+    status = str(result.status_code) if result.status_code is not None else "-"
+    issue = result.issue or "ok"
+    profile_rows = ""
+    if result.profile_results:
+        rows = []
+        for profile_result in sorted(
+            result.profile_results,
+            key=lambda current: (current.level, current.profile.casefold()),
+        ):
+            profile_name = profile_result.profile
+            if profile_result.anonymous:
+                profile_name = f"{profile_name} (anonymous)"
+            profile_status = (
+                str(profile_result.status_code) if profile_result.status_code is not None else "-"
+            )
+            profile_schema = "mismatch" if profile_result.response_schema_valid is False else "-"
+            rows.append(
+                "<tr>"
+                f"<td>{escape(profile_name)}</td>"
+                f"<td>{profile_result.level}</td>"
+                f"<td>{escape(profile_status)}</td>"
+                f"<td>{escape(profile_result.issue or 'ok')}</td>"
+                f"<td>{escape(profile_schema)}</td>"
+                f"<td><code>{escape(profile_result.url)}</code></td>"
+                "</tr>"
+            )
+        profile_rows = (
+            "<div class='subsection'><h4>Profile outcomes</h4>"
+            "<table><thead><tr><th>Profile</th><th>Level</th><th>Status</th>"
+            "<th>Issue</th><th>Schema</th><th>URL</th></tr></thead><tbody>"
+            + "".join(rows)
+            + "</tbody></table></div>"
+        )
+
+    workflow_rows = ""
+    if result.workflow_steps:
+        rows = []
+        for step in result.workflow_steps:
+            step_status = str(step.status_code) if step.status_code is not None else "-"
+            rows.append(
+                "<tr>"
+                f"<td>{escape(step.name)}</td>"
+                f"<td>{escape(step.operation_id)}</td>"
+                f"<td>{escape(step.method)}</td>"
+                f"<td>{escape(step_status)}</td>"
+                f"<td><code>{escape(step.url)}</code></td>"
+                "</tr>"
+            )
+        workflow_rows = (
+            "<div class='subsection'><h4>Workflow steps</h4>"
+            "<table><thead><tr><th>Step</th><th>Operation</th><th>Method</th>"
+            "<th>Status</th><th>URL</th></tr></thead><tbody>"
+            + "".join(rows)
+            + "</tbody></table></div>"
+        )
+
+    excerpt = ""
+    if result.response_excerpt:
+        excerpt = (
+            "<div class='subsection'><h4>Response excerpt</h4>"
+            f"<pre>{escape(result.response_excerpt)}</pre></div>"
+        )
+
+    error = ""
+    if result.error:
+        error = f"<p class='callout'>{escape(result.error)}</p>"
+
+    meta_grid = "".join(
+        [
+            _result_meta_item_html("Type", result.type),
+            _result_meta_item_html("Operation", result.operation_id),
+            _result_meta_item_html("Method", result.method),
+            _result_meta_item_html("Status", status),
+            _result_meta_item_html("Severity", result.severity),
+            _result_meta_item_html("Confidence", result.confidence),
+        ]
+    )
+    artifact_html = _artifact_links_html(result, artifact_root=artifact_root)
+
+    return (
+        "<article class='result-card'>"
+        f"<header><h3>{escape(result.name)}</h3>"
+        f"<span class='badge {escape(_issue_badge_class(result.issue))}'>{escape(issue)}</span>"
+        "</header>"
+        "<div class='meta-grid'>"
+        f"{meta_grid}"
+        "</div>"
+        f"<p><code>{escape(result.url)}</code></p>"
+        f"<div class='subsection'><h4>Artifacts</h4>{artifact_html}</div>"
+        f"{error}{profile_rows}{workflow_rows}{excerpt}"
+        "</article>"
+    )
+
+
+def render_html_report(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    artifact_root: str | Path | None = None,
+) -> str:
+    comparison = compare_attack_results(results, baseline, suppressions=suppressions)
+    artifact_root_path = Path(artifact_root) if artifact_root is not None else None
+    artifact_index_paths = (
+        sorted(artifact_root_path.rglob("*.json"))
+        if artifact_root_path and artifact_root_path.exists()
+        else []
+    )
+    issue_counter = Counter(result.issue or "ok" for result in results.results)
+
+    summary_cards = [
+        ("Total results", str(len(results.results))),
+        ("Active flagged", str(len(comparison.current_findings))),
+        ("Suppressed", str(len(comparison.suppressed_current_findings))),
+        (
+            "Profiles",
+            str(len(results.profiles)) if results.profiles else "single",
+        ),
+    ]
+    if baseline is not None:
+        summary_cards.extend(
+            [
+                ("New", str(len(comparison.new_findings))),
+                ("Resolved", str(len(comparison.resolved_findings))),
+                ("Persisting", str(len(comparison.persisting_findings))),
+            ]
+        )
+
+    flagged_rows = "".join(
+        "<tr>"
+        f"<td>{escape(finding.name)}</td>"
+        f"<td>{escape(finding.kind)}</td>"
+        f"<td>{escape(str(finding.status_code) if finding.status_code is not None else '-')}</td>"
+        f"<td>{escape(finding.issue or '-')}</td>"
+        f"<td>{escape(finding.severity)}</td>"
+        f"<td>{escape(finding.confidence)}</td>"
+        f"<td>{_artifact_links_html(finding, artifact_root=artifact_root_path)}</td>"
+        "</tr>"
+        for finding in comparison.current_findings
+    ) or ("<tr><td colspan='7' class='muted'>No active flagged findings.</td></tr>")
+
+    suppressed_rows = (
+        "".join(
+            _suppressed_finding_row_html(finding)
+            for finding in comparison.suppressed_current_findings
+        )
+        or "<tr><td colspan='5' class='muted'>No suppressed findings.</td></tr>"
+    )
+
+    outcome_rows = "".join(
+        f"<tr><td>{escape(outcome)}</td><td>{count}</td></tr>"
+        for outcome, count in sorted(issue_counter.items())
+    )
+
+    artifact_index = ""
+    if artifact_index_paths:
+        artifact_rows = "".join(
+            (
+                f"<li><a href='{escape(path.as_posix(), quote=True)}'>"
+                f"{escape(path.relative_to(artifact_root_path).as_posix())}</a></li>"
+            )
+            for path in artifact_index_paths
+        )
+        artifact_index = (
+            "<section class='panel'><h2>Artifact index</h2>"
+            f"<ul class='artifact-list'>{artifact_rows}</ul></section>"
+        )
+
+    diff_panels = ""
+    if baseline is not None:
+        diff_panels = (
+            "<section class='panel'>"
+            "<h2>Regression summary</h2>"
+            "<div class='summary-grid'>"
+            f"{_summary_card_html('Baseline executed at', baseline.executed_at.isoformat())}"
+            f"{_summary_card_html('New findings', str(len(comparison.new_findings)))}"
+            f"{_summary_card_html('Resolved findings', str(len(comparison.resolved_findings)))}"
+            f"{_summary_card_html('Persisting findings', str(len(comparison.persisting_findings)))}"
+            "</div></section>"
+        )
+
+    cards_html = "".join(
+        _result_card_html(result, artifact_root=artifact_root_path) for result in results.results
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>knives-out report</title>
+    <style>
+      :root {{
+        --bg: #f7f2e8;
+        --panel: rgba(255, 252, 247, 0.92);
+        --ink: #1d1a16;
+        --muted: #6b6359;
+        --border: rgba(69, 50, 28, 0.16);
+        --accent: #0f766e;
+        --warning: #b45309;
+        --critical: #b42318;
+        --shadow: 0 20px 60px rgba(31, 24, 17, 0.08);
+      }}
+      * {{ box-sizing: border-box; }}
+      body {{
+        margin: 0;
+        background:
+          radial-gradient(circle at top left, rgba(15, 118, 110, 0.12), transparent 36%),
+          radial-gradient(circle at top right, rgba(180, 83, 9, 0.12), transparent 28%),
+          linear-gradient(180deg, #fbf6ee 0%, var(--bg) 100%);
+        color: var(--ink);
+        font-family: Charter, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+        line-height: 1.55;
+      }}
+      main {{
+        width: min(1180px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 40px 0 56px;
+      }}
+      h1, h2, h3, h4 {{ margin: 0; }}
+      h1 {{ font-size: clamp(2rem, 3vw, 3.2rem); }}
+      h2 {{ font-size: 1.35rem; margin-bottom: 16px; }}
+      h3 {{ font-size: 1.15rem; }}
+      p, ul {{ margin: 0; }}
+      code, pre {{
+        font-family: "IBM Plex Mono", "SFMono-Regular", "Menlo", "Consolas", monospace;
+      }}
+      .hero {{
+        padding: 32px;
+        border-bottom: 1px solid var(--border);
+      }}
+      .hero p {{
+        margin-top: 10px;
+        color: var(--muted);
+      }}
+      .panel, .result-card {{
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(12px);
+      }}
+      .panel {{
+        padding: 28px;
+        margin-top: 24px;
+      }}
+      .summary-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 14px;
+      }}
+      .summary-card {{
+        padding: 18px;
+        background: rgba(255, 255, 255, 0.72);
+        border-radius: 18px;
+        border: 1px solid var(--border);
+      }}
+      .label {{
+        display: block;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 6px;
+      }}
+      .badge {{
+        display: inline-flex;
+        align-items: center;
+        padding: 0.28rem 0.7rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }}
+      .badge.critical {{ background: rgba(180, 35, 24, 0.12); color: var(--critical); }}
+      .badge.warning {{ background: rgba(180, 83, 9, 0.12); color: var(--warning); }}
+      .badge.neutral {{ background: rgba(15, 118, 110, 0.12); color: var(--accent); }}
+      table {{
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+      }}
+      th, td {{
+        padding: 12px 10px;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+        vertical-align: top;
+      }}
+      th {{
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }}
+      .muted {{ color: var(--muted); }}
+      .result-grid {{
+        display: grid;
+        gap: 18px;
+        margin-top: 24px;
+      }}
+      .result-card {{
+        padding: 24px;
+      }}
+      .result-card header {{
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        align-items: flex-start;
+        margin-bottom: 16px;
+      }}
+      .meta-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 12px;
+        margin-bottom: 12px;
+      }}
+      .subsection {{
+        margin-top: 16px;
+      }}
+      .subsection h4 {{
+        margin-bottom: 10px;
+        color: var(--muted);
+      }}
+      .callout {{
+        margin-top: 14px;
+        padding: 14px 16px;
+        border-left: 4px solid var(--warning);
+        background: rgba(180, 83, 9, 0.08);
+        border-radius: 12px;
+      }}
+      pre {{
+        margin: 0;
+        padding: 14px;
+        border-radius: 16px;
+        background: #1f1a17;
+        color: #f6ede1;
+        overflow-x: auto;
+      }}
+      .artifact-list {{
+        display: grid;
+        gap: 10px;
+        padding-left: 20px;
+      }}
+      a {{ color: var(--accent); text-decoration: none; }}
+      a:hover {{ text-decoration: underline; }}
+      @media (max-width: 720px) {{
+        main {{ width: min(100vw - 20px, 100%); padding-top: 20px; }}
+        .hero, .panel, .result-card {{ border-radius: 20px; }}
+        .result-card header {{ flex-direction: column; }}
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="panel hero">
+        <h1>knives-out report</h1>
+        <p>
+          Source: <code>{escape(results.source)}</code><br>
+          Base URL: <code>{escape(results.base_url)}</code><br>
+          Executed at: <code>{escape(results.executed_at.isoformat())}</code>
+        </p>
+      </section>
+
+      <section class="panel">
+        <h2>Summary</h2>
+        <div class="summary-grid">
+          {"".join(_summary_card_html(label, value) for label, value in summary_cards)}
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Outcome summary</h2>
+        <table>
+          <thead><tr><th>Outcome</th><th>Count</th></tr></thead>
+          <tbody>{outcome_rows}</tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>Flagged findings</h2>
+        <table>
+          <thead><tr><th>Attack</th><th>Kind</th><th>Status</th><th>Issue</th><th>Severity</th><th>Confidence</th><th>Artifacts</th></tr></thead>
+          <tbody>{flagged_rows}</tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>Suppressed findings</h2>
+        <table>
+          <thead><tr><th>Attack</th><th>Issue</th><th>Reason</th><th>Owner</th><th>Expires</th></tr></thead>
+          <tbody>{suppressed_rows}</tbody>
+        </table>
+      </section>
+
+      {diff_panels}
+      {artifact_index}
+
+      <section class="panel">
+        <h2>Detailed results</h2>
+        <div class="result-grid">{cards_html}</div>
+      </section>
+    </main>
+  </body>
+</html>
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -216,6 +216,53 @@ def test_report_command_supports_baseline(tmp_path: Path) -> None:
     assert "## Persisting findings" in report
 
 
+def test_report_command_supports_html_and_artifact_links(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    report_path = tmp_path / "report.html"
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    (artifact_root / "atk_html.json").write_text("{}", encoding="utf-8")
+
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_html",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="HTML failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            str(results_path),
+            "--format",
+            "html",
+            "--artifact-root",
+            str(artifact_root),
+            "--out",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in report
+    assert "<h2>Artifact index</h2>" in report
+    assert "atk_html.json" in report
+
+
 def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
     attacks_path = tmp_path / "attacks.json"
     out_path = tmp_path / "results.json"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -25,6 +25,9 @@ def test_readme_includes_ci_guidance() -> None:
     assert "--auto-workflows" in readme
     assert "--tag orders" in readme
     assert "--path /draft-orders/{draftId}" in readme
+    assert "knives-out report results.json --format html" in readme
+    assert "--artifact-root artifacts" in readme
+    assert "report.html" in readme
     assert "examples/openapi/storefront.yaml" in readme
     assert "examples/workflow_packs/listed_pet_lookup.py" in readme
 
@@ -45,6 +48,10 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "--profile anonymous" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
     assert "knives-out report results.json --out report.md" in workflow
+    assert (
+        "knives-out report results.json --format html --artifact-root artifacts --out report.html"
+        in workflow
+    )
     assert "knives-out report results.json \\" in workflow
     assert "knives-out verify results.json" in workflow
     assert "knives-out triage results.json --out .knives-out-ignore.yml" in workflow
@@ -58,11 +65,13 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
 
     assert "results.json" in ci_doc
     assert "report.md" in ci_doc
+    assert "report.html" in ci_doc
     assert "artifacts/" in ci_doc
     assert "Simple gating with no baseline" in ci_doc
     assert "Baseline-aware gating" in ci_doc
     assert "Optional: checked-in suppressions" in ci_doc
     assert "Optional: multi-profile authorization runs" in ci_doc
+    assert "Optional: HTML report and artifact index" in ci_doc
     assert "examples/auth_profiles/anonymous-user-admin.yml" in ci_doc
     assert "knives-out triage results.json --out .knives-out-ignore.yml" in ci_doc
     assert ".knives-out-ignore.yml" in ci_doc
@@ -73,6 +82,7 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Promote qualifying findings" in ci_doc
     assert "pytest --cov=src/knives_out --cov-report=term-missing" in ci_doc
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in ci_doc
+    assert "--format html --artifact-root artifacts --out report.html" in ci_doc
 
 
 def test_sync_wiki_workflow_uses_dedicated_secret_and_sync_script() -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -82,7 +82,9 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Promote qualifying findings" in ci_doc
     assert "pytest --cov=src/knives_out --cov-report=term-missing" in ci_doc
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in ci_doc
-    assert "--format html --artifact-root artifacts --out report.html" in ci_doc
+    assert "--format html" in ci_doc
+    assert "--artifact-root artifacts" in ci_doc
+    assert "--out report.html" in ci_doc
 
 
 def test_sync_wiki_workflow_uses_dedicated_secret_and_sync_script() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import httpx
 
@@ -17,7 +18,7 @@ from knives_out.models import (
     WorkflowStep,
     WorkflowStepResult,
 )
-from knives_out.reporting import render_markdown_report
+from knives_out.reporting import render_html_report, render_markdown_report
 from knives_out.runner import execute_attack_suite, execute_attack_suite_profiles
 from knives_out.suppressions import SuppressionRule
 
@@ -1154,3 +1155,65 @@ def test_render_markdown_report_shows_workflow_sections() -> None:
     assert "- Workflow phase: `setup`" in report
     assert "| Step | Operation | Method | Status | URL |" in report
     assert "List pets" in report
+
+
+def test_render_html_report_shows_artifact_index_and_profile_outcomes(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    (artifact_root / "wf_lookup.json").write_text("{}", encoding="utf-8")
+    (artifact_root / "wf_lookup-step-01.json").write_text("{}", encoding="utf-8")
+    profile_root = artifact_root / "anonymous"
+    profile_root.mkdir()
+    (profile_root / "wf_lookup.json").write_text("{}", encoding="utf-8")
+
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        profiles=["anonymous"],
+        results=[
+            AttackResult(
+                type="workflow",
+                attack_id="wf_lookup",
+                operation_id="getPet",
+                kind="wrong_type_param",
+                name="Workflow lookup",
+                method="GET",
+                url="https://example.com/pets/42",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+                response_excerpt='{"error":"boom"}',
+                profile_results=[
+                    ProfileAttackResult(
+                        profile="anonymous",
+                        level=0,
+                        anonymous=True,
+                        url="https://example.com/pets/42",
+                        status_code=500,
+                        issue="server_error",
+                        severity="high",
+                        confidence="high",
+                    )
+                ],
+                workflow_steps=[
+                    WorkflowStepResult(
+                        name="List pets",
+                        operation_id="listPets",
+                        method="GET",
+                        url="https://example.com/pets",
+                        status_code=200,
+                    )
+                ],
+            )
+        ],
+    )
+
+    report = render_html_report(results, artifact_root=artifact_root)
+
+    assert "<!DOCTYPE html>" in report
+    assert "<h2>Artifact index</h2>" in report
+    assert "wf_lookup-step-01.json" in report
+    assert "<h4>Profile outcomes</h4>" in report
+    assert "anonymous (anonymous)" in report


### PR DESCRIPTION
## Summary
- add HTML report rendering with artifact links, profile/workflow sections, and regression summaries
- add report CLI support for `--format html` and `--artifact-root`
- document the new report flow and cover it with CLI/report tests

## Testing
- `python3 -m ruff check src/knives_out/cli.py src/knives_out/reporting.py tests/test_runner.py tests/test_cli.py tests/test_docs.py`
- `python3 -m ruff format --check src/knives_out/cli.py src/knives_out/reporting.py tests/test_runner.py tests/test_cli.py tests/test_docs.py`
- `python3 -m pytest -q tests/test_cli.py tests/test_runner.py` *(fails in this host Python 3.9 environment because project dependencies like typer and httpx are not installed; rely on GitHub Actions for full validation)*