### PR TITLE
[codex] Add GraphQL schema support

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Generate attack suite
         run: |
           knives-out generate "$SPEC_PATH" --tag orders --out attacks.json
+          # For GraphQL SDL or introspection instead:
+          # knives-out generate examples/graphql/library.graphql \
+          #   --graphql-endpoint /graphql \
+          #   --out attacks.json
           # Path filters are exact matches against the OpenAPI path template:
           # knives-out generate "$SPEC_PATH" \
           #   --path /draft-orders/{draftId} \

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ It helps developers break their APIs on purpose before someone else does.
 
 ## What it does
 
-Given an OpenAPI document, `knives-out` can:
+Given an OpenAPI or GraphQL schema, `knives-out` can:
 
 - inspect the operations in the spec
 - generate replayable negative test cases
 - generate schema-aware mutation attacks from declared constraints
 - optionally chain setup requests into replayable workflow attacks
+- generate GraphQL query and mutation attacks from SDL or introspection output
 - load auth/session plugins for bearer tokens, login flows, and shared sessions
 - execute the same suite across named auth profiles and compare their outcomes
 - run those attacks against a live base URL
@@ -29,7 +30,7 @@ Given an OpenAPI document, `knives-out` can:
 
 The initial focus is narrow by design:
 
-- OpenAPI input
+- OpenAPI and GraphQL input
 - replayable JSON artifacts
 - deterministic attack generation
 - CI-friendly output
@@ -50,6 +51,7 @@ The starter scaffold generates a first wave of useful negative tests:
 - malformed JSON bodies
 - missing auth headers or query credentials when the spec declares security
 - opt-in setup-plus-terminal workflow attacks that reuse extracted response values
+- GraphQL variable type coercion, required-variable removal, and invalid enum values
 
 This is not a full fuzzing engine yet. It is a structured attack generator, runner, and CI gate.
 
@@ -66,7 +68,6 @@ That makes the architecture easier to evolve further with:
 - custom attack packs
 - deeper stateful workflows
 - LLM application testing
-- GraphQL support
 - richer CI policies
 - protocol expansion beyond OpenAPI REST
 
@@ -83,6 +84,7 @@ Inspect the sample specs:
 ```bash
 knives-out inspect examples/openapi/petstore.yaml
 knives-out inspect examples/openapi/storefront.yaml --tag orders
+knives-out inspect examples/graphql/library.graphql
 ```
 
 Generate attacks:
@@ -90,6 +92,15 @@ Generate attacks:
 ```bash
 knives-out generate examples/openapi/petstore.yaml --out attacks.json
 knives-out generate examples/openapi/storefront.yaml --tag orders --out attacks.json
+knives-out generate examples/graphql/library.graphql --out graphql-attacks.json
+```
+
+If your GraphQL endpoint is not `/graphql`, pass it during inspection or generation:
+
+```bash
+knives-out generate examples/graphql/library.graphql \
+  --graphql-endpoint /api/graphql \
+  --out graphql-attacks.json
 ```
 
 Opt in to built-in stateful workflows:
@@ -198,6 +209,8 @@ credentials on `--header` or `--query`, or move up to
 to keep only the highest-signal regressions around, follow `verify` with
 `knives-out promote results.json --attacks attacks.json`. See `docs/ci.md` for the sample
 workflow, secret setup, filtering patterns, baseline-aware CI flows, and checked-in suppressions.
+GraphQL schemas follow the same `inspect` / `generate` / `run` / `report` / `verify` flow, with
+`generate` automatically emitting variable-coercion attacks from SDL or introspection input.
 If you keep a `.knives-out-ignore.yml` file in the repo root, `report`, `verify`, and `promote`
 will load it automatically. Use `knives-out triage results.json` to seed new entries when you want
 to capture known findings without hand-writing YAML. For authorization-focused regression coverage,
@@ -208,10 +221,16 @@ you can also run one suite across `anonymous`, `user`, and `admin` profiles with
 
 ### `inspect`
 
-Shows a summary of operations discovered in an OpenAPI document.
+Shows a summary of operations discovered in an OpenAPI document or GraphQL schema.
 
 ```bash
 knives-out inspect path/to/openapi.yaml
+```
+
+GraphQL SDL or introspection JSON works too:
+
+```bash
+knives-out inspect examples/graphql/library.graphql --graphql-endpoint /graphql
 ```
 
 `inspect` surfaces preflight warnings for spec gaps such as missing request schemas, vague
@@ -227,10 +246,16 @@ knives-out inspect examples/openapi/storefront.yaml \
 
 ### `generate`
 
-Builds an `AttackSuite` JSON file from an OpenAPI document.
+Builds an `AttackSuite` JSON file from an OpenAPI document or GraphQL schema.
 
 ```bash
 knives-out generate path/to/openapi.yaml --out attacks.json
+```
+
+GraphQL SDL or introspection JSON uses the same command:
+
+```bash
+knives-out generate examples/graphql/library.graphql --out graphql-attacks.json
 ```
 
 `generate` echoes the same preflight warnings as `inspect` because many CI flows skip an explicit
@@ -600,11 +625,13 @@ knives-out run attacks.json \
 
 ## Roadmap
 
-The current direction is still intentionally modest:
+The previously planned adoption and GraphQL milestones are now shipped. The next planning pass is
+intentionally still open so the roadmap can reflect real usage instead of guessing too early.
 
-- parse common OpenAPI patterns well
-- generate useful negative tests with low noise
-- make every generated attack replayable
-- make result triage fast and obvious
+Right now the likely themes are:
 
-See `docs/architecture.md` and `docs/roadmap.md` for the initial direction.
+- stronger built-in auth acquisition and refresh flows for common OAuth/session cases
+- deeper GraphQL response validation, federation awareness, and subscription coverage
+- richer CI triage ergonomics and report navigation
+
+See `docs/architecture.md` and `docs/roadmap.md` for the current planning notes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,36 +16,57 @@ The core idea is that generation, execution, and reporting are separate concerns
 ```text
 src/knives_out/
   cli.py             # Typer entrypoint
-  models.py          # Pydantic models for operations, attacks, and results
+  graphql_loader.py  # GraphQL SDL/introspection parsing
+  models.py          # Pydantic models for operations, attacks, results, and profiles
   openapi_loader.py  # OpenAPI parsing and local $ref resolution
-  generator.py       # Attack generation from OperationSpec objects
-  runner.py          # HTTP execution and basic evaluation
-  reporting.py       # Markdown report rendering
+  spec_loader.py     # Schema autodetection for OpenAPI or GraphQL
+  generator.py       # Request and workflow attack generation
+  filtering.py       # Tag and path filtering helpers
+  runner.py          # HTTP execution, workflows, profiles, and auth runtime
+  auth_plugins.py    # Auth/session plugin helpers
+  profiles.py        # Multi-profile loading and comparison inputs
+  reporting.py       # Markdown and HTML report rendering
+  verification.py    # CI policy checks
+  promotion.py       # Regression-suite promotion from results
+  suppressions.py    # Checked-in finding suppressions and triage helpers
+  attack_packs.py    # Custom request attack extensions
+  workflow_packs.py  # Custom workflow attack extensions
 ```
 
 ## Flow
 
 ### 1. Load spec
 
-`openapi_loader.py` reads YAML/JSON, resolves local `$ref` values, and extracts a simplified list of `OperationSpec` objects.
+`spec_loader.py` autodetects whether the input is OpenAPI or GraphQL. `openapi_loader.py` reads
+YAML/JSON, resolves local `$ref` values, and extracts a simplified list of `OperationSpec`
+objects. `graphql_loader.py` does the same for GraphQL SDL or introspection JSON.
 
 ### 2. Generate suite
 
-`generator.py` turns each `OperationSpec` into a set of `AttackCase` objects. Those cases are serialized into a stable JSON artifact.
+`generator.py` turns each `OperationSpec` into a set of request and workflow attacks. Those cases
+are serialized into a stable JSON artifact.
 
 That JSON should become the contract between future generators and future runners.
 
 ### 3. Execute suite
 
-`runner.py` executes the saved suite against a concrete base URL. Runtime auth, query values, or environment-specific defaults are merged at this phase rather than baked into generation.
+`runner.py` executes the saved suite against a concrete base URL. Runtime auth, query values,
+profile-specific defaults, and workflow state are merged at this phase rather than baked into
+generation. For GraphQL attacks, a `200` response with an `errors` array is treated as an
+expected validation failure instead of an unexpected success.
 
 ### 4. Report findings
 
-`reporting.py` reduces the results into a Markdown report. For the initial milestone, a result is flagged when it produces:
+`reporting.py` reduces the results into Markdown or HTML. `verification.py`, `promotion.py`, and
+`suppressions.py` then build CI and triage workflows on the same result model.
+
+Today, a result is typically flagged when it produces:
 
 - a transport error
 - a 5xx response
 - an unexpected 2xx/3xx response to a negative test
+- a response-schema mismatch
+- a high-signal authorization comparison issue across profiles
 
 ## Why save attacks as JSON?
 
@@ -61,23 +82,19 @@ It gives the project:
 
 ## Expected near-term evolution
 
-The next additions should probably be:
+The next milestone work should extend the current architecture in two directions:
 
-1. richer schema sampling
-2. better security scheme handling
-3. custom rule packs
-4. OpenAPI response-schema validation
-5. request/response artifact storage per attack
-6. baseline vs. regression comparisons
+1. first-class auth/session profile strategies for common OAuth and session-login flows
+2. clearer auth setup diagnostics in reports and CI flows
+3. protocol-aware filtering that still shares the current run/report/verify pipeline
+4. stronger GraphQL response-shape validation on top of the new protocol loader
 
 ## Things intentionally deferred
 
-These are interesting, but they should wait until the first milestone is solid:
+These are still interesting, but they should wait until the next two milestones are solid:
 
 - browser/session automation
-- OAuth flows
-- multi-step workflow attacks
-- GraphQL
+- redirect-driven OAuth auth-code flows
 - gRPC
 - LLM toolchain testing
 - distributed fuzzing

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,7 +2,7 @@
 
 `knives-out` is designed to fit a normal CI workflow:
 
-1. generate a replayable attack suite from a checked-in OpenAPI spec
+1. generate a replayable attack suite from a checked-in OpenAPI or GraphQL schema
 2. optionally opt in to workflow generation for stateful coverage
 3. run that suite against a dev or staging deployment
 4. render a Markdown report for review
@@ -41,6 +41,8 @@ If you want identity-aware authorization coverage, the repo also includes
 
 For richer checked-in examples, the repo now includes `examples/openapi/storefront.yaml`, which
 combines exact tags, path filters, schema constraints, and a producer/consumer workflow chain.
+For GraphQL, the repo includes `examples/graphql/library.graphql`, which demonstrates query and
+mutation variable attacks from SDL input.
 
 ## Expected exit behavior
 
@@ -165,6 +167,24 @@ You can add app-specific journeys by loading a workflow pack module or entry poi
       --auto-workflows \
       --workflow-pack-module examples/workflow_packs/listed_pet_lookup.py \
       --out attacks.json
+```
+
+## Optional: GraphQL schemas
+
+GraphQL SDL or introspection JSON follows the same generate/run/report/verify flow. The generated
+attacks target invalid variables, required-variable removal, and type coercion failures.
+
+```yaml
+- name: Inspect a GraphQL schema
+  run: knives-out inspect examples/graphql/library.graphql
+```
+
+```yaml
+- name: Generate GraphQL attacks
+  run: |
+    knives-out generate examples/graphql/library.graphql \
+      --graphql-endpoint /graphql \
+      --out graphql-attacks.json
 ```
 
 ## Optional: tag and path filtering

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,93 +1,37 @@
-# Initial roadmap
+# Roadmap
 
-## Milestone: v0.1 — useful negative testing from OpenAPI
+`knives-out` now ships the milestone stack that used to define the near-term roadmap:
 
-The first release should answer a simple question:
+- replayable REST request attacks
+- workflow attacks with shared state and extracted values
+- response-schema validation, CI verification, suppressions, and regression-suite promotion
+- auth/session plugins and multi-profile authorization comparisons
+- HTML reporting with linked artifacts
+- GraphQL SDL and introspection loading with replayable variable-coercion attacks
 
-> Can `knives-out` generate and run a meaningful set of adversarial API tests from a normal OpenAPI spec?
+That means the next roadmap should be shaped by real usage instead of the original bootstrap plan.
 
-## First 10 GitHub issues
+## Recently completed
 
-### 1. Improve schema sampling for nested objects and arrays
-**Goal:** Generate better valid baseline payloads so the negative tests are less noisy.
+- v0.5: suppressions and triage
+- v0.6: multi-profile authorization testing
+- v0.7: HTML report and artifact index
+- v0.8: GraphQL support
 
-**Acceptance criteria:**
-- object generation includes nested required fields
-- array generation handles item schemas recursively
-- unit tests cover nested schemas
+## Next planning pass
 
-### 2. Support path-level and operation-level parameter overrides correctly
-**Goal:** Confirm operation parameters replace path parameters with the same name/in location.
+The next milestone set is not locked yet, but the strongest candidates are:
 
-**Acceptance criteria:**
-- override logic is explicitly tested
-- duplicate parameters are resolved deterministically
+1. built-in auth acquisition and refresh flows for common OAuth/session patterns
+2. deeper GraphQL response validation, federation awareness, and subscription coverage
+3. richer CI and artifact navigation for large suites
+4. stronger reporting and triage ergonomics for long-lived regression programs
 
-### 3. Add response-schema validation against declared OpenAPI responses
-**Goal:** Flag cases where the API returns the wrong response shape.
+## Still deferred
 
-**Acceptance criteria:**
-- runner can map status code to declared schema
-- report highlights response-schema mismatches
+These remain interesting, but they should not displace the next planning pass:
 
-### 4. Add auth scheme support for API keys in headers and query strings
-**Goal:** Make missing-auth tests more accurate for real-world APIs.
-
-**Acceptance criteria:**
-- security schemes are extracted from components
-- missing-auth attacks remove the right credential
-- tests cover header and query apiKey schemes
-
-### 5. Add output directory with per-attack request/response artifacts
-**Goal:** Make triage easier by preserving concrete request and response evidence.
-
-**Acceptance criteria:**
-- optional artifact directory is created on run
-- each attack has a stable artifact file name
-- artifacts include request metadata and response body excerpt
-
-### 6. Add attack filtering by operation, method, and kind
-**Goal:** Let users target a subset of the suite while iterating.
-
-**Acceptance criteria:**
-- CLI supports include/exclude filters
-- filtering works during generation and/or run
-
-### 7. Add custom attack packs via Python entry points or local modules
-**Goal:** Let users extend the generator without forking the project.
-
-**Acceptance criteria:**
-- attack pack interface is documented
-- one example custom pack exists
-- CLI can load custom packs
-
-### 8. Introduce severity/confidence scoring
-**Goal:** Rank findings so the report is useful on larger suites.
-
-**Acceptance criteria:**
-- each finding has confidence and severity fields
-- report sorts flagged findings by score
-
-### 9. Add CI examples for running against a dev environment
-**Goal:** Make the tool usable in a normal engineering workflow.
-
-**Acceptance criteria:**
-- README includes CI usage
-- a sample GitHub Actions workflow can run generation + execution
-
-### 10. Add OpenAPI spec linting and preflight warnings
-**Goal:** Tell users when the spec itself is too incomplete to generate reliable attacks.
-
-**Acceptance criteria:**
-- warnings for missing request schemas, vague security, and unresolved refs
-- inspect command surfaces preflight warnings clearly
-
-## After v0.1
-
-Once the fundamentals are solid, the next larger expansions are:
-
-- stateful workflow attacks
-- auth/session plugins
-- GraphQL support
-- prompt-injection and tool-misuse testing for LLM apps
-- regression suites generated from previously discovered findings
+- browser-assisted login and redirect-driven OAuth flows
+- gRPC support
+- LLM application and tool-misuse testing
+- distributed fuzzing or large-scale orchestration

--- a/examples/graphql/library.graphql
+++ b/examples/graphql/library.graphql
@@ -1,0 +1,34 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Query {
+  book(id: ID!): Book
+  books(limit: Int, genre: Genre): [Book!]!
+}
+
+type Mutation {
+  createBook(input: CreateBookInput!): Book!
+  rateBook(id: ID!, rating: Int!): Book!
+}
+
+type Book {
+  id: ID!
+  title: String!
+  genre: Genre!
+  rating: Int
+}
+
+input CreateBookInput {
+  title: String!
+  genre: Genre!
+  rating: Int
+  tags: [String!]
+}
+
+enum Genre {
+  FICTION
+  NONFICTION
+  REFERENCE
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "knives-out"
 version = "0.1.0"
-description = "Adversarial testing for APIs from OpenAPI specs."
+description = "Adversarial testing for APIs from OpenAPI and GraphQL schemas."
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -13,6 +13,7 @@ authors = [
   { name = "Keith Wegner" }
 ]
 dependencies = [
+  "graphql-core>=3.2.6",
   "httpx>=0.27.0",
   "pydantic>=2.8.0",
   "PyYAML>=6.0.2",

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -14,7 +14,6 @@ from knives_out.auth_plugins import PluginRuntimeError, load_auth_plugins
 from knives_out.filtering import filter_attack_suite, filter_operations
 from knives_out.generator import generate_attack_suite
 from knives_out.models import AttackResults, AuthProfile, PreflightWarning
-from knives_out.openapi_loader import load_operations_with_warnings
 from knives_out.profiles import (
     load_auth_profiles,
     resolve_auth_profile_modules,
@@ -31,6 +30,7 @@ from knives_out.runner import (
     execute_attack_suite_profiles,
     load_attack_suite,
 )
+from knives_out.spec_loader import load_operations_with_warnings
 from knives_out.suppressions import (
     DEFAULT_SUPPRESSIONS_PATH,
     SuppressionRule,
@@ -47,7 +47,10 @@ from knives_out.verification import (
 )
 from knives_out.workflow_packs import load_workflow_packs
 
-app = typer.Typer(no_args_is_help=True, help="Adversarial API testing from OpenAPI specs.")
+app = typer.Typer(
+    no_args_is_help=True,
+    help="Adversarial API testing from OpenAPI and GraphQL schemas.",
+)
 console = Console()
 
 
@@ -188,6 +191,10 @@ def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> Non
 @app.command()
 def inspect(
     spec: Path,
+    graphql_endpoint: Annotated[
+        str,
+        typer.Option(help="GraphQL endpoint path to use when inspecting GraphQL schemas."),
+    ] = "/graphql",
     tag: Annotated[
         list[str] | None,
         typer.Option(help="Only include operations with these tags. Repeatable."),
@@ -205,8 +212,8 @@ def inspect(
         typer.Option(help="Exclude operations for these exact OpenAPI paths. Repeatable."),
     ] = None,
 ) -> None:
-    """Show the operations discovered in an OpenAPI spec."""
-    loaded = load_operations_with_warnings(spec)
+    """Show the operations discovered in an OpenAPI or GraphQL schema."""
+    loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
     operations = filter_operations(
         loaded.operations,
         include_paths=path,
@@ -241,6 +248,10 @@ def inspect(
 @app.command()
 def generate(
     spec: Path,
+    graphql_endpoint: Annotated[
+        str,
+        typer.Option(help="GraphQL endpoint path to use when generating from GraphQL schemas."),
+    ] = "/graphql",
     out: Annotated[
         Path,
         typer.Option(help="Where to write the generated attack suite."),
@@ -311,11 +322,11 @@ def generate(
         typer.Option(help="Load custom workflow packs from local Python module paths. Repeatable."),
     ] = None,
 ) -> None:
-    """Generate a replayable attack suite from an OpenAPI spec.
+    """Generate a replayable attack suite from an OpenAPI or GraphQL schema.
 
     Filters are applied after attack generation and before the suite is written.
     """
-    loaded = load_operations_with_warnings(spec)
+    loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
     operations = loaded.operations
     attack_packs = load_attack_packs(entry_point_names=pack, module_paths=pack_module)
     workflow_packs = load_workflow_packs(

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -1024,7 +1024,228 @@ def generate_workflow_attacks(
     return workflows
 
 
+def _graphql_expected_outcomes() -> list[str]:
+    return ["graphql_error", "4xx"]
+
+
+def _graphql_sample_value(schema: dict[str, Any] | None) -> Any:
+    schema = _normalize_schema(schema)
+    if "default" in schema:
+        return schema["default"]
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+
+    schema_type = _schema_type(schema)
+    if schema_type == "array":
+        return [_graphql_sample_value(schema.get("items", {}))]
+    if schema_type == "object":
+        return {
+            name: _graphql_sample_value(property_schema)
+            for name, property_schema in schema.get("properties", {}).items()
+        }
+    return _sample_scalar_value(schema)
+
+
+def _graphql_request_body(operation: OperationSpec, variables: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "query": operation.graphql_document or "",
+        "variables": deepcopy(variables),
+    }
+
+
+def _graphql_variable_label(path: tuple[str | int, ...]) -> str:
+    label = "variables"
+    for token in path:
+        if isinstance(token, int):
+            label += f"[{token}]"
+        else:
+            label += f".{token}"
+    return label
+
+
+def _graphql_variable_reference(path: tuple[str | int, ...]) -> str:
+    return f"GraphQL variable '{_graphql_variable_label(path)}'"
+
+
+def _collect_graphql_variable_mutations(
+    schema: dict[str, Any] | None,
+    value: Any,
+    *,
+    path: tuple[str | int, ...] = (),
+) -> list[_BodyMutation]:
+    schema = _normalize_schema(schema)
+    schema_type = _schema_type(schema)
+    mutations: list[_BodyMutation] = []
+
+    if path:
+        mutations.append(
+            _BodyMutation(
+                kind="wrong_type_variable",
+                target=_graphql_variable_label(path),
+                name=f"Wrong-type {_graphql_variable_reference(path)}",
+                description=(
+                    f"Substitutes a wrong-type value for {_graphql_variable_reference(path)}."
+                ),
+                action="replace",
+                path=path,
+                value=invalid_scalar_value(schema),
+            )
+        )
+
+        if schema.get("enum"):
+            mutations.append(
+                _BodyMutation(
+                    kind="invalid_enum",
+                    target=_graphql_variable_label(path),
+                    name=f"Invalid enum {_graphql_variable_reference(path)}",
+                    description=(
+                        f"Uses a value outside the declared enum for "
+                        f"{_graphql_variable_reference(path)}."
+                    ),
+                    action="replace",
+                    path=path,
+                    value=invalid_enum_value(schema),
+                )
+            )
+
+    if schema_type == "array":
+        if isinstance(value, list) and value:
+            mutations.extend(
+                _collect_graphql_variable_mutations(
+                    schema.get("items"),
+                    value[0],
+                    path=(*path, 0),
+                )
+            )
+        return mutations
+
+    if schema_type == "object" and isinstance(value, dict):
+        for required_name in schema.get("required", []):
+            if required_name not in value:
+                continue
+            property_path = (*path, required_name)
+            mutations.append(
+                _BodyMutation(
+                    kind="missing_required_variable",
+                    target=_graphql_variable_label(property_path),
+                    name=f"Missing required {_graphql_variable_reference(property_path)}",
+                    description=f"Removes required {_graphql_variable_reference(property_path)}.",
+                    action="remove",
+                    path=property_path,
+                )
+            )
+
+        for property_name, property_schema in schema.get("properties", {}).items():
+            if property_name not in value:
+                continue
+            mutations.extend(
+                _collect_graphql_variable_mutations(
+                    property_schema,
+                    value[property_name],
+                    path=(*path, property_name),
+                )
+            )
+
+    return mutations
+
+
+def _graphql_attack_from_mutation(
+    operation: OperationSpec,
+    mutation: _BodyMutation,
+    *,
+    variables: dict[str, Any],
+) -> AttackCase:
+    mutated_variables = deepcopy(variables)
+    if mutation.action == "replace":
+        mutated_variables = _replace_json_value(
+            mutated_variables,
+            mutation.path,
+            deepcopy(mutation.value),
+        )
+    elif mutation.action == "remove":
+        mutated_variables = _remove_json_value(mutated_variables, mutation.path)
+    else:
+        raise ValueError(f"Unknown GraphQL mutation action: {mutation.action}")
+
+    return AttackCase(
+        id=attack_id(operation.operation_id, mutation.kind, mutation.target),
+        name=mutation.name,
+        kind=mutation.kind,
+        operation_id=operation.operation_id,
+        method=operation.method,
+        path=operation.path,
+        tags=_tags_for_attack(operation),
+        auth_required=operation.auth_required,
+        description=mutation.description,
+        body_json=_graphql_request_body(operation, mutated_variables),
+        content_type="application/json",
+        expected_outcomes=_graphql_expected_outcomes(),
+        response_schemas=_response_schemas_for_attack(operation),
+    )
+
+
+def _generate_graphql_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]:
+    variables_schema = operation.graphql_variables_schema or {
+        "type": "object",
+        "properties": {},
+    }
+    variables = _graphql_sample_value(variables_schema)
+    if not isinstance(variables, dict):
+        variables = {}
+
+    attacks: list[AttackCase] = []
+    if operation.request_body_required:
+        attacks.append(
+            AttackCase(
+                id=attack_id(operation.operation_id, "missing_request_body", "body"),
+                name="Missing request body",
+                kind="missing_request_body",
+                operation_id=operation.operation_id,
+                method=operation.method,
+                path=operation.path,
+                tags=_tags_for_attack(operation),
+                auth_required=operation.auth_required,
+                description="Omits the required GraphQL request body.",
+                omit_body=True,
+                expected_outcomes=_graphql_expected_outcomes(),
+                response_schemas=_response_schemas_for_attack(operation),
+            )
+        )
+
+    attacks.append(
+        AttackCase(
+            id=attack_id(operation.operation_id, "malformed_json_body", "body"),
+            name="Malformed JSON body",
+            kind="malformed_json_body",
+            operation_id=operation.operation_id,
+            method=operation.method,
+            path=operation.path,
+            tags=_tags_for_attack(operation),
+            auth_required=operation.auth_required,
+            description="Sends invalid JSON for a GraphQL request body.",
+            raw_body=malformed_json_body(operation.request_body_schema),
+            content_type="application/json",
+            expected_outcomes=_graphql_expected_outcomes(),
+            response_schemas=_response_schemas_for_attack(operation),
+        )
+    )
+
+    for mutation in _collect_graphql_variable_mutations(variables_schema, variables):
+        attacks.append(
+            _graphql_attack_from_mutation(
+                operation,
+                mutation,
+                variables=variables,
+            )
+        )
+
+    return attacks
+
+
 def generate_attacks_for_operation(operation: OperationSpec) -> list[AttackCase]:
+    if operation.protocol == "graphql":
+        return _generate_graphql_attacks_for_operation(operation)
+
     attacks: list[AttackCase] = []
     base_path_params, base_query_params, base_headers, base_body = base_request_context(operation)
 

--- a/src/knives_out/graphql_loader.py
+++ b/src/knives_out/graphql_loader.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from graphql import (
+    GraphQLEnumType,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLScalarType,
+    GraphQLSchema,
+    GraphQLUnionType,
+    build_client_schema,
+    build_schema,
+    get_named_type,
+)
+
+from knives_out.models import LoadedOperations, OperationSpec, ParameterSpec
+
+
+def _load_graphql_schema(path: str | Path) -> GraphQLSchema:
+    schema_path = Path(path)
+    raw = schema_path.read_text(encoding="utf-8")
+
+    if schema_path.suffix.lower() == ".json":
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError("GraphQL introspection JSON did not parse to an object.")
+        if "__schema" in payload:
+            return build_client_schema(payload)
+        data = payload.get("data")
+        if isinstance(data, dict) and "__schema" in data:
+            return build_client_schema(data)
+        raise ValueError("GraphQL introspection JSON is missing '__schema'.")
+
+    return build_schema(raw)
+
+
+def _json_schema_for_input_type(type_: Any) -> tuple[dict[str, Any], bool]:
+    if isinstance(type_, GraphQLNonNull):
+        schema, _ = _json_schema_for_input_type(type_.of_type)
+        return schema, True
+
+    if isinstance(type_, GraphQLList):
+        item_schema, _ = _json_schema_for_input_type(type_.of_type)
+        return {"type": "array", "items": item_schema}, False
+
+    named_type = get_named_type(type_)
+    if isinstance(named_type, GraphQLScalarType):
+        scalar_name = named_type.name
+        if scalar_name == "Int":
+            return {"type": "integer"}, False
+        if scalar_name == "Float":
+            return {"type": "number"}, False
+        if scalar_name == "Boolean":
+            return {"type": "boolean"}, False
+        return {"type": "string"}, False
+
+    if isinstance(named_type, GraphQLEnumType):
+        return {"type": "string", "enum": list(named_type.values)}, False
+
+    if isinstance(named_type, GraphQLInputObjectType):
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for field_name, field in named_type.fields.items():
+            field_schema, field_required = _json_schema_for_input_type(field.type)
+            properties[field_name] = field_schema
+            if field_required:
+                required.append(field_name)
+        schema: dict[str, Any] = {"type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+        return schema, False
+
+    return {"type": "string"}, False
+
+
+def _selection_set_for_output_type(type_: Any) -> str:
+    named_type = get_named_type(type_)
+    if isinstance(named_type, (GraphQLObjectType, GraphQLInterfaceType, GraphQLUnionType)):
+        return "{ __typename }"
+    return ""
+
+
+def _graphql_document(
+    *,
+    operation_type: str,
+    field_name: str,
+    field: Any,
+) -> str:
+    variable_definitions: list[str] = []
+    argument_bindings: list[str] = []
+    for argument_name, argument in field.args.items():
+        variable_definitions.append(f"${argument_name}: {argument.type}")
+        argument_bindings.append(f"{argument_name}: ${argument_name}")
+
+    operation_name = field_name[:1].upper() + field_name[1:]
+    definitions = f"({', '.join(variable_definitions)})" if variable_definitions else ""
+    bindings = f"({', '.join(argument_bindings)})" if argument_bindings else ""
+    selection_set = _selection_set_for_output_type(field.type)
+    selection = f" {selection_set}" if selection_set else ""
+    return f"{operation_type} {operation_name}{definitions} {{ {field_name}{bindings}{selection} }}"
+
+
+def _variables_schema(field: Any) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for argument_name, argument in field.args.items():
+        argument_schema, argument_required = _json_schema_for_input_type(argument.type)
+        properties[argument_name] = argument_schema
+        if argument_required:
+            required.append(argument_name)
+
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _request_body_schema(document: str, variables_schema: dict[str, Any]) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "default": document},
+            "variables": variables_schema,
+        },
+        "required": ["query"],
+    }
+    if variables_schema.get("properties"):
+        schema["required"] = ["query", "variables"]
+    return schema
+
+
+def _operation_specs(
+    *,
+    root: GraphQLObjectType | None,
+    operation_type: str,
+    endpoint: str,
+) -> list[OperationSpec]:
+    if root is None:
+        return []
+
+    operations: list[OperationSpec] = []
+    for field_name, field in root.fields.items():
+        variables_schema = _variables_schema(field)
+        document = _graphql_document(
+            operation_type=operation_type,
+            field_name=field_name,
+            field=field,
+        )
+        operations.append(
+            OperationSpec(
+                operation_id=field_name,
+                method="POST",
+                path=endpoint,
+                protocol="graphql",
+                summary=getattr(field, "description", None),
+                tags=["graphql", operation_type],
+                parameters=[
+                    ParameterSpec(
+                        name=argument_name,
+                        location="graphql-variable",
+                        required=isinstance(argument.type, GraphQLNonNull),
+                        schema_def=_json_schema_for_input_type(argument.type)[0],
+                    )
+                    for argument_name, argument in field.args.items()
+                ],
+                request_body_required=True,
+                request_body_schema=_request_body_schema(document, variables_schema),
+                request_body_content_type="application/json",
+                graphql_operation_type=operation_type,
+                graphql_document=document,
+                graphql_variables_schema=variables_schema,
+            )
+        )
+
+    return operations
+
+
+def load_graphql_operations_with_warnings(
+    path: str | Path,
+    *,
+    endpoint: str = "/graphql",
+) -> LoadedOperations:
+    schema = _load_graphql_schema(path)
+    operations = [
+        *_operation_specs(root=schema.query_type, operation_type="query", endpoint=endpoint),
+        *_operation_specs(root=schema.mutation_type, operation_type="mutation", endpoint=endpoint),
+    ]
+    return LoadedOperations(operations=operations, warnings=[])
+
+
+def load_graphql_operations(path: str | Path, *, endpoint: str = "/graphql") -> list[OperationSpec]:
+    return load_graphql_operations_with_warnings(path, endpoint=endpoint).operations

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -26,6 +26,7 @@ class OperationSpec(BaseModel):
     operation_id: str
     method: str
     path: str
+    protocol: Literal["openapi", "graphql"] = "openapi"
     summary: str | None = None
     tags: list[str] = Field(default_factory=list)
     parameters: list[ParameterSpec] = Field(default_factory=list)
@@ -36,6 +37,9 @@ class OperationSpec(BaseModel):
     auth_header_names: list[str] = Field(default_factory=list)
     auth_query_names: list[str] = Field(default_factory=list)
     response_schemas: dict[str, ResponseSpec] = Field(default_factory=dict)
+    graphql_operation_type: Literal["query", "mutation"] | None = None
+    graphql_document: str | None = None
+    graphql_variables_schema: dict[str, Any] | None = None
 
 
 class PreflightWarning(BaseModel):

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -137,13 +137,43 @@ def _remove_header_names(headers: dict[str, str], names: list[str]) -> dict[str,
     return {key: value for key, value in headers.items() if key.lower() not in lowered}
 
 
-def evaluate_result(status_code: int | None, error: str | None) -> tuple[bool, str | None]:
+def _response_has_graphql_errors(response: httpx.Response) -> bool:
+    try:
+        payload = response.json()
+    except ValueError:
+        return False
+
+    errors = payload.get("errors") if isinstance(payload, dict) else None
+    return isinstance(errors, list) and bool(errors)
+
+
+def _response_matches_expected(
+    response: httpx.Response,
+    expected_outcomes: list[str],
+) -> bool:
+    if _status_matches_expected(response.status_code, expected_outcomes):
+        return True
+    return any(
+        expected.strip().lower() == "graphql_error" and _response_has_graphql_errors(response)
+        for expected in expected_outcomes
+    )
+
+
+def evaluate_result(
+    status_code: int | None,
+    error: str | None,
+    *,
+    response: httpx.Response | None = None,
+    expected_outcomes: list[str] | None = None,
+) -> tuple[bool, str | None]:
     if error:
         return True, "transport_error"
     if status_code is None:
         return True, "no_status"
     if 500 <= status_code < 600:
         return True, "server_error"
+    if response is not None and _response_matches_expected(response, expected_outcomes or ["4xx"]):
+        return False, None
     if 200 <= status_code < 400:
         return True, "unexpected_success"
     return False, None
@@ -712,6 +742,8 @@ def _request_result(
     flagged, issue = evaluate_result(
         execution.response.status_code if execution.response else None,
         execution.error,
+        response=execution.response,
+        expected_outcomes=attack.expected_outcomes,
     )
     response_schema_status: str | None = None
     response_schema_valid: bool | None = None

--- a/src/knives_out/spec_loader.py
+++ b/src/knives_out/spec_loader.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from knives_out.graphql_loader import load_graphql_operations_with_warnings
+from knives_out.models import LoadedOperations
+from knives_out.openapi_loader import load_operations_with_warnings as load_openapi_operations
+
+
+def _looks_like_graphql_introspection(path: Path) -> bool:
+    if path.suffix.lower() != ".json":
+        return False
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return False
+
+    if not isinstance(payload, dict):
+        return False
+    if "__schema" in payload:
+        return True
+    data = payload.get("data")
+    return isinstance(data, dict) and "__schema" in data
+
+
+def is_graphql_schema_path(path: str | Path) -> bool:
+    schema_path = Path(path)
+    if schema_path.suffix.lower() in {".graphql", ".gql"}:
+        return True
+    return _looks_like_graphql_introspection(schema_path)
+
+
+def load_operations_with_warnings(
+    path: str | Path,
+    *,
+    graphql_endpoint: str = "/graphql",
+) -> LoadedOperations:
+    if is_graphql_schema_path(path):
+        return load_graphql_operations_with_warnings(path, endpoint=graphql_endpoint)
+    return load_openapi_operations(path)
+
+
+def load_operations(
+    path: str | Path,
+    *,
+    graphql_endpoint: str = "/graphql",
+):
+    return load_operations_with_warnings(path, graphql_endpoint=graphql_endpoint).operations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,9 @@ from knives_out.suppressions import load_suppressions
 
 runner = CliRunner()
 EXAMPLE_SPEC = Path(__file__).resolve().parents[1] / "examples" / "openapi" / "petstore.yaml"
+GRAPHQL_EXAMPLE_SPEC = (
+    Path(__file__).resolve().parents[1] / "examples" / "graphql" / "library.graphql"
+)
 
 
 def _write_results(path: Path, results: AttackResults) -> None:
@@ -46,7 +49,7 @@ def test_inspect_command_runs() -> None:
 def test_inspect_command_shows_preflight_warnings(monkeypatch) -> None:
     monkeypatch.setattr(
         "knives_out.cli.load_operations_with_warnings",
-        lambda spec: LoadedOperations(
+        lambda spec, **_: LoadedOperations(
             operations=[],
             warnings=[
                 PreflightWarning(
@@ -71,7 +74,7 @@ def test_inspect_command_shows_preflight_warnings(monkeypatch) -> None:
 def test_inspect_command_filters_operations_by_tag(monkeypatch) -> None:
     monkeypatch.setattr(
         "knives_out.cli.load_operations_with_warnings",
-        lambda spec: LoadedOperations(
+        lambda spec, **_: LoadedOperations(
             operations=[
                 {
                     "operation_id": "listPets",
@@ -98,6 +101,22 @@ def test_inspect_command_filters_operations_by_tag(monkeypatch) -> None:
     assert "Found 1 operations." in result.stdout
 
 
+def test_inspect_command_supports_graphql_schema(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "inspect",
+            str(GRAPHQL_EXAMPLE_SPEC),
+            "--graphql-endpoint",
+            "/api/graphql",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Found 4 operations." in result.stdout
+    assert "/api/graphql" in result.stdout
+
+
 def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
     out_path = tmp_path / "attacks.json"
     result = runner.invoke(app, ["generate", str(EXAMPLE_SPEC), "--out", str(out_path)])
@@ -107,6 +126,16 @@ def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
     suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert suite.attacks
     assert all(attack.type == "request" for attack in suite.attacks)
+
+
+def test_generate_command_supports_graphql_schema(tmp_path: Path) -> None:
+    out_path = tmp_path / "graphql-attacks.json"
+    result = runner.invoke(app, ["generate", str(GRAPHQL_EXAMPLE_SPEC), "--out", str(out_path)])
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert any(attack.kind == "wrong_type_variable" for attack in suite.attacks)
+    assert all(attack.path == "/graphql" for attack in suite.attacks)
 
 
 def test_generate_command_supports_auto_workflows(tmp_path: Path) -> None:
@@ -914,7 +943,7 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(
         "knives_out.cli.load_operations_with_warnings",
-        lambda spec: LoadedOperations(operations=[], warnings=[]),
+        lambda spec, **_: LoadedOperations(operations=[], warnings=[]),
     )
     monkeypatch.setattr(
         "knives_out.cli.generate_attack_suite",
@@ -969,7 +998,7 @@ def test_generate_command_filters_attacks_by_tag(tmp_path: Path, monkeypatch) ->
 
     monkeypatch.setattr(
         "knives_out.cli.load_operations_with_warnings",
-        lambda spec: LoadedOperations(operations=[], warnings=[]),
+        lambda spec, **_: LoadedOperations(operations=[], warnings=[]),
     )
     monkeypatch.setattr(
         "knives_out.cli.generate_attack_suite",
@@ -1024,7 +1053,7 @@ def test_generate_command_echoes_preflight_warnings(tmp_path: Path, monkeypatch)
 
     monkeypatch.setattr(
         "knives_out.cli.load_operations_with_warnings",
-        lambda spec: LoadedOperations(
+        lambda spec, **_: LoadedOperations(
             operations=[],
             warnings=[
                 PreflightWarning(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -3,6 +3,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 CI_DOC = ROOT / "docs" / "ci.md"
+ARCHITECTURE_DOC = ROOT / "docs" / "architecture.md"
+ROADMAP_DOC = ROOT / "docs" / "roadmap.md"
 DEV_WORKFLOW = ROOT / ".github" / "workflows" / "dev-environment-example.yml"
 SYNC_WIKI_WORKFLOW = ROOT / ".github" / "workflows" / "sync-wiki.yml"
 
@@ -29,7 +31,12 @@ def test_readme_includes_ci_guidance() -> None:
     assert "--artifact-root artifacts" in readme
     assert "report.html" in readme
     assert "examples/openapi/storefront.yaml" in readme
+    assert "examples/graphql/library.graphql" in readme
+    assert "--graphql-endpoint /api/graphql" in readme
+    assert "graphql-attacks.json" in readme
     assert "examples/workflow_packs/listed_pet_lookup.py" in readme
+    assert "stronger built-in auth acquisition and refresh flows" in readme
+    assert "deeper GraphQL response validation" in readme
 
 
 def test_dev_environment_workflow_matches_current_cli_surface() -> None:
@@ -44,6 +51,8 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "--path /draft-orders/{draftId}" in workflow
     assert "--auto-workflows" in workflow
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in workflow
+    assert "examples/graphql/library.graphql" in workflow
+    assert "--graphql-endpoint /graphql" in workflow
     assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in workflow
     assert "--profile anonymous" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
@@ -72,7 +81,9 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Optional: checked-in suppressions" in ci_doc
     assert "Optional: multi-profile authorization runs" in ci_doc
     assert "Optional: HTML report and artifact index" in ci_doc
+    assert "Optional: GraphQL schemas" in ci_doc
     assert "examples/auth_profiles/anonymous-user-admin.yml" in ci_doc
+    assert "examples/graphql/library.graphql" in ci_doc
     assert "knives-out triage results.json --out .knives-out-ignore.yml" in ci_doc
     assert ".knives-out-ignore.yml" in ci_doc
     assert "--baseline previous-results.json" in ci_doc
@@ -97,3 +108,21 @@ def test_sync_wiki_workflow_uses_dedicated_secret_and_sync_script() -> None:
     assert "WIKI_PUSH_TOKEN" in workflow
     assert "python scripts/sync_wiki.py publish" in workflow
     assert "github.repository }}.wiki.git" in workflow
+
+
+def test_roadmap_and_architecture_describe_next_milestones() -> None:
+    roadmap = ROADMAP_DOC.read_text(encoding="utf-8")
+    architecture = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+
+    assert "## Recently completed" in roadmap
+    assert "v0.8: GraphQL support" in roadmap
+    assert "## Next planning pass" in roadmap
+    assert "built-in auth acquisition and refresh flows" in roadmap
+    assert "GraphQL response validation" in roadmap
+    assert "LLM application and tool-misuse testing" in roadmap
+
+    assert "graphql_loader.py" in architecture
+    assert "spec_loader.py" in architecture
+    assert "GraphQL SDL or introspection JSON" in architecture
+    assert "200` response with an `errors` array" in architecture
+    assert "redirect-driven OAuth auth-code flows" in architecture

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,13 +5,14 @@ from pathlib import Path
 from knives_out.attack_packs import load_module_attack_packs
 from knives_out.auth_plugins import load_module_auth_plugins
 from knives_out.generator import generate_attack_suite
-from knives_out.openapi_loader import load_operations
 from knives_out.profiles import load_auth_profiles
+from knives_out.spec_loader import load_operations
 from knives_out.workflow_packs import load_module_workflow_packs
 
 ROOT = Path(__file__).resolve().parents[1]
 PETSTORE_SPEC = ROOT / "examples" / "openapi" / "petstore.yaml"
 STOREFRONT_SPEC = ROOT / "examples" / "openapi" / "storefront.yaml"
+GRAPHQL_SPEC = ROOT / "examples" / "graphql" / "library.graphql"
 ATTACK_PACK_MODULE = ROOT / "examples" / "custom_packs" / "unexpected_header.py"
 WORKFLOW_PACK_MODULE = ROOT / "examples" / "workflow_packs" / "listed_pet_lookup.py"
 AUTH_PLUGIN_MODULE = ROOT / "examples" / "auth_plugins" / "login_bearer.py"
@@ -22,6 +23,17 @@ def test_checked_in_openapi_examples_load() -> None:
     for spec in (PETSTORE_SPEC, STOREFRONT_SPEC):
         operations = load_operations(spec)
         assert operations
+
+
+def test_checked_in_graphql_example_loads() -> None:
+    operations = load_operations(GRAPHQL_SPEC)
+
+    assert {operation.operation_id for operation in operations} == {
+        "book",
+        "books",
+        "createBook",
+        "rateBook",
+    }
 
 
 def test_storefront_example_emits_workflows_and_schema_mutations() -> None:
@@ -37,6 +49,16 @@ def test_storefront_example_emits_workflows_and_schema_mutations() -> None:
         attack.type == "workflow" and attack.operation_id == "getDraftOrder"
         for attack in suite.attacks
     )
+
+
+def test_graphql_example_emits_graphql_variable_attacks() -> None:
+    suite = generate_attack_suite(
+        load_operations(GRAPHQL_SPEC),
+        source=str(GRAPHQL_SPEC),
+    )
+
+    assert any(attack.kind == "wrong_type_variable" for attack in suite.attacks)
+    assert any(attack.kind == "missing_required_variable" for attack in suite.attacks)
 
 
 def test_checked_in_example_modules_load() -> None:

--- a/tests/test_graphql_generator.py
+++ b/tests/test_graphql_generator.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from knives_out.generator import generate_attack_suite
+from knives_out.spec_loader import load_operations
+
+GRAPHQL_SPEC = Path(__file__).resolve().parents[1] / "examples" / "graphql" / "library.graphql"
+
+
+def test_generate_graphql_attack_suite_emits_variable_mutations() -> None:
+    suite = generate_attack_suite(
+        load_operations(GRAPHQL_SPEC),
+        source=str(GRAPHQL_SPEC),
+    )
+
+    create_book_attacks = [
+        attack for attack in suite.attacks if attack.operation_id == "createBook"
+    ]
+    kinds = {attack.kind for attack in create_book_attacks}
+
+    assert "missing_request_body" in kinds
+    assert "malformed_json_body" in kinds
+    assert "wrong_type_variable" in kinds
+    assert "missing_required_variable" in kinds
+    assert "invalid_enum" in kinds
+
+    wrong_type_attack = next(
+        attack for attack in create_book_attacks if attack.kind == "wrong_type_variable"
+    )
+    assert wrong_type_attack.path == "/graphql"
+    assert wrong_type_attack.expected_outcomes == ["graphql_error", "4xx"]
+    assert wrong_type_attack.body_json["query"].startswith("mutation CreateBook")
+    assert "variables" in wrong_type_attack.body_json

--- a/tests/test_graphql_loader.py
+++ b/tests/test_graphql_loader.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+
+from graphql import build_schema
+from graphql.utilities import introspection_from_schema
+
+from knives_out.graphql_loader import load_graphql_operations
+from knives_out.spec_loader import is_graphql_schema_path, load_operations_with_warnings
+
+
+def _graphql_schema_text() -> str:
+    return dedent(
+        """
+        type Query {
+          book(id: ID!): Book
+          books(limit: Int, genre: Genre): [Book!]!
+        }
+
+        type Mutation {
+          createBook(input: CreateBookInput!): Book!
+        }
+
+        type Book {
+          id: ID!
+          title: String!
+          genre: Genre!
+        }
+
+        input CreateBookInput {
+          title: String!
+          genre: Genre!
+          rating: Int
+        }
+
+        enum Genre {
+          FICTION
+          NONFICTION
+        }
+        """
+    ).strip()
+
+
+def test_load_graphql_operations_from_sdl(tmp_path) -> None:
+    schema_path = tmp_path / "library.graphql"
+    schema_path.write_text(_graphql_schema_text(), encoding="utf-8")
+
+    operations = load_graphql_operations(schema_path, endpoint="/api/graphql")
+
+    assert [operation.operation_id for operation in operations] == [
+        "book",
+        "books",
+        "createBook",
+    ]
+
+    book = operations[0]
+    assert book.protocol == "graphql"
+    assert book.graphql_operation_type == "query"
+    assert book.method == "POST"
+    assert book.path == "/api/graphql"
+    assert book.tags == ["graphql", "query"]
+    assert book.graphql_document == "query Book($id: ID!) { book(id: $id) { __typename } }"
+    assert book.graphql_variables_schema == {
+        "type": "object",
+        "properties": {"id": {"type": "string"}},
+        "required": ["id"],
+    }
+
+    create_book = operations[-1]
+    assert create_book.graphql_operation_type == "mutation"
+    assert create_book.graphql_variables_schema == {
+        "type": "object",
+        "properties": {
+            "input": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "genre": {"type": "string", "enum": ["FICTION", "NONFICTION"]},
+                    "rating": {"type": "integer"},
+                },
+                "required": ["title", "genre"],
+            }
+        },
+        "required": ["input"],
+    }
+
+
+def test_spec_loader_detects_graphql_introspection_json(tmp_path) -> None:
+    schema = build_schema(_graphql_schema_text())
+    introspection_path = tmp_path / "library-introspection.json"
+    introspection_path.write_text(
+        json.dumps({"data": introspection_from_schema(schema)}),
+        encoding="utf-8",
+    )
+
+    loaded = load_operations_with_warnings(introspection_path)
+
+    assert is_graphql_schema_path(introspection_path) is True
+    assert loaded.warnings == []
+    assert {operation.operation_id for operation in loaded.operations} == {
+        "book",
+        "books",
+        "createBook",
+    }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1117,6 +1117,72 @@ def test_execute_attack_suite_requires_json_for_setup_extractions(monkeypatch) -
     assert "response body was not JSON" in (result.error or "")
 
 
+def test_execute_attack_suite_treats_graphql_errors_as_expected_failures(monkeypatch) -> None:
+    _install_stub_response(monkeypatch, httpx.Response(200, json={"errors": [{"message": "bad"}]}))
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_graphql_error",
+                    name="Wrong-type GraphQL variable",
+                    kind="wrong_type_variable",
+                    operation_id="book",
+                    method="POST",
+                    path="/graphql",
+                    description="Wrong type for GraphQL variable.",
+                    body_json={
+                        "query": "query Book($id: ID!) { book(id: $id) { __typename } }",
+                        "variables": {"id": 123},
+                    },
+                    expected_outcomes=["graphql_error", "4xx"],
+                )
+            ],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert result.issue is None
+    assert result.status_code == 200
+
+
+def test_execute_attack_suite_flags_graphql_success_without_errors(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(200, json={"data": {"book": {"__typename": "Book"}}}),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_graphql_success",
+                    name="Wrong-type GraphQL variable",
+                    kind="wrong_type_variable",
+                    operation_id="book",
+                    method="POST",
+                    path="/graphql",
+                    description="Wrong type for GraphQL variable.",
+                    body_json={
+                        "query": "query Book($id: ID!) { book(id: $id) { __typename } }",
+                        "variables": {"id": 123},
+                    },
+                    expected_outcomes=["graphql_error", "4xx"],
+                )
+            ],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "unexpected_success"
+
+
 def test_render_markdown_report_shows_workflow_sections() -> None:
     results = AttackResults(
         source="unit",


### PR DESCRIPTION
## Summary
- add GraphQL SDL and introspection loading with auto-detection for inspect and generate
- generate replayable GraphQL variable-coercion attacks and treat `200 + errors[]` as expected validation failures at runtime
- add a checked-in GraphQL example plus docs and coverage for the shared inspect/generate/run/report flow

## Testing
- `python3 -m ruff check src/knives_out/models.py src/knives_out/graphql_loader.py src/knives_out/spec_loader.py src/knives_out/cli.py src/knives_out/generator.py src/knives_out/runner.py tests/test_graphql_loader.py tests/test_graphql_generator.py tests/test_runner.py tests/test_cli.py tests/test_examples.py tests/test_docs.py`
- `python3 -m ruff format --check src/knives_out/models.py src/knives_out/graphql_loader.py src/knives_out/spec_loader.py src/knives_out/cli.py src/knives_out/generator.py src/knives_out/runner.py tests/test_graphql_loader.py tests/test_graphql_generator.py tests/test_runner.py tests/test_cli.py tests/test_examples.py tests/test_docs.py`
- `python3 -m pytest -q tests/test_docs.py`
- full `pytest` unavailable in this host Python 3.9 environment because project dependencies like `typer`, `httpx`, and `graphql-core` are not installed; rely on GitHub Actions for full validation