### PR TITLE
[codex] Refresh next milestone roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,13 +625,11 @@ knives-out run attacks.json \
 
 ## Roadmap
 
-The previously planned adoption and GraphQL milestones are now shipped. The next planning pass is
-intentionally still open so the roadmap can reflect real usage instead of guessing too early.
+The next two milestones are:
 
-Right now the likely themes are:
+- **v0.9:** first-class auth and session realism through built-in OAuth and session profile config
+- **v0.10:** deeper GraphQL coverage with response validation, federation awareness, and
+  subscription support as staged scope
 
-- stronger built-in auth acquisition and refresh flows for common OAuth/session cases
-- deeper GraphQL response validation, federation awareness, and subscription coverage
-- richer CI triage ergonomics and report navigation
-
-See `docs/architecture.md` and `docs/roadmap.md` for the current planning notes.
+LLM application testing stays deferred until after that API-focused expansion. See
+`docs/architecture.md` and `docs/roadmap.md` for the detailed milestone breakdown.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,8 @@ The next milestone work should extend the current architecture in two directions
 1. first-class auth/session profile strategies for common OAuth and session-login flows
 2. clearer auth setup diagnostics in reports and CI flows
 3. protocol-aware filtering that still shares the current run/report/verify pipeline
-4. stronger GraphQL response-shape validation on top of the new protocol loader
+4. stronger GraphQL response-shape validation, federation awareness, and staged subscription
+   support on top of the new protocol loader
 
 ## Things intentionally deferred
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,35 +1,85 @@
 # Roadmap
 
-`knives-out` now ships the milestone stack that used to define the near-term roadmap:
+`knives-out` now has a strong OpenAPI and GraphQL base:
 
-- replayable REST request attacks
-- workflow attacks with shared state and extracted values
-- response-schema validation, CI verification, suppressions, and regression-suite promotion
+- replayable REST request and workflow attacks
+- schema-aware mutation generation
+- response-schema validation, suppressions, and regression-suite promotion
 - auth/session plugins and multi-profile authorization comparisons
-- HTML reporting with linked artifacts
+- Markdown and HTML reporting with linked artifacts
 - GraphQL SDL and introspection loading with replayable variable-coercion attacks
 
-That means the next roadmap should be shaped by real usage instead of the original bootstrap plan.
+That means the roadmap should now focus on making protected APIs easier to adopt in real CI flows
+and then deepening the newly added GraphQL surface.
 
 ## Recently completed
 
 - v0.5: suppressions and triage
 - v0.6: multi-profile authorization testing
 - v0.7: HTML report and artifact index
-- v0.8: GraphQL support
+- v0.8: GraphQL schema support
 
-## Next planning pass
+## v0.9 — first-class auth and session realism
 
-The next milestone set is not locked yet, but the strongest candidates are:
+**Goal:** Make common protected API flows work from profile YAML alone, without requiring custom
+Python plugins for the happy path.
 
-1. built-in auth acquisition and refresh flows for common OAuth/session patterns
-2. deeper GraphQL response validation, federation awareness, and subscription coverage
-3. richer CI and artifact navigation for large suites
-4. stronger reporting and triage ergonomics for long-lived regression programs
+### Committed scope
 
-## Still deferred
+- Add a built-in `auth` block to profile files used by `knives-out run --profile-file ...`
+- Support OAuth 2.0 `client_credentials`
+- Support trusted internal resource-owner/password flows
+- Reuse and refresh bearer tokens when a profile exposes refresh-token state
+- Support session login via HTTP `POST` form or JSON endpoints with cookie reuse
+- Acquire auth state once per profile and reuse it across request attacks and workflow attacks
+- Surface auth setup and acquisition failures distinctly in reports without breaking `verify`,
+  `promote`, suppressions, or HTML reporting
+- Keep the current plugin/module path fully supported as the escape hatch for nonstandard auth
 
-These remain interesting, but they should not displace the next planning pass:
+### Acceptance criteria
+
+- A team can run one suite across named profiles that use built-in OAuth/session config only
+- Token refresh and cookie reuse work across normal request attacks and workflow attacks
+- Auth acquisition failures are visible and actionable without being misclassified as API findings
+- Existing plugin-based runs and static header/query runs remain backward compatible
+
+### Explicitly out of scope
+
+- browser automation
+- redirect-driven OAuth auth-code login
+
+## v0.10 — deeper GraphQL coverage
+
+**Goal:** Extend the existing GraphQL support from schema loading and coercion attacks into fuller
+execution and review coverage while preserving the current replayable artifact model.
+
+### Committed core
+
+- Strengthen GraphQL response validation and result classification for `data` plus `errors`
+  payloads
+- Preserve report, verify, promote, triage, suppression, and HTML-report parity for GraphQL suites
+- Keep the same auth profiles and session machinery used by REST runs
+- Improve filtering around GraphQL operation names and root fields
+- Add federation-aware schema loading for subgraph or supergraph inputs where the schema source is
+  still a checked-in artifact
+
+### Stretch track
+
+- staged subscription coverage with a deliberately limited initial transport
+- higher-order attack packs such as fragment or alias amplification
+- persisted-query misuse coverage once the base path is stable
+
+### Acceptance criteria
+
+- A team can check in SDL or introspection JSON, generate a replayable GraphQL suite, run it, and
+  review findings with the current report/verify flow
+- GraphQL runs support the same auth profiles and suppressions model as REST runs
+- Federation-aware loading lands behind the same artifact model rather than a separate workflow
+- Subscriptions remain stretch scope and are not required to complete the milestone
+
+## Deferred beyond v0.10
+
+These remain interesting, but they should not displace the next two milestones:
 
 - browser-assisted login and redirect-driven OAuth flows
 - gRPC support

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -35,8 +35,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert "--graphql-endpoint /api/graphql" in readme
     assert "graphql-attacks.json" in readme
     assert "examples/workflow_packs/listed_pet_lookup.py" in readme
-    assert "stronger built-in auth acquisition and refresh flows" in readme
-    assert "deeper GraphQL response validation" in readme
+    assert "**v0.9:** first-class auth and session realism" in readme
+    assert "**v0.10:** deeper GraphQL coverage" in readme
 
 
 def test_dev_environment_workflow_matches_current_cli_surface() -> None:
@@ -115,14 +115,17 @@ def test_roadmap_and_architecture_describe_next_milestones() -> None:
     architecture = ARCHITECTURE_DOC.read_text(encoding="utf-8")
 
     assert "## Recently completed" in roadmap
-    assert "v0.8: GraphQL support" in roadmap
-    assert "## Next planning pass" in roadmap
-    assert "built-in auth acquisition and refresh flows" in roadmap
-    assert "GraphQL response validation" in roadmap
+    assert "v0.8: GraphQL schema support" in roadmap
+    assert "## v0.9 — first-class auth and session realism" in roadmap
+    assert "client_credentials" in roadmap
+    assert "## v0.10 — deeper GraphQL coverage" in roadmap
+    assert "subscription coverage" in roadmap
     assert "LLM application and tool-misuse testing" in roadmap
 
     assert "graphql_loader.py" in architecture
     assert "spec_loader.py" in architecture
     assert "GraphQL SDL or introspection JSON" in architecture
     assert "200` response with an `errors` array" in architecture
+    assert "first-class auth/session profile strategies" in architecture
+    assert "GraphQL response-shape validation, federation awareness" in architecture
     assert "redirect-driven OAuth auth-code flows" in architecture


### PR DESCRIPTION
## Summary
- refresh the roadmap to match what is already shipped on main
- define the next two milestones as built-in auth/session realism and deeper GraphQL coverage
- align the README, architecture doc, and doc tests with the updated milestone direction

## Testing
- python3 -m ruff check tests/test_docs.py
- python3 -m pytest tests/test_docs.py tests/test_sync_wiki.py
- python3 scripts/sync_wiki.py render --out-dir /tmp/knives-out-wiki-render