### PR TITLE
[codex] Add built-in auth acquisition flows

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -48,6 +48,11 @@ jobs:
           KNIVES_OUT_BASE_URL: ${{ secrets.KNIVES_OUT_BASE_URL }}
           KNIVES_OUT_AUTH_HEADER: ${{ secrets.KNIVES_OUT_AUTH_HEADER }}
           KNIVES_OUT_AUTH_QUERY: ${{ secrets.KNIVES_OUT_AUTH_QUERY }}
+          KNIVES_OUT_USER_TOKEN: ${{ secrets.KNIVES_OUT_USER_TOKEN }}
+          KNIVES_OUT_ADMIN_TOKEN: ${{ secrets.KNIVES_OUT_ADMIN_TOKEN }}
+          KNIVES_OUT_CLIENT_ID: ${{ secrets.KNIVES_OUT_CLIENT_ID }}
+          KNIVES_OUT_CLIENT_SECRET: ${{ secrets.KNIVES_OUT_CLIENT_SECRET }}
+          KNIVES_OUT_CLIENT_AUDIENCE: ${{ secrets.KNIVES_OUT_CLIENT_AUDIENCE }}
           KNIVES_OUT_LOGIN_USERNAME: ${{ secrets.KNIVES_OUT_LOGIN_USERNAME }}
           KNIVES_OUT_LOGIN_PASSWORD: ${{ secrets.KNIVES_OUT_LOGIN_PASSWORD }}
         run: |
@@ -71,6 +76,14 @@ jobs:
             args+=(--query "${KNIVES_OUT_AUTH_QUERY}")
           fi
 
+          # For built-in bearer or session flows, use a checked-in auth config:
+          # args+=(--auth-config examples/auth_configs/client-credentials.yml)
+          # Or execute the checked-in named user/admin configs:
+          # args+=(
+          #   --auth-config examples/auth_configs/user-admin.yml
+          #   --auth-profile user
+          #   --auth-profile admin
+          # )
           # For login/session auth, load a plugin module instead of static header/query credentials:
           # args+=(--auth-plugin-module examples/auth_plugins/login_bearer.py)
           # For identity-aware authorization coverage, use a checked-in profile file instead:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Given an OpenAPI or GraphQL schema, `knives-out` can:
 - generate schema-aware mutation attacks from declared constraints
 - optionally chain setup requests into replayable workflow attacks
 - generate GraphQL query and mutation attacks from SDL or introspection output
+- load built-in auth configs for common bearer-token and session-cookie flows
 - load auth/session plugins for bearer tokens, login flows, and shared sessions
 - execute the same suite across named auth profiles and compare their outcomes
 - run those attacks against a live base URL
@@ -124,7 +125,17 @@ knives-out run attacks.json \
   --out results.json
 ```
 
-Or load an auth/session plugin when static headers are not enough:
+Or use a built-in auth config when static headers are not enough:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-config examples/auth_configs/user-admin.yml \
+  --auth-profile user \
+  --out results.json
+```
+
+Or move up to a custom plugin when the built-in config strategies are not enough:
 
 ```bash
 knives-out run attacks.json \
@@ -191,6 +202,9 @@ It uses repository secrets instead of hard-coded targets:
 - `KNIVES_OUT_BASE_URL` for the dev or staging base URL
 - `KNIVES_OUT_AUTH_HEADER` for an optional header like `Authorization: Bearer ...`
 - `KNIVES_OUT_AUTH_QUERY` for an optional query credential like `api_key=...`
+- `KNIVES_OUT_USER_TOKEN` / `KNIVES_OUT_ADMIN_TOKEN` when you use `examples/auth_configs/user-admin.yml`
+- `KNIVES_OUT_CLIENT_ID` / `KNIVES_OUT_CLIENT_SECRET` / `KNIVES_OUT_CLIENT_AUDIENCE` when you use
+  `examples/auth_configs/client-credentials.yml`
 - plugin-specific login or bearer env vars when you use `--auth-plugin` or `--auth-plugin-module`
 
 `knives-out run` currently exits with status `0` when the suite executes successfully, even if
@@ -205,8 +219,10 @@ When you want stateful coverage, generate with `--auto-workflows` first, then ad
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
 you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
 credentials on `--header` or `--query`, or move up to
-`--auth-plugin-module examples/auth_plugins/login_bearer.py` for login/session flows. When you want
-to keep only the highest-signal regressions around, follow `verify` with
+`--auth-config examples/auth_configs/user-admin.yml` or
+`--auth-config examples/auth_configs/client-credentials.yml` for common bearer/session flows.
+Custom logic can still use `--auth-plugin-module examples/auth_plugins/login_bearer.py`. When you
+want to keep only the highest-signal regressions around, follow `verify` with
 `knives-out promote results.json --attacks attacks.json`. See `docs/ci.md` for the sample
 workflow, secret setup, filtering patterns, baseline-aware CI flows, and checked-in suppressions.
 GraphQL schemas follow the same `inspect` / `generate` / `run` / `report` / `verify` flow, with
@@ -310,7 +326,16 @@ knives-out run attacks.json \
   --out results.json
 ```
 
-You can also load auth/session plugins from entry points or local modules:
+You can also use a built-in auth config for common bearer/session flows:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-config examples/auth_configs/client-credentials.yml \
+  --out results.json
+```
+
+Or load a custom auth/session plugin from entry points or local modules:
 
 ```bash
 knives-out run attacks.json \
@@ -332,9 +357,10 @@ knives-out run attacks.json \
 ```
 
 Each profile can contribute its own headers, query params, entry-point plugins, or local
-`auth_plugin_modules`. Multi-profile runs aggregate per-profile outcomes into one `results.json`
-and add auth comparison findings such as `anonymous_access` and `authorization_inversion` when
-those differences are strong enough to infer safely.
+`auth_plugin_modules`, and can optionally reference a named built-in auth config with
+`auth_config`. Multi-profile runs aggregate per-profile outcomes into one `results.json` and add
+auth comparison findings such as `anonymous_access` and `authorization_inversion` when those
+differences are strong enough to infer safely.
 
 Run-time filters match the same exact tag/path semantics:
 
@@ -578,6 +604,46 @@ knives-out generate examples/openapi/petstore.yaml \
   --out attacks.json
 ```
 
+## Built-in auth configs
+
+Built-in auth configs cover the common cases where you want realistic auth without writing Python.
+
+Supported strategies:
+
+- `static_bearer`
+- `client_credentials`
+- `password_json`
+- `login_json_bearer`
+- `login_form_cookie`
+
+The repo includes checked-in examples at:
+
+- `examples/auth_configs/user-admin.yml`
+- `examples/auth_configs/client-credentials.yml`
+
+Single-profile example:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-config examples/auth_configs/client-credentials.yml \
+  --out results.json
+```
+
+Named auth-config profiles:
+
+```bash
+knives-out run attacks.json \
+  --base-url http://localhost:8000 \
+  --auth-config examples/auth_configs/user-admin.yml \
+  --auth-profile user \
+  --auth-profile admin \
+  --out results.json
+```
+
+Built-in auth events are recorded in `results.json` and rendered separately in reports, so auth
+bootstrap or refresh failures do not masquerade as attack findings.
+
 ## Auth/session plugins
 
 Auth/session plugins run at execution time and can mutate outgoing requests or establish shared
@@ -625,11 +691,11 @@ knives-out run attacks.json \
 
 ## Roadmap
 
-The next two milestones are:
+The built-in auth/config milestone is now shipped. The next likely milestone is:
 
-- **v0.9:** first-class auth and session realism through built-in OAuth and session profile config
 - **v0.10:** deeper GraphQL coverage with response validation, federation awareness, and
   subscription support as staged scope
 
+After that, the likely follow-on is richer CI and report navigation for large regression programs.
 LLM application testing stays deferred until after that API-focused expansion. See
-`docs/architecture.md` and `docs/roadmap.md` for the detailed milestone breakdown.
+`docs/architecture.md` and `docs/roadmap.md` for the current milestone notes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,8 @@ src/knives_out/
   generator.py       # Request and workflow attack generation
   filtering.py       # Tag and path filtering helpers
   runner.py          # HTTP execution, workflows, profiles, and auth runtime
+  auth_config.py     # Built-in auth config loading and profile helpers
+  builtin_auth.py    # Built-in bearer/session acquisition and refresh runtime
   auth_plugins.py    # Auth/session plugin helpers
   profiles.py        # Multi-profile loading and comparison inputs
   reporting.py       # Markdown and HTML report rendering
@@ -51,14 +53,15 @@ That JSON should become the contract between future generators and future runner
 ### 3. Execute suite
 
 `runner.py` executes the saved suite against a concrete base URL. Runtime auth, query values,
-profile-specific defaults, and workflow state are merged at this phase rather than baked into
-generation. For GraphQL attacks, a `200` response with an `errors` array is treated as an
-expected validation failure instead of an unexpected success.
+profile-specific defaults, built-in auth acquisition/refresh, and workflow state are merged at
+this phase rather than baked into generation. For GraphQL attacks, a `200` response with an `errors`
+array is treated as an expected validation failure instead of an unexpected success.
 
 ### 4. Report findings
 
 `reporting.py` reduces the results into Markdown or HTML. `verification.py`, `promotion.py`, and
-`suppressions.py` then build CI and triage workflows on the same result model.
+`suppressions.py` then build CI and triage workflows on the same result model, while auth setup
+and refresh diagnostics stay visible without becoming attack findings by themselves.
 
 Today, a result is typically flagged when it produces:
 
@@ -84,11 +87,11 @@ It gives the project:
 
 The next milestone work should extend the current architecture in two directions:
 
-1. first-class auth/session profile strategies for common OAuth and session-login flows
-2. clearer auth setup diagnostics in reports and CI flows
-3. protocol-aware filtering that still shares the current run/report/verify pipeline
-4. stronger GraphQL response-shape validation, federation awareness, and staged subscription
-   support on top of the new protocol loader
+1. stronger GraphQL response-shape validation, federation awareness, and staged subscription
+   support on top of the protocol loader
+2. clearer CI and artifact navigation for large regression suites
+3. richer report ergonomics around suppressions, baselines, and auth diagnostics
+4. browser-free auth acquisition can keep expanding, but redirect-driven OAuth stays out of scope
 
 ## Things intentionally deferred
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,6 +25,11 @@ Optional secrets:
 
 - `KNIVES_OUT_AUTH_HEADER`
 - `KNIVES_OUT_AUTH_QUERY`
+- `KNIVES_OUT_USER_TOKEN`
+- `KNIVES_OUT_ADMIN_TOKEN`
+- `KNIVES_OUT_CLIENT_ID`
+- `KNIVES_OUT_CLIENT_SECRET`
+- `KNIVES_OUT_CLIENT_AUDIENCE`
 - plugin-specific login or bearer env vars if you use an auth plugin module
 
 The optional values should match the current CLI surface:
@@ -32,9 +37,10 @@ The optional values should match the current CLI surface:
 - `KNIVES_OUT_AUTH_HEADER`: `Authorization: Bearer dev-token`
 - `KNIVES_OUT_AUTH_QUERY`: `api_key=dev-secret`
 
-For static credentials, `--header` and `--query` are still the simplest fit. Use auth/session
-plugins when your CI flow needs to log in, fetch a bearer token, or establish a shared session
-before the suite or each workflow runs.
+For static credentials, `--header` and `--query` are still the simplest fit. For common auth
+flows, prefer `--auth-config examples/auth_configs/user-admin.yml` or
+`--auth-config examples/auth_configs/client-credentials.yml`. Use auth/session plugins when your
+CI flow needs custom logic beyond the built-in bearer and session-cookie strategies.
 
 If you want identity-aware authorization coverage, the repo also includes
 `examples/auth_profiles/anonymous-user-admin.yml` as a starter profile file.
@@ -211,6 +217,39 @@ The same exact-match filters work in `inspect`, `generate`, and `run`:
 ```
 
 ## Optional: auth/session plugins
+
+For many protected APIs, a built-in auth config is enough:
+
+```yaml
+- name: Run suite with built-in auth config
+  run: |
+    knives-out run attacks.json \
+      --base-url "${KNIVES_OUT_BASE_URL}" \
+      --auth-config examples/auth_configs/client-credentials.yml \
+      --artifact-dir artifacts \
+      --out results.json
+```
+
+Or execute checked-in named auth configs as profiles:
+
+```yaml
+- name: Run suite across built-in user and admin auth configs
+  run: |
+    knives-out run attacks.json \
+      --base-url "${KNIVES_OUT_BASE_URL}" \
+      --auth-config examples/auth_configs/user-admin.yml \
+      --auth-profile user \
+      --auth-profile admin \
+      --artifact-dir artifacts \
+      --out results.json
+```
+
+Built-in auth config examples live at:
+
+- `examples/auth_configs/user-admin.yml`
+- `examples/auth_configs/client-credentials.yml`
+
+If your target needs custom Python logic instead, fall back to plugins:
 
 For login or shared-session flows, load a local auth plugin module during `run`:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,16 +1,16 @@
 # Roadmap
 
-`knives-out` now has a strong OpenAPI and GraphQL base:
+`knives-out` now ships the milestone stack that used to define the near-term roadmap:
 
-- replayable REST request and workflow attacks
-- schema-aware mutation generation
-- response-schema validation, suppressions, and regression-suite promotion
-- auth/session plugins and multi-profile authorization comparisons
-- Markdown and HTML reporting with linked artifacts
+- replayable REST request attacks
+- workflow attacks with shared state and extracted values
+- response-schema validation, CI verification, suppressions, and regression-suite promotion
+- auth/session plugins, multi-profile authorization comparisons, and built-in auth acquisition
+- HTML reporting with linked artifacts
 - GraphQL SDL and introspection loading with replayable variable-coercion attacks
 
-That means the roadmap should now focus on making protected APIs easier to adopt in real CI flows
-and then deepening the newly added GraphQL surface.
+That means the next roadmap should keep following real usage instead of the original bootstrap
+guesswork.
 
 ## Recently completed
 
@@ -18,70 +18,34 @@ and then deepening the newly added GraphQL surface.
 - v0.6: multi-profile authorization testing
 - v0.7: HTML report and artifact index
 - v0.8: GraphQL schema support
-
-## v0.9 — first-class auth and session realism
-
-**Goal:** Make common protected API flows work from profile YAML alone, without requiring custom
-Python plugins for the happy path.
-
-### Committed scope
-
-- Add a built-in `auth` block to profile files used by `knives-out run --profile-file ...`
-- Support OAuth 2.0 `client_credentials`
-- Support trusted internal resource-owner/password flows
-- Reuse and refresh bearer tokens when a profile exposes refresh-token state
-- Support session login via HTTP `POST` form or JSON endpoints with cookie reuse
-- Acquire auth state once per profile and reuse it across request attacks and workflow attacks
-- Surface auth setup and acquisition failures distinctly in reports without breaking `verify`,
-  `promote`, suppressions, or HTML reporting
-- Keep the current plugin/module path fully supported as the escape hatch for nonstandard auth
-
-### Acceptance criteria
-
-- A team can run one suite across named profiles that use built-in OAuth/session config only
-- Token refresh and cookie reuse work across normal request attacks and workflow attacks
-- Auth acquisition failures are visible and actionable without being misclassified as API findings
-- Existing plugin-based runs and static header/query runs remain backward compatible
-
-### Explicitly out of scope
-
-- browser automation
-- redirect-driven OAuth auth-code login
+- v0.9: built-in auth acquisition and refresh flows
+  - shipped strategies include `static_bearer`, `client_credentials`, `password_json`,
+    `login_json_bearer`, and `login_form_cookie`
 
 ## v0.10 — deeper GraphQL coverage
 
-**Goal:** Extend the existing GraphQL support from schema loading and coercion attacks into fuller
-execution and review coverage while preserving the current replayable artifact model.
+The next likely milestone is a GraphQL-focused expansion on top of the loader and runner we now
+have. The strongest targets are:
 
-### Committed core
+- response-shape validation against declared GraphQL result structure
+- federation awareness and clearer subgraph-related diagnostics
+- staged subscription coverage that still fits the current generate/run/report pipeline
+- better protocol-aware reporting for mixed OpenAPI and GraphQL programs
 
-- Strengthen GraphQL response validation and result classification for `data` plus `errors`
-  payloads
-- Preserve report, verify, promote, triage, suppression, and HTML-report parity for GraphQL suites
-- Keep the same auth profiles and session machinery used by REST runs
-- Improve filtering around GraphQL operation names and root fields
-- Add federation-aware schema loading for subgraph or supergraph inputs where the schema source is
-  still a checked-in artifact
+## v0.11 — richer CI and triage ergonomics
 
-### Stretch track
+After the GraphQL pass, the next best leverage point is day-to-day review ergonomics:
 
-- staged subscription coverage with a deliberately limited initial transport
-- higher-order attack packs such as fragment or alias amplification
-- persisted-query misuse coverage once the base path is stable
+- stronger artifact navigation for large suites
+- better suppression and baseline review flows
+- clearer auth diagnostic summaries in HTML and Markdown reports
+- smaller, higher-signal CI summaries for long-lived regression programs
 
-### Acceptance criteria
+## Still deferred
 
-- A team can check in SDL or introspection JSON, generate a replayable GraphQL suite, run it, and
-  review findings with the current report/verify flow
-- GraphQL runs support the same auth profiles and suppressions model as REST runs
-- Federation-aware loading lands behind the same artifact model rather than a separate workflow
-- Subscriptions remain stretch scope and are not required to complete the milestone
+These remain interesting, but they should not displace the next planning pass:
 
-## Deferred beyond v0.10
-
-These remain interesting, but they should not displace the next two milestones:
-
-- browser-assisted login and redirect-driven OAuth flows
+- browser-assisted login and redirect-driven OAuth auth-code flows
 - gRPC support
 - LLM application and tool-misuse testing
 - distributed fuzzing or large-scale orchestration

--- a/examples/auth_configs/client-credentials.yml
+++ b/examples/auth_configs/client-credentials.yml
@@ -1,0 +1,12 @@
+auth:
+  - name: service
+    strategy: client_credentials
+    description: Service-to-service OAuth client credentials flow.
+    endpoint: /oauth/token
+    request_form:
+      grant_type: client_credentials
+      client_id: "{{env.KNIVES_OUT_CLIENT_ID}}"
+      client_secret: "{{env.KNIVES_OUT_CLIENT_SECRET}}"
+      audience: "{{env.KNIVES_OUT_CLIENT_AUDIENCE}}"
+    token_pointer: /access_token
+    expires_in_pointer: /expires_in

--- a/examples/auth_configs/user-admin.yml
+++ b/examples/auth_configs/user-admin.yml
@@ -1,0 +1,14 @@
+auth:
+  - name: user
+    strategy: static_bearer
+    description: Typical authenticated user traffic with a bearer token from CI secrets.
+    level: 10
+    token: "{{env.KNIVES_OUT_USER_TOKEN}}"
+
+  - name: admin
+    strategy: static_bearer
+    description: Higher-trust admin traffic with an audit header.
+    level: 20
+    headers:
+      X-Audit: "1"
+    token: "{{env.KNIVES_OUT_ADMIN_TOKEN}}"

--- a/src/knives_out/auth_config.py
+++ b/src/knives_out/auth_config.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+from knives_out.models import AuthProfile
+
+AuthStrategy = Literal[
+    "static_bearer",
+    "client_credentials",
+    "password_json",
+    "login_json_bearer",
+    "login_form_cookie",
+]
+
+
+class BuiltInAuthConfig(BaseModel):
+    name: str
+    strategy: AuthStrategy
+    description: str | None = None
+    level: int = 0
+    anonymous: bool = False
+    headers: dict[str, str] = Field(default_factory=dict)
+    query: dict[str, Any] = Field(default_factory=dict)
+    header_name: str | None = "Authorization"
+    header_scheme: str | None = "Bearer"
+    query_name: str | None = None
+    token: str | None = None
+    endpoint: str | None = None
+    method: str = "POST"
+    request_headers: dict[str, str] = Field(default_factory=dict)
+    request_query: dict[str, Any] = Field(default_factory=dict)
+    request_json: Any | None = None
+    request_form: dict[str, Any] = Field(default_factory=dict)
+    token_pointer: str | None = None
+    expires_in_pointer: str | None = None
+    refresh_on_401: bool = True
+    refresh_window_seconds: int = 30
+    expected_statuses: list[str] = Field(default_factory=lambda: ["2xx"])
+
+    @model_validator(mode="after")
+    def _validate_strategy_requirements(self) -> BuiltInAuthConfig:
+        if self.request_json is not None and self.request_form:
+            raise ValueError("Use only one of 'request_json' or 'request_form'.")
+
+        if self.strategy == "static_bearer":
+            if not self.token:
+                raise ValueError("static_bearer auth requires 'token'.")
+            return self
+
+        if not self.endpoint:
+            raise ValueError(f"{self.strategy} auth requires 'endpoint'.")
+
+        if self.strategy == "login_form_cookie":
+            return self
+
+        if not self.token_pointer:
+            raise ValueError(f"{self.strategy} auth requires 'token_pointer'.")
+        return self
+
+
+class AuthConfigFile(BaseModel):
+    auth: list[BuiltInAuthConfig] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_unique_names(self) -> AuthConfigFile:
+        seen: set[str] = set()
+        for config in self.auth:
+            normalized = config.name.casefold()
+            if normalized in seen:
+                raise ValueError(f"Duplicate auth config name {config.name!r}.")
+            seen.add(normalized)
+        return self
+
+
+def load_auth_configs(path: str | Path) -> AuthConfigFile:
+    raw = Path(path).read_text(encoding="utf-8")
+    data = yaml.safe_load(raw) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Auth config file must contain a top-level mapping.")
+    try:
+        return AuthConfigFile.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def select_auth_configs(
+    auth_file: AuthConfigFile,
+    *,
+    include_names: list[str] | None = None,
+) -> list[BuiltInAuthConfig]:
+    if not include_names:
+        return list(auth_file.auth)
+
+    selected: list[BuiltInAuthConfig] = []
+    missing = list(include_names)
+    for config in auth_file.auth:
+        if config.name not in include_names:
+            continue
+        selected.append(config)
+        if config.name in missing:
+            missing.remove(config.name)
+
+    if missing:
+        raise ValueError("Unknown auth config name(s): " + ", ".join(sorted(missing)))
+    return selected
+
+
+def auth_config_map(configs: list[BuiltInAuthConfig]) -> dict[str, BuiltInAuthConfig]:
+    return {config.name: config for config in configs}
+
+
+def auth_profiles_from_configs(configs: list[BuiltInAuthConfig]) -> list[AuthProfile]:
+    return [
+        AuthProfile(
+            name=config.name,
+            level=config.level,
+            anonymous=config.anonymous,
+            description=config.description,
+            headers=dict(config.headers),
+            query=dict(config.query),
+            auth_config=config.name,
+        )
+        for config in configs
+    ]

--- a/src/knives_out/auth_plugins.py
+++ b/src/knives_out/auth_plugins.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import httpx
 
-from knives_out.models import WorkflowAttackCase
+from knives_out.models import AuthEvent, WorkflowAttackCase
 
 ENTRY_POINT_GROUP = "knives_out.auth_plugins"
 
@@ -22,6 +22,7 @@ class RuntimeContext:
     scope: str
     state: dict[str, Any] = field(default_factory=dict)
     extracted_values: dict[str, Any] = field(default_factory=dict)
+    auth_events: list[AuthEvent] = field(default_factory=list)
     workflow_id: str | None = None
     profile_name: str | None = None
     profile_level: int = 0
@@ -63,6 +64,7 @@ class RequestExecution:
     error: str | None
     duration_ms: float
     resolution_error: bool = False
+    retry_requested: bool = False
 
 
 class PluginRuntimeError(RuntimeError):

--- a/src/knives_out/builtin_auth.py
+++ b/src/knives_out/builtin_auth.py
@@ -52,6 +52,9 @@ class BuiltInAuthPlugin(RuntimePlugin):
             context.state[self._state_key] = bundle
         return bundle
 
+    def _request_key(self, request: PreparedRequest) -> str:
+        return f"{request.phase}:{request.attack_id}"
+
     def _template_values(self, bundle: dict[str, Any]) -> dict[str, Any]:
         return dict(bundle.get("values") or {})
 
@@ -244,6 +247,7 @@ class BuiltInAuthPlugin(RuntimePlugin):
             return True
         except (RuntimeError, ValueError, httpx.HTTPError) as exc:
             bundle["last_error"] = str(exc)
+            bundle["client_id"] = id(context.client)
             bundle.pop("session_ready", None)
             bundle.pop("token", None)
             bundle.pop("expires_at", None)
@@ -259,6 +263,12 @@ class BuiltInAuthPlugin(RuntimePlugin):
 
     def _ensure_ready(self, context: RuntimeContext, *, trigger: str) -> bool:
         bundle = self._bundle(context)
+        if (
+            trigger == "request"
+            and bundle.get("last_error")
+            and bundle.get("client_id") == id(context.client)
+        ):
+            return False
         if self.config.strategy == "login_form_cookie":
             if bundle.get("session_ready") and bundle.get("client_id") == id(context.client):
                 return True
@@ -278,9 +288,14 @@ class BuiltInAuthPlugin(RuntimePlugin):
         self._ensure_ready(context, trigger="workflow")
 
     def before_request(self, request: PreparedRequest, context: RuntimeContext) -> None:
+        bundle = self._bundle(context)
+        request_key = self._request_key(request)
+        if bundle.get("active_request_key") != request_key:
+            bundle["active_request_key"] = request_key
+            bundle.pop("retried_request_key", None)
         self._ensure_ready(context, trigger="request")
         if self.config.strategy != "login_form_cookie":
-            self._inject_token(request, self._bundle(context))
+            self._inject_token(request, bundle)
 
     def after_request(
         self,
@@ -288,7 +303,6 @@ class BuiltInAuthPlugin(RuntimePlugin):
         context: RuntimeContext,
         execution: RequestExecution,
     ) -> None:
-        del request
         if (
             execution.response is None
             or execution.response.status_code != 401
@@ -297,7 +311,13 @@ class BuiltInAuthPlugin(RuntimePlugin):
             return
 
         bundle = self._bundle(context)
+        if bundle.get("retried_request_key") == self._request_key(request):
+            return
         if bundle.get("retry_in_progress"):
+            return
+        if bundle.get("last_error") and bundle.get("token") is None and not bundle.get(
+            "session_ready"
+        ):
             return
 
         bundle["retry_in_progress"] = True
@@ -307,6 +327,7 @@ class BuiltInAuthPlugin(RuntimePlugin):
             bundle["retry_in_progress"] = False
 
         if refreshed:
+            bundle["retried_request_key"] = self._request_key(request)
             execution.retry_requested = True
 
 

--- a/src/knives_out/builtin_auth.py
+++ b/src/knives_out/builtin_auth.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import httpx
+
+from knives_out.auth_config import BuiltInAuthConfig
+from knives_out.auth_plugins import (
+    LoadedAuthPlugin,
+    PreparedRequest,
+    RequestExecution,
+    RuntimeContext,
+    RuntimePlugin,
+    extract_json_pointer,
+    make_auth_plugin,
+)
+from knives_out.models import AuthEvent
+
+_EXACT_PLACEHOLDER = "{{"
+
+
+def _status_matches_expected(status_code: int | None, expected_statuses: list[str]) -> bool:
+    if status_code is None:
+        return False
+    for expected in expected_statuses:
+        normalized = expected.strip().lower()
+        if not normalized:
+            continue
+        if normalized.endswith("xx") and len(normalized) == 3 and normalized[0].isdigit():
+            if status_code // 100 == int(normalized[0]):
+                return True
+            continue
+        if normalized.isdigit() and status_code == int(normalized):
+            return True
+    return False
+
+
+class BuiltInAuthPlugin(RuntimePlugin):
+    def __init__(self, config: BuiltInAuthConfig) -> None:
+        self.config = config
+
+    @property
+    def _state_key(self) -> str:
+        return f"built_in_auth:{self.config.name}"
+
+    def _bundle(self, context: RuntimeContext) -> dict[str, Any]:
+        bundle = context.state.setdefault(self._state_key, {})
+        if not isinstance(bundle, dict):
+            bundle = {}
+            context.state[self._state_key] = bundle
+        return bundle
+
+    def _template_values(self, bundle: dict[str, Any]) -> dict[str, Any]:
+        return dict(bundle.get("values") or {})
+
+    def _resolve_placeholder(self, placeholder: str, values: dict[str, Any]) -> Any:
+        if placeholder.startswith("env."):
+            env_name = placeholder[4:]
+            env_value = os.environ.get(env_name)
+            if env_value is None:
+                raise RuntimeError(f"Missing environment variable {env_name!r}.")
+            return env_value
+        if placeholder not in values:
+            raise RuntimeError(f"Missing auth template value {placeholder!r}.")
+        return values[placeholder]
+
+    def _resolve_templates(self, value: Any, values: dict[str, Any]) -> Any:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.startswith(_EXACT_PLACEHOLDER) and stripped.endswith("}}"):
+                placeholder = stripped[2:-2].strip()
+                if stripped == f"{{{{{placeholder}}}}}":
+                    return self._resolve_placeholder(placeholder, values)
+
+            rendered = value
+            while "{{" in rendered and "}}" in rendered:
+                start = rendered.find("{{")
+                end = rendered.find("}}", start + 2)
+                if start == -1 or end == -1:
+                    break
+                placeholder = rendered[start + 2 : end].strip()
+                replacement = str(self._resolve_placeholder(placeholder, values))
+                rendered = rendered[:start] + replacement + rendered[end + 2 :]
+            return rendered
+        if isinstance(value, list):
+            return [self._resolve_templates(item, values) for item in value]
+        if isinstance(value, dict):
+            return {str(key): self._resolve_templates(item, values) for key, item in value.items()}
+        return value
+
+    def _record_event(
+        self,
+        context: RuntimeContext,
+        *,
+        phase: str,
+        success: bool,
+        trigger: str,
+        endpoint: str | None = None,
+        status_code: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        context.auth_events.append(
+            AuthEvent(
+                name=self.config.name,
+                strategy=self.config.strategy,
+                phase=phase,  # type: ignore[arg-type]
+                success=success,
+                profile=context.profile_name,
+                trigger=trigger,
+                endpoint=endpoint,
+                status_code=status_code,
+                error=error,
+            )
+        )
+
+    def _token_expired(self, bundle: dict[str, Any]) -> bool:
+        expires_at = bundle.get("expires_at")
+        if not isinstance(expires_at, (int, float)):
+            return False
+        return time.time() + self.config.refresh_window_seconds >= float(expires_at)
+
+    def _set_token_state(
+        self,
+        bundle: dict[str, Any],
+        *,
+        token: Any,
+        expires_in: Any | None,
+        context: RuntimeContext,
+    ) -> None:
+        bundle["token"] = token
+        values = self._template_values(bundle)
+        values["token"] = token
+        values["access_token"] = token
+        bundle["values"] = values
+        if expires_in is None:
+            bundle.pop("expires_at", None)
+        else:
+            bundle["expires_at"] = time.time() + float(expires_in)
+        bundle["client_id"] = id(context.client)
+
+    def _inject_token(self, request: PreparedRequest, bundle: dict[str, Any]) -> None:
+        token = bundle.get("token")
+        if token is None:
+            return
+        if self.config.header_name:
+            if self.config.header_scheme:
+                request.headers[self.config.header_name] = f"{self.config.header_scheme} {token}"
+            else:
+                request.headers[self.config.header_name] = str(token)
+        if self.config.query_name:
+            request.query[self.config.query_name] = token
+
+    def _auth_request_kwargs(self, bundle: dict[str, Any]) -> dict[str, Any]:
+        values = self._template_values(bundle)
+        request_headers = self._resolve_templates(self.config.request_headers, values)
+        request_query = self._resolve_templates(self.config.request_query, values)
+        request_kwargs: dict[str, Any] = {
+            "params": request_query,
+            "headers": {name: str(value) for name, value in request_headers.items()},
+        }
+        if self.config.request_json is not None:
+            request_kwargs["json"] = self._resolve_templates(self.config.request_json, values)
+        elif self.config.request_form:
+            request_kwargs["data"] = self._resolve_templates(self.config.request_form, values)
+        return request_kwargs
+
+    def _acquire(self, context: RuntimeContext, *, phase: str, trigger: str) -> bool:
+        bundle = self._bundle(context)
+        if self.config.strategy == "static_bearer":
+            try:
+                token = self._resolve_templates(self.config.token, self._template_values(bundle))
+            except RuntimeError as exc:
+                bundle["last_error"] = str(exc)
+                self._record_event(
+                    context, phase=phase, success=False, trigger=trigger, error=str(exc)
+                )
+                return False
+            self._set_token_state(bundle, token=token, expires_in=None, context=context)
+            bundle.pop("last_error", None)
+            self._record_event(context, phase=phase, success=True, trigger=trigger)
+            return True
+
+        endpoint = self.config.endpoint
+        if endpoint is None:
+            message = f"Auth config '{self.config.name}' is missing an endpoint."
+            bundle["last_error"] = message
+            self._record_event(context, phase=phase, success=False, trigger=trigger, error=message)
+            return False
+
+        url = context.build_url(endpoint)
+        try:
+            response = context.client.request(
+                self.config.method,
+                url,
+                **self._auth_request_kwargs(bundle),
+            )
+            if not _status_matches_expected(response.status_code, self.config.expected_statuses):
+                raise RuntimeError(
+                    f"Auth request returned status {response.status_code}; "
+                    f"expected one of {', '.join(self.config.expected_statuses)}."
+                )
+
+            if self.config.strategy == "login_form_cookie":
+                bundle["session_ready"] = True
+                bundle["client_id"] = id(context.client)
+                bundle.pop("last_error", None)
+                self._record_event(
+                    context,
+                    phase=phase,
+                    success=True,
+                    trigger=trigger,
+                    endpoint=endpoint,
+                    status_code=response.status_code,
+                )
+                return True
+
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise RuntimeError(f"Auth response was not valid JSON: {exc}") from exc
+
+            token_pointer = self.config.token_pointer
+            if token_pointer is None:
+                raise RuntimeError("Token-based auth config is missing token_pointer.")
+            token = extract_json_pointer(payload, token_pointer)
+            expires_in = None
+            if self.config.expires_in_pointer:
+                try:
+                    expires_in = extract_json_pointer(payload, self.config.expires_in_pointer)
+                except ValueError:
+                    expires_in = None
+            self._set_token_state(bundle, token=token, expires_in=expires_in, context=context)
+            bundle.pop("last_error", None)
+            self._record_event(
+                context,
+                phase=phase,
+                success=True,
+                trigger=trigger,
+                endpoint=endpoint,
+                status_code=response.status_code,
+            )
+            return True
+        except (RuntimeError, ValueError, httpx.HTTPError) as exc:
+            bundle["last_error"] = str(exc)
+            bundle.pop("session_ready", None)
+            bundle.pop("token", None)
+            bundle.pop("expires_at", None)
+            self._record_event(
+                context,
+                phase=phase,
+                success=False,
+                trigger=trigger,
+                endpoint=endpoint,
+                error=str(exc),
+            )
+            return False
+
+    def _ensure_ready(self, context: RuntimeContext, *, trigger: str) -> bool:
+        bundle = self._bundle(context)
+        if self.config.strategy == "login_form_cookie":
+            if bundle.get("session_ready") and bundle.get("client_id") == id(context.client):
+                return True
+            return self._acquire(context, phase="acquire", trigger=trigger)
+
+        if bundle.get("token") is None:
+            return self._acquire(context, phase="acquire", trigger=trigger)
+        if self._token_expired(bundle):
+            return self._acquire(context, phase="refresh", trigger="expiry")
+        return True
+
+    def before_suite(self, context: RuntimeContext) -> None:
+        self._ensure_ready(context, trigger="suite")
+
+    def before_workflow(self, workflow, context: RuntimeContext) -> None:
+        del workflow
+        self._ensure_ready(context, trigger="workflow")
+
+    def before_request(self, request: PreparedRequest, context: RuntimeContext) -> None:
+        self._ensure_ready(context, trigger="request")
+        if self.config.strategy != "login_form_cookie":
+            self._inject_token(request, self._bundle(context))
+
+    def after_request(
+        self,
+        request: PreparedRequest,
+        context: RuntimeContext,
+        execution: RequestExecution,
+    ) -> None:
+        del request
+        if (
+            execution.response is None
+            or execution.response.status_code != 401
+            or not self.config.refresh_on_401
+        ):
+            return
+
+        bundle = self._bundle(context)
+        if bundle.get("retry_in_progress"):
+            return
+
+        bundle["retry_in_progress"] = True
+        try:
+            refreshed = self._acquire(context, phase="refresh", trigger="401")
+        finally:
+            bundle["retry_in_progress"] = False
+
+        if refreshed:
+            execution.retry_requested = True
+
+
+def make_builtin_auth_plugin(config: BuiltInAuthConfig) -> LoadedAuthPlugin:
+    return make_auth_plugin(config.name, BuiltInAuthPlugin(config))

--- a/src/knives_out/builtin_auth.py
+++ b/src/knives_out/builtin_auth.py
@@ -315,8 +315,10 @@ class BuiltInAuthPlugin(RuntimePlugin):
             return
         if bundle.get("retry_in_progress"):
             return
-        if bundle.get("last_error") and bundle.get("token") is None and not bundle.get(
-            "session_ready"
+        if (
+            bundle.get("last_error")
+            and bundle.get("token") is None
+            and not bundle.get("session_ready")
         ):
             return
 

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -10,6 +10,12 @@ from rich.console import Console
 from rich.table import Table
 
 from knives_out.attack_packs import load_attack_packs
+from knives_out.auth_config import (
+    auth_config_map,
+    auth_profiles_from_configs,
+    load_auth_configs,
+    select_auth_configs,
+)
 from knives_out.auth_plugins import PluginRuntimeError, load_auth_plugins
 from knives_out.filtering import filter_attack_suite, filter_operations
 from knives_out.generator import generate_attack_suite
@@ -152,6 +158,27 @@ def _load_auth_profiles_or_error(
         return resolve_auth_profile_modules(selected_profiles, relative_to=path)
     except (OSError, ValueError) as exc:
         raise typer.BadParameter(f"Could not read auth profile file '{path}': {exc}") from exc
+
+
+def _load_auth_configs_or_error(
+    path: Path | None,
+    *,
+    include_names: list[str] | None = None,
+):
+    if path is None:
+        if include_names:
+            raise typer.BadParameter("--auth-profile requires --auth-config.")
+        return []
+
+    try:
+        auth_file = load_auth_configs(path)
+        selected_configs = select_auth_configs(auth_file, include_names=include_names)
+    except (OSError, ValueError) as exc:
+        raise typer.BadParameter(f"Could not read auth config file '{path}': {exc}") from exc
+
+    if not selected_configs:
+        raise typer.BadParameter(f"Auth config file '{path}' did not define any auth entries.")
+    return selected_configs
 
 
 def _print_suppression_summary(
@@ -400,6 +427,14 @@ def run(
         list[Path] | None,
         typer.Option(help="Load auth/session plugins from local Python module paths. Repeatable."),
     ] = None,
+    auth_config: Annotated[
+        Path | None,
+        typer.Option(help="Optional built-in auth config YAML file."),
+    ] = None,
+    auth_profile: Annotated[
+        list[str] | None,
+        typer.Option(help="Only execute these named auth configs from --auth-config. Repeatable."),
+    ] = None,
     profile_file: Annotated[
         Path | None,
         typer.Option(help="Optional auth profile YAML file for multi-profile execution."),
@@ -470,9 +505,13 @@ def run(
     default_headers = _parse_key_value(header, separator=":")
     default_query = _parse_key_value(query, separator="=")
     auth_profiles = _load_auth_profiles_or_error(profile_file, include_names=profile)
+    built_in_auth_configs = _load_auth_configs_or_error(auth_config, include_names=auth_profile)
+    built_in_auth_by_name = auth_config_map(built_in_auth_configs)
     global_auth_plugin_modules = [str(path.resolve()) for path in auth_plugin_module or []]
 
-    if auth_profiles:
+    if auth_profiles or built_in_auth_configs:
+        if not auth_profiles:
+            auth_profiles = auth_profiles_from_configs(built_in_auth_configs)
         auth_profiles = [
             auth_profile.model_copy(
                 update={
@@ -505,6 +544,7 @@ def run(
                 default_query=default_query,
                 timeout_seconds=timeout,
                 artifact_dir=artifact_dir,
+                built_in_auth_configs=built_in_auth_by_name,
             )
         else:
             results = execute_attack_suite(
@@ -515,6 +555,7 @@ def run(
                 timeout_seconds=timeout,
                 artifact_dir=artifact_dir,
                 auth_plugins=auth_plugins,
+                built_in_auth_configs=built_in_auth_configs,
             )
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -524,16 +565,19 @@ def run(
     out.write_text(results.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
 
     flagged = sum(1 for result in results.results if result.flagged)
+    auth_failures = sum(1 for event in results.auth_events if not event.success)
     if results.profiles:
         console.print(
             f"Executed {len(suite.attacks)} attacks across {len(results.profiles)} profile(s) "
             f"against [bold]{base_url}[/bold] and produced {len(results.results)} result(s). "
-            f"Flagged {flagged} result(s)."
+            f"Flagged {flagged} result(s). "
+            f"Recorded {auth_failures} auth failure(s)."
         )
     else:
         console.print(
             f"Executed {len(results.results)} attacks against [bold]{base_url}[/bold]. "
-            f"Flagged {flagged} result(s)."
+            f"Flagged {flagged} result(s). "
+            f"Recorded {auth_failures} auth failure(s)."
         )
     console.print(f"Wrote results to [bold]{out}[/bold].")
 

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, model_validator
 SeverityLevel = Literal["none", "low", "medium", "high", "critical"]
 ConfidenceLevel = Literal["none", "low", "medium", "high"]
 AttackType = Literal["request", "workflow"]
+AuthEventPhase = Literal["acquire", "refresh"]
 
 
 class ParameterSpec(BaseModel):
@@ -62,6 +63,7 @@ class AuthProfile(BaseModel):
     description: str | None = None
     headers: dict[str, str] = Field(default_factory=dict)
     query: dict[str, Any] = Field(default_factory=dict)
+    auth_config: str | None = None
     auth_plugins: list[str] = Field(default_factory=list)
     auth_plugin_modules: list[str] = Field(default_factory=list)
 
@@ -194,6 +196,18 @@ class WorkflowStepResult(BaseModel):
     response_excerpt: str | None = None
 
 
+class AuthEvent(BaseModel):
+    name: str
+    strategy: str
+    phase: AuthEventPhase
+    success: bool = True
+    profile: str | None = None
+    trigger: str | None = None
+    endpoint: str | None = None
+    status_code: int | None = None
+    error: str | None = None
+
+
 class ProfileAttackResult(BaseModel):
     profile: str
     level: int = 0
@@ -243,6 +257,7 @@ class AttackResults(BaseModel):
     base_url: str
     executed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     profiles: list[str] = Field(default_factory=list)
+    auth_events: list[AuthEvent] = Field(default_factory=list)
     results: list[AttackResult] = Field(default_factory=list)
 
     @model_validator(mode="before")

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -5,7 +5,7 @@ from collections import Counter
 from html import escape
 from pathlib import Path
 
-from knives_out.models import AttackResults, ProfileAttackResult
+from knives_out.models import AttackResults, AuthEvent, ProfileAttackResult
 from knives_out.suppressions import SuppressedFinding, SuppressionRule
 from knives_out.verification import (
     ComparedFinding,
@@ -62,6 +62,28 @@ def _profile_table_rows(profile_results: list[ProfileAttackResult]) -> list[str]
     return rows
 
 
+def _auth_event_sort_key(event: AuthEvent) -> tuple[str, str, str, str]:
+    return (
+        (event.profile or "").casefold(),
+        event.name.casefold(),
+        event.phase,
+        event.trigger or "",
+    )
+
+
+def _auth_event_table_rows(events: list[AuthEvent]) -> list[str]:
+    rows: list[str] = []
+    for event in sorted(events, key=_auth_event_sort_key):
+        profile = event.profile or "-"
+        status = str(event.status_code) if event.status_code is not None else "-"
+        outcome = "ok" if event.success else "failed"
+        rows.append(
+            f"| {profile} | {event.name} | {event.strategy} | {event.phase} | "
+            f"{event.trigger or '-'} | {outcome} | {status} | {event.error or '-'} |"
+        )
+    return rows
+
+
 def _workflow_phase(result) -> str:
     if result.type != "workflow":
         return "request"
@@ -81,6 +103,7 @@ def render_markdown_report(
     total = len(results.results)
     flagged = len(comparison.current_findings)
     suppressed_flagged = len(comparison.suppressed_current_findings)
+    auth_failures = sum(1 for event in results.auth_events if not event.success)
     response_schema_mismatches = sum(
         1 for result in results.results if result.response_schema_valid is False
     )
@@ -98,6 +121,7 @@ def render_markdown_report(
         lines.append(f"- Profile names: `{', '.join(results.profiles)}`")
     lines.append(f"- Active flagged results: **{flagged}**")
     lines.append(f"- Suppressed flagged results: **{suppressed_flagged}**")
+    lines.append(f"- Auth setup/refresh failures: **{auth_failures}**")
     lines.append(f"- Response schema mismatches: **{response_schema_mismatches}**")
     lines.append("")
     lines.append("## Outcome summary")
@@ -135,6 +159,17 @@ def render_markdown_report(
     lines.extend(_suppressed_table_rows(comparison.suppressed_current_findings))
     if not comparison.suppressed_current_findings:
         lines.append("| None | - | - | - | - |")
+
+    lines.append("")
+    lines.append("## Auth diagnostics")
+    lines.append("")
+    lines.append(
+        "| Profile | Auth config | Strategy | Phase | Trigger | Outcome | Status | Error |"
+    )
+    lines.append("| --- | --- | --- | --- | --- | --- | ---: | --- |")
+    lines.extend(_auth_event_table_rows(results.auth_events))
+    if not results.auth_events:
+        lines.append("| None | - | - | - | - | - | - | - |")
 
     if baseline is not None:
         lines.append("")
@@ -312,6 +347,24 @@ def _suppressed_finding_row_html(finding: SuppressedFinding) -> str:
     )
 
 
+def _auth_event_row_html(event: AuthEvent) -> str:
+    profile = event.profile or "-"
+    status = str(event.status_code) if event.status_code is not None else "-"
+    outcome = "ok" if event.success else "failed"
+    return (
+        "<tr>"
+        f"<td>{escape(profile)}</td>"
+        f"<td>{escape(event.name)}</td>"
+        f"<td>{escape(event.strategy)}</td>"
+        f"<td>{escape(event.phase)}</td>"
+        f"<td>{escape(event.trigger or '-')}</td>"
+        f"<td>{escape(outcome)}</td>"
+        f"<td>{escape(status)}</td>"
+        f"<td>{escape(event.error or '-')}</td>"
+        "</tr>"
+    )
+
+
 def _result_card_html(result, *, artifact_root: Path | None) -> str:
     status = str(result.status_code) if result.status_code is not None else "-"
     issue = result.issue or "ok"
@@ -427,6 +480,7 @@ def render_html_report(
         ("Total results", str(len(results.results))),
         ("Active flagged", str(len(comparison.current_findings))),
         ("Suppressed", str(len(comparison.suppressed_current_findings))),
+        ("Auth failures", str(sum(1 for event in results.auth_events if not event.success))),
         (
             "Profiles",
             str(len(results.profiles)) if results.profiles else "single",
@@ -460,6 +514,13 @@ def render_html_report(
             for finding in comparison.suppressed_current_findings
         )
         or "<tr><td colspan='5' class='muted'>No suppressed findings.</td></tr>"
+    )
+    auth_event_rows = (
+        "".join(
+            _auth_event_row_html(event)
+            for event in sorted(results.auth_events, key=_auth_event_sort_key)
+        )
+        or "<tr><td colspan='8' class='muted'>No auth diagnostics recorded.</td></tr>"
     )
 
     outcome_rows = "".join(
@@ -705,6 +766,19 @@ def render_html_report(
         <table>
           <thead><tr><th>Attack</th><th>Issue</th><th>Reason</th><th>Owner</th><th>Expires</th></tr></thead>
           <tbody>{suppressed_rows}</tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>Auth diagnostics</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Profile</th><th>Auth config</th><th>Strategy</th><th>Phase</th>
+              <th>Trigger</th><th>Outcome</th><th>Status</th><th>Error</th>
+            </tr>
+          </thead>
+          <tbody>{auth_event_rows}</tbody>
         </table>
       </section>
 

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 
 import httpx
 
+from knives_out.auth_config import BuiltInAuthConfig
 from knives_out.auth_plugins import (
     LoadedAuthPlugin,
     PluginRuntimeError,
@@ -22,6 +23,7 @@ from knives_out.auth_plugins import (
     load_auth_plugins,
     make_auth_plugin,
 )
+from knives_out.builtin_auth import make_builtin_auth_plugin
 from knives_out.models import (
     AttackCase,
     AttackDefinition,
@@ -603,12 +605,15 @@ def _loaded_auth_plugins(
     *,
     auth_plugins: list[LoadedAuthPlugin | RuntimePlugin | type[RuntimePlugin]] | None,
     workflow_hooks: list[WorkflowHook] | None,
+    built_in_auth_configs: list[BuiltInAuthConfig] | None = None,
 ) -> list[LoadedAuthPlugin]:
     loaded: list[LoadedAuthPlugin] = []
     for index, plugin in enumerate(auth_plugins or [], start=1):
         loaded.append(_coerce_loaded_auth_plugin(plugin, default_name=f"auth-plugin-{index}"))
     for index, hook in enumerate(workflow_hooks or [], start=1):
         loaded.append(_coerce_loaded_auth_plugin(hook, default_name=f"workflow-hook-{index}"))
+    for config in built_in_auth_configs or []:
+        loaded.append(make_builtin_auth_plugin(config))
     return loaded
 
 
@@ -624,92 +629,98 @@ def _execute_request(
     artifact_metadata: dict[str, Any] | None,
     auth_plugins: list[LoadedAuthPlugin],
 ) -> RequestExecution:
-    _invoke_auth_plugins(auth_plugins, "before_request", request, context)
-
+    total_duration_ms = 0.0
     request_kwargs: dict[str, Any] | None = None
-    try:
-        url = _resolve_request_path(
-            request,
-            base_url=context.base_url,
-            extracted_values=context.extracted_values,
-        )
-        headers = _resolved_headers(
-            request,
-            default_headers=default_headers,
-            extracted_values=context.extracted_values,
-        )
-        query = _resolved_query(
-            request,
-            default_query=default_query,
-            extracted_values=context.extracted_values,
-        )
-        request_kwargs = {
-            "params": query,
-            "headers": headers,
-        }
-        if not request.omit_body:
-            if request.raw_body is not None:
-                request_kwargs["content"] = str(
-                    _resolve_templates(request.raw_body, context.extracted_values)
-                )
-                content_type = request.content_type
-                if content_type is not None:
-                    content_type = str(_resolve_templates(content_type, context.extracted_values))
-                if content_type and "Content-Type" not in headers:
-                    request_kwargs["headers"] = {**headers, "Content-Type": content_type}
-                    headers = request_kwargs["headers"]
-            elif request.body_json is not None:
-                request_kwargs["json"] = _resolve_templates(
-                    request.body_json,
-                    context.extracted_values,
-                )
-        execution = RequestExecution(
-            url=url,
-            headers=headers,
-            query=query,
-            response=None,
-            error=None,
-            duration_ms=0.0,
-        )
-    except WorkflowResolutionError as exc:
+    execution: RequestExecution | None = None
+    max_attempts = 2
+
+    for attempt in range(max_attempts):
+        _invoke_auth_plugins(auth_plugins, "before_request", request, context)
+
+        try:
+            url = _resolve_request_path(
+                request,
+                base_url=context.base_url,
+                extracted_values=context.extracted_values,
+            )
+            headers = _resolved_headers(
+                request,
+                default_headers=default_headers,
+                extracted_values=context.extracted_values,
+            )
+            query = _resolved_query(
+                request,
+                default_query=default_query,
+                extracted_values=context.extracted_values,
+            )
+            request_kwargs = {
+                "params": query,
+                "headers": headers,
+            }
+            if not request.omit_body:
+                if request.raw_body is not None:
+                    request_kwargs["content"] = str(
+                        _resolve_templates(request.raw_body, context.extracted_values)
+                    )
+                    content_type = request.content_type
+                    if content_type is not None:
+                        content_type = str(
+                            _resolve_templates(content_type, context.extracted_values)
+                        )
+                    if content_type and "Content-Type" not in headers:
+                        request_kwargs["headers"] = {**headers, "Content-Type": content_type}
+                        headers = request_kwargs["headers"]
+                elif request.body_json is not None:
+                    request_kwargs["json"] = _resolve_templates(
+                        request.body_json,
+                        context.extracted_values,
+                    )
+            execution = RequestExecution(
+                url=url,
+                headers=headers,
+                query=query,
+                response=None,
+                error=None,
+                duration_ms=0.0,
+            )
+        except WorkflowResolutionError as exc:
+            execution = RequestExecution(
+                url=context.build_url(request.path),
+                headers={},
+                query={},
+                response=None,
+                error=str(exc),
+                duration_ms=0.0,
+                resolution_error=True,
+            )
+            _invoke_auth_plugins(auth_plugins, "after_request", request, context, execution)
+            break
+
+        start = time.perf_counter()
+        try:
+            execution.response = client.request(request.method, execution.url, **request_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            execution.error = str(exc)
+        execution.duration_ms = (time.perf_counter() - start) * 1000.0
+        total_duration_ms += execution.duration_ms
+
+        _invoke_auth_plugins(auth_plugins, "after_request", request, context, execution)
+        if execution.retry_requested and attempt + 1 < max_attempts:
+            continue
+        break
+
+    if execution is None:
         execution = RequestExecution(
             url=context.build_url(request.path),
             headers={},
             query={},
             response=None,
-            error=str(exc),
+            error="Request execution did not produce a result.",
             duration_ms=0.0,
-            resolution_error=True,
         )
-        _invoke_auth_plugins(auth_plugins, "after_request", request, context, execution)
-        if (
-            artifact_root is not None
-            and artifact_filename is not None
-            and artifact_metadata is not None
-        ):
-            _write_request_artifact(
-                artifact_root,
-                filename=artifact_filename,
-                request=request,
-                metadata=artifact_metadata,
-                url=execution.url,
-                headers=execution.headers,
-                query=execution.query,
-                request_kwargs=None,
-                response=None,
-                error=execution.error,
-                duration_ms=execution.duration_ms,
-            )
-        return execution
+    else:
+        execution.duration_ms = total_duration_ms or execution.duration_ms
 
-    start = time.perf_counter()
-    try:
-        execution.response = client.request(request.method, execution.url, **request_kwargs)
-    except Exception as exc:  # noqa: BLE001
-        execution.error = str(exc)
-    execution.duration_ms = (time.perf_counter() - start) * 1000.0
-
-    _invoke_auth_plugins(auth_plugins, "after_request", request, context, execution)
     if (
         artifact_root is not None
         and artifact_filename is not None
@@ -1040,6 +1051,7 @@ def _execute_workflow_attack(
     artifact_root: Path | None,
     auth_plugins: list[LoadedAuthPlugin],
     initial_state: dict[str, Any],
+    auth_events,
 ) -> AttackResult:
     total_duration_ms = 0.0
     with httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client:
@@ -1049,6 +1061,7 @@ def _execute_workflow_attack(
             scope="workflow",
             state=dict(initial_state),
             extracted_values={},
+            auth_events=auth_events,
             workflow_id=workflow.id,
         )
         _invoke_auth_plugins(auth_plugins, "before_workflow", workflow, context)
@@ -1187,6 +1200,7 @@ def execute_attack_suite(
     artifact_dir: str | Path | None = None,
     auth_plugins: list[LoadedAuthPlugin | RuntimePlugin | type[RuntimePlugin]] | None = None,
     workflow_hooks: list[WorkflowHook] | None = None,
+    built_in_auth_configs: list[BuiltInAuthConfig] | None = None,
     profile_name: str | None = None,
     profile_level: int = 0,
     profile_anonymous: bool = False,
@@ -1201,6 +1215,7 @@ def execute_attack_suite(
     loaded_plugins = _loaded_auth_plugins(
         auth_plugins=auth_plugins,
         workflow_hooks=workflow_hooks,
+        built_in_auth_configs=built_in_auth_configs,
     )
     with httpx.Client(timeout=timeout_seconds, follow_redirects=False) as client:
         suite_context = RuntimeContext(
@@ -1224,6 +1239,7 @@ def execute_attack_suite(
                         artifact_root=artifact_root,
                         auth_plugins=loaded_plugins,
                         initial_state=suite_context.state,
+                        auth_events=suite_context.auth_events,
                     )
                 )
                 continue
@@ -1255,6 +1271,7 @@ def execute_attack_suite(
         source=suite.source,
         base_url=base_url,
         profiles=[profile_name] if profile_name is not None else [],
+        auth_events=suite_context.auth_events,
         results=results,
     )
 
@@ -1268,6 +1285,7 @@ def execute_attack_suite_profiles(
     default_query: dict[str, Any] | None = None,
     timeout_seconds: float = 10.0,
     artifact_dir: str | Path | None = None,
+    built_in_auth_configs: dict[str, BuiltInAuthConfig] | None = None,
 ) -> AttackResults:
     if not profiles:
         raise ValueError("At least one auth profile is required for multi-profile execution.")
@@ -1277,6 +1295,14 @@ def execute_attack_suite_profiles(
 
     per_profile_runs: list[tuple[AuthProfile, AttackResults]] = []
     for profile in profiles:
+        built_in_configs = []
+        if profile.auth_config:
+            if built_in_auth_configs is None or profile.auth_config not in built_in_auth_configs:
+                raise ValueError(
+                    f"Profile '{profile.name}' references unknown auth config "
+                    f"{profile.auth_config!r}."
+                )
+            built_in_configs.append(built_in_auth_configs[profile.auth_config])
         loaded_plugins = load_auth_plugins(
             entry_point_names=profile.auth_plugins,
             module_paths=[Path(module_path) for module_path in profile.auth_plugin_modules],
@@ -1289,6 +1315,7 @@ def execute_attack_suite_profiles(
             timeout_seconds=timeout_seconds,
             artifact_dir=_profile_artifact_dir(artifact_dir, profile),
             auth_plugins=loaded_plugins,
+            built_in_auth_configs=built_in_configs,
             profile_name=profile.name,
             profile_level=profile.level,
             profile_anonymous=profile.anonymous,
@@ -1331,5 +1358,6 @@ def execute_attack_suite_profiles(
         source=suite.source,
         base_url=base_url,
         profiles=[profile.name for profile in profiles],
+        auth_events=[event for _, run in per_profile_runs for event in run.auth_events],
         results=aggregated_results,
     )

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from knives_out.auth_config import (
+    auth_config_map,
+    auth_profiles_from_configs,
+    load_auth_configs,
+    select_auth_configs,
+)
+
+
+def test_load_auth_configs_reads_named_entries(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n"
+        "  - name: user\n"
+        "    strategy: static_bearer\n"
+        "    token: user-token\n"
+        "    level: 10\n"
+        "  - name: admin\n"
+        "    strategy: client_credentials\n"
+        "    endpoint: /oauth/token\n"
+        "    request_form:\n"
+        "      grant_type: client_credentials\n"
+        "    token_pointer: /access_token\n",
+        encoding="utf-8",
+    )
+
+    auth_file = load_auth_configs(config_path)
+
+    assert [config.name for config in auth_file.auth] == ["user", "admin"]
+    assert auth_file.auth[1].endpoint == "/oauth/token"
+
+
+def test_select_auth_configs_filters_named_entries(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n"
+        "  - name: user\n"
+        "    strategy: static_bearer\n"
+        "    token: user-token\n"
+        "  - name: admin\n"
+        "    strategy: static_bearer\n"
+        "    token: admin-token\n",
+        encoding="utf-8",
+    )
+    auth_file = load_auth_configs(config_path)
+
+    selected = select_auth_configs(auth_file, include_names=["admin"])
+
+    assert [config.name for config in selected] == ["admin"]
+
+
+def test_auth_profiles_from_configs_preserves_profile_metadata(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n"
+        "  - name: anonymous\n"
+        "    strategy: login_form_cookie\n"
+        "    endpoint: /login\n"
+        "    anonymous: true\n"
+        "    level: 0\n"
+        "    headers:\n"
+        "      X-Trace-Id: trace-123\n",
+        encoding="utf-8",
+    )
+
+    auth_file = load_auth_configs(config_path)
+    profiles = auth_profiles_from_configs(auth_file.auth)
+
+    assert profiles[0].name == "anonymous"
+    assert profiles[0].auth_config == "anonymous"
+    assert profiles[0].anonymous is True
+    assert profiles[0].headers["X-Trace-Id"] == "trace-123"
+    assert auth_config_map(auth_file.auth)["anonymous"].strategy == "login_form_cookie"
+
+
+def test_load_auth_configs_validates_required_strategy_fields(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n  - name: broken\n    strategy: static_bearer\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="static_bearer auth requires 'token'"):
+        load_auth_configs(config_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,11 +313,12 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        built_in_auth_configs=None,
         profile_name=None,
         profile_level=0,
         profile_anonymous=False,
     ) -> AttackResults:
-        del profile_name, profile_level, profile_anonymous
+        del built_in_auth_configs, profile_name, profile_level, profile_anonymous
         captured["suite_source"] = suite.source
         captured["base_url"] = base_url
         captured["artifact_dir"] = artifact_dir
@@ -1130,12 +1131,13 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        built_in_auth_configs=None,
         profile_name=None,
         profile_level=0,
         profile_anonymous=False,
     ) -> AttackResults:
         del default_headers, default_query, timeout_seconds, artifact_dir
-        del workflow_hooks, profile_name, profile_level, profile_anonymous
+        del workflow_hooks, built_in_auth_configs, profile_name, profile_level, profile_anonymous
         captured["attack_ids"] = [attack.id for attack in suite.attacks]
         captured["auth_plugins"] = auth_plugins
         return AttackResults(source=suite.source, base_url=base_url, results=[])
@@ -1205,6 +1207,7 @@ def test_run_command_filters_attacks_by_path_before_execution(tmp_path: Path, mo
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        built_in_auth_configs=None,
         profile_name=None,
         profile_level=0,
         profile_anonymous=False,
@@ -1217,6 +1220,7 @@ def test_run_command_filters_attacks_by_path_before_execution(tmp_path: Path, mo
             artifact_dir,
             auth_plugins,
             workflow_hooks,
+            built_in_auth_configs,
             profile_name,
             profile_level,
             profile_anonymous,
@@ -1278,6 +1282,7 @@ def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> Non
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        built_in_auth_configs=None,
         profile_name=None,
         profile_level=0,
         profile_anonymous=False,
@@ -1288,6 +1293,7 @@ def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> Non
             timeout_seconds,
             artifact_dir,
             workflow_hooks,
+            built_in_auth_configs,
             profile_name,
             profile_level,
             profile_anonymous,
@@ -1363,11 +1369,13 @@ def test_run_command_executes_selected_auth_profiles(tmp_path: Path, monkeypatch
         default_query: dict[str, str],
         timeout_seconds: float,
         artifact_dir: Path | None,
+        built_in_auth_configs=None,
     ) -> AttackResults:
         del default_headers, default_query, timeout_seconds, artifact_dir
         captured["suite_source"] = suite.source
         captured["base_url"] = base_url
         captured["profile_names"] = [profile.name for profile in profiles]
+        captured["built_in_auth_configs"] = built_in_auth_configs
         return AttackResults(
             source=suite.source,
             base_url=base_url,
@@ -1410,9 +1418,180 @@ def test_run_command_executes_selected_auth_profiles(tmp_path: Path, monkeypatch
     assert captured["suite_source"] == "unit"
     assert captured["base_url"] == "https://example.com"
     assert captured["profile_names"] == ["user"]
+    assert captured["built_in_auth_configs"] == {}
     assert "Executed 1 attacks across 1 profile(s)" in _normalized_output(result.stdout)
     saved = AttackResults.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert saved.profiles == ["user"]
+
+
+def test_run_command_combines_profile_file_with_built_in_auth_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    profile_path = tmp_path / "profiles.yml"
+    auth_config_path = tmp_path / "auth.yml"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    profile_path.write_text(
+        "profiles:\n  - name: user\n    level: 10\n    auth_config: user\n",
+        encoding="utf-8",
+    )
+    auth_config_path.write_text(
+        "auth:\n"
+        "  - name: user\n"
+        "    strategy: static_bearer\n"
+        "    token: user-token\n"
+        "    level: 10\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite_profiles(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        profiles,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+        built_in_auth_configs=None,
+    ) -> AttackResults:
+        del suite, base_url, default_headers, default_query, timeout_seconds, artifact_dir
+        captured["profile_auth_configs"] = [profile.auth_config for profile in profiles]
+        captured["built_in_auth_configs"] = sorted((built_in_auth_configs or {}).keys())
+        return AttackResults(
+            source="unit",
+            base_url="https://example.com",
+            profiles=[profile.name for profile in profiles],
+            results=[],
+        )
+
+    monkeypatch.setattr(
+        "knives_out.cli.execute_attack_suite_profiles",
+        _fake_execute_attack_suite_profiles,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--profile-file",
+            str(profile_path),
+            "--auth-config",
+            str(auth_config_path),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["profile_auth_configs"] == ["user"]
+    assert captured["built_in_auth_configs"] == ["user"]
+
+
+def test_run_command_supports_built_in_auth_config_profiles(tmp_path: Path, monkeypatch) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    out_path = tmp_path / "results.json"
+    auth_config_path = tmp_path / "auth.yml"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    auth_config_path.write_text(
+        "auth:\n"
+        "  - name: user\n"
+        "    strategy: static_bearer\n"
+        "    token: user-token\n"
+        "    level: 10\n"
+        "  - name: admin\n"
+        "    strategy: static_bearer\n"
+        "    token: admin-token\n"
+        "    level: 20\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execute_attack_suite_profiles(
+        suite: AttackSuite,
+        *,
+        base_url: str,
+        profiles,
+        default_headers: dict[str, str],
+        default_query: dict[str, str],
+        timeout_seconds: float,
+        artifact_dir: Path | None,
+        built_in_auth_configs=None,
+    ) -> AttackResults:
+        del suite, default_headers, default_query, timeout_seconds, artifact_dir
+        captured["base_url"] = base_url
+        captured["profile_names"] = [profile.name for profile in profiles]
+        captured["profile_auth_configs"] = [profile.auth_config for profile in profiles]
+        captured["built_in_auth_configs"] = sorted((built_in_auth_configs or {}).keys())
+        return AttackResults(
+            source="unit",
+            base_url=base_url,
+            profiles=[profile.name for profile in profiles],
+            results=[],
+        )
+
+    monkeypatch.setattr(
+        "knives_out.cli.execute_attack_suite_profiles",
+        _fake_execute_attack_suite_profiles,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--auth-config",
+            str(auth_config_path),
+            "--auth-profile",
+            "admin",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["base_url"] == "https://example.com"
+    assert captured["profile_names"] == ["admin"]
+    assert captured["profile_auth_configs"] == ["admin"]
+    assert captured["built_in_auth_configs"] == ["admin"]
+
+
+def test_run_command_requires_auth_config_for_auth_profile_name(tmp_path: Path) -> None:
+    attacks_path = tmp_path / "attacks.json"
+    attacks_path.write_text(
+        AttackSuite(source="unit", attacks=[]).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(attacks_path),
+            "--base-url",
+            "https://example.com",
+            "--auth-profile",
+            "admin",
+        ],
+    )
+
+    assert result.exit_code == 2
 
 
 def test_run_command_requires_profile_file_for_profile_name(tmp_path: Path) -> None:
@@ -1454,6 +1633,7 @@ def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypat
         artifact_dir: Path | None,
         auth_plugins=None,
         workflow_hooks=None,
+        built_in_auth_configs=None,
         profile_name=None,
         profile_level=0,
         profile_anonymous=False,
@@ -1467,6 +1647,7 @@ def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypat
             artifact_dir,
             auth_plugins,
             workflow_hooks,
+            built_in_auth_configs,
             profile_name,
             profile_level,
             profile_anonymous,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -35,9 +35,13 @@ def test_readme_includes_ci_guidance() -> None:
     assert "examples/graphql/library.graphql" in readme
     assert "--graphql-endpoint /api/graphql" in readme
     assert "graphql-attacks.json" in readme
+    assert "examples/auth_configs/user-admin.yml" in readme
+    assert "examples/auth_configs/client-credentials.yml" in readme
+    assert "--auth-config examples/auth_configs/user-admin.yml" in readme
+    assert "--auth-profile user" in readme
     assert "examples/workflow_packs/listed_pet_lookup.py" in readme
-    assert "**v0.9:** first-class auth and session realism" in readme
     assert "**v0.10:** deeper GraphQL coverage" in readme
+    assert "The built-in auth/config milestone is now shipped." in readme
 
 
 def test_dev_environment_workflow_matches_current_cli_surface() -> None:
@@ -54,6 +58,9 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in workflow
     assert "examples/graphql/library.graphql" in workflow
     assert "--graphql-endpoint /graphql" in workflow
+    assert "--auth-config examples/auth_configs/client-credentials.yml" in workflow
+    assert "--auth-config examples/auth_configs/user-admin.yml" in workflow
+    assert "--auth-profile user" in workflow
     assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in workflow
     assert "--profile anonymous" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
@@ -81,8 +88,11 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Baseline-aware gating" in ci_doc
     assert "Optional: checked-in suppressions" in ci_doc
     assert "Optional: multi-profile authorization runs" in ci_doc
+    assert "built-in auth config" in ci_doc
     assert "Optional: HTML report and artifact index" in ci_doc
     assert "Optional: GraphQL schemas" in ci_doc
+    assert "examples/auth_configs/user-admin.yml" in ci_doc
+    assert "examples/auth_configs/client-credentials.yml" in ci_doc
     assert "examples/auth_profiles/anonymous-user-admin.yml" in ci_doc
     assert "examples/graphql/library.graphql" in ci_doc
     assert "knives-out triage results.json --out .knives-out-ignore.yml" in ci_doc
@@ -141,7 +151,7 @@ def test_roadmap_and_architecture_describe_next_milestones() -> None:
 
     assert "## Recently completed" in roadmap
     assert "v0.8: GraphQL schema support" in roadmap
-    assert "## v0.9 — first-class auth and session realism" in roadmap
+    assert "v0.9: built-in auth acquisition and refresh flows" in roadmap
     assert "client_credentials" in roadmap
     assert "## v0.10 — deeper GraphQL coverage" in roadmap
     assert "subscription coverage" in roadmap
@@ -149,8 +159,11 @@ def test_roadmap_and_architecture_describe_next_milestones() -> None:
 
     assert "graphql_loader.py" in architecture
     assert "spec_loader.py" in architecture
+    assert "auth_config.py" in architecture
+    assert "builtin_auth.py" in architecture
     assert "GraphQL SDL or introspection JSON" in architecture
-    assert "200` response with an `errors` array" in architecture
-    assert "first-class auth/session profile strategies" in architecture
+    assert "`200` response" in architecture
+    assert "`errors`" in architecture
+    assert "built-in auth acquisition/refresh" in architecture
     assert "GraphQL response-shape validation, federation awareness" in architecture
     assert "redirect-driven OAuth auth-code flows" in architecture

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from knives_out.attack_packs import load_module_attack_packs
+from knives_out.auth_config import load_auth_configs
 from knives_out.auth_plugins import load_module_auth_plugins
 from knives_out.generator import generate_attack_suite
 from knives_out.profiles import load_auth_profiles
@@ -17,6 +18,8 @@ ATTACK_PACK_MODULE = ROOT / "examples" / "custom_packs" / "unexpected_header.py"
 WORKFLOW_PACK_MODULE = ROOT / "examples" / "workflow_packs" / "listed_pet_lookup.py"
 AUTH_PLUGIN_MODULE = ROOT / "examples" / "auth_plugins" / "login_bearer.py"
 AUTH_PROFILE_FILE = ROOT / "examples" / "auth_profiles" / "anonymous-user-admin.yml"
+AUTH_CONFIG_FILE = ROOT / "examples" / "auth_configs" / "user-admin.yml"
+CLIENT_CREDENTIALS_CONFIG_FILE = ROOT / "examples" / "auth_configs" / "client-credentials.yml"
 
 
 def test_checked_in_openapi_examples_load() -> None:
@@ -79,3 +82,11 @@ def test_checked_in_auth_profile_example_loads() -> None:
         "user",
         "admin",
     ]
+
+
+def test_checked_in_auth_config_examples_load() -> None:
+    auth_file = load_auth_configs(AUTH_CONFIG_FILE)
+    client_credentials = load_auth_configs(CLIENT_CREDENTIALS_CONFIG_FILE)
+
+    assert [config.name for config in auth_file.auth] == ["user", "admin"]
+    assert client_credentials.auth[0].strategy == "client_credentials"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -20,6 +20,7 @@ def test_load_auth_profiles_reads_named_profiles(tmp_path: Path) -> None:
         "    level: 0\n"
         "  - name: admin\n"
         "    level: 20\n"
+        "    auth_config: admin\n"
         "    headers:\n"
         "      Authorization: Bearer admin\n",
         encoding="utf-8",
@@ -28,6 +29,7 @@ def test_load_auth_profiles_reads_named_profiles(tmp_path: Path) -> None:
     profiles_file = load_auth_profiles(profile_path)
 
     assert [profile.name for profile in profiles_file.profiles] == ["anonymous", "admin"]
+    assert profiles_file.profiles[1].auth_config == "admin"
     assert profiles_file.profiles[1].headers["Authorization"] == "Bearer admin"
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -548,7 +548,7 @@ def test_render_markdown_report_shows_auth_diagnostics() -> None:
 
 
 def test_execute_attack_suite_applies_static_bearer_auth_config(monkeypatch) -> None:
-    response = httpx.Response(401, text="missing auth")
+    response = httpx.Response(422, text="invalid input")
     client = _install_recording_client(monkeypatch, response)
     suite = AttackSuite(source="unit", attacks=[_attack_case(response_schemas={})])
 
@@ -577,7 +577,7 @@ def test_execute_attack_suite_refreshes_bearer_token_on_401(monkeypatch) -> None
         if request["url"] == "https://example.com/oauth/token":
             return httpx.Response(
                 200,
-                json={"access_token": tokens.pop(0), "expires_in": 1},
+                json={"access_token": tokens.pop(0), "expires_in": 3600},
             )
         authorization = (request.get("headers") or {}).get("Authorization")
         if authorization == "Bearer expired-token":

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 
+from knives_out.auth_config import BuiltInAuthConfig
 from knives_out.auth_plugins import RuntimePlugin
 from knives_out.models import (
     AttackCase,
@@ -519,6 +520,169 @@ def test_render_markdown_report_shows_suppressed_findings() -> None:
     assert "known issue" in report
     assert "Active flagged results: **0**" in report
     assert "Suppressed flagged results: **1**" in report
+
+
+def test_render_markdown_report_shows_auth_diagnostics() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        auth_events=[
+            {
+                "name": "user",
+                "strategy": "client_credentials",
+                "phase": "acquire",
+                "success": False,
+                "trigger": "suite",
+                "endpoint": "/oauth/token",
+                "error": "invalid client credentials",
+            }
+        ],
+        results=[],
+    )
+
+    report = render_markdown_report(results)
+
+    assert "## Auth diagnostics" in report
+    assert "client_credentials" in report
+    assert "invalid client credentials" in report
+
+
+def test_execute_attack_suite_applies_static_bearer_auth_config(monkeypatch) -> None:
+    response = httpx.Response(401, text="missing auth")
+    client = _install_recording_client(monkeypatch, response)
+    suite = AttackSuite(source="unit", attacks=[_attack_case(response_schemas={})])
+
+    results = execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        built_in_auth_configs=[
+            BuiltInAuthConfig(
+                name="user",
+                strategy="static_bearer",
+                token="dev-token",
+            )
+        ],
+    )
+
+    assert client.requests[0]["headers"]["Authorization"] == "Bearer dev-token"
+    assert len(results.auth_events) == 1
+    assert results.auth_events[0].success is True
+    assert results.auth_events[0].name == "user"
+
+
+def test_execute_attack_suite_refreshes_bearer_token_on_401(monkeypatch) -> None:
+    tokens = ["expired-token", "fresh-token"]
+
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        if request["url"] == "https://example.com/oauth/token":
+            return httpx.Response(
+                200,
+                json={"access_token": tokens.pop(0), "expires_in": 1},
+            )
+        authorization = (request.get("headers") or {}).get("Authorization")
+        if authorization == "Bearer expired-token":
+            return httpx.Response(401, json={"detail": "expired"})
+        if authorization == "Bearer fresh-token":
+            return httpx.Response(422, json={"detail": "invalid payload"})
+        return httpx.Response(500, json={"detail": "unexpected"})
+
+    client = _HandlerClient(_handler)
+    _install_client_sequence(monkeypatch, [client])
+
+    suite = AttackSuite(source="unit", attacks=[_attack_case(response_schemas={})])
+    results = execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        built_in_auth_configs=[
+            BuiltInAuthConfig(
+                name="service",
+                strategy="client_credentials",
+                endpoint="/oauth/token",
+                request_form={
+                    "grant_type": "client_credentials",
+                    "client_id": "client",
+                    "client_secret": "secret",
+                },
+                token_pointer="/access_token",
+                expires_in_pointer="/expires_in",
+            )
+        ],
+    )
+
+    assert [request["url"] for request in client.requests] == [
+        "https://example.com/oauth/token",
+        "https://example.com/pets",
+        "https://example.com/oauth/token",
+        "https://example.com/pets",
+    ]
+    assert client.requests[1]["headers"]["Authorization"] == "Bearer expired-token"
+    assert client.requests[3]["headers"]["Authorization"] == "Bearer fresh-token"
+    assert results.results[0].status_code == 422
+    assert results.results[0].flagged is False
+    assert [event.phase for event in results.auth_events] == ["acquire", "refresh"]
+
+
+def test_execute_attack_suite_records_auth_failures_separately(monkeypatch) -> None:
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        if request["url"] == "https://example.com/login":
+            return httpx.Response(500, json={"detail": "boom"})
+        return httpx.Response(401, json={"detail": "unauthorized"})
+
+    _install_client_sequence(monkeypatch, [_HandlerClient(_handler)])
+    suite = AttackSuite(source="unit", attacks=[_attack_case(response_schemas={})])
+
+    results = execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        built_in_auth_configs=[
+            BuiltInAuthConfig(
+                name="user",
+                strategy="login_json_bearer",
+                endpoint="/login",
+                request_json={"username": "demo", "password": "pw"},
+                token_pointer="/token",
+            )
+        ],
+    )
+
+    assert len(results.auth_events) == 1
+    assert results.auth_events[0].success is False
+    assert results.auth_events[0].status_code is None
+    assert "status 500" in (results.auth_events[0].error or "")
+    assert results.results[0].status_code == 401
+    assert results.results[0].flagged is False
+
+
+def test_execute_attack_suite_establishes_cookie_session_with_form_login(monkeypatch) -> None:
+    def _handler(request: dict[str, object]) -> httpx.Response:
+        if request["url"] == "https://example.com/login":
+            return httpx.Response(200, headers={"set-cookie": "session=abc123; Path=/"})
+        cookie = (request.get("headers") or {}).get("Cookie")
+        if cookie == "session=abc123":
+            return httpx.Response(422, json={"detail": "invalid payload"})
+        return httpx.Response(401, json={"detail": "unauthorized"})
+
+    client = _HandlerClient(_handler)
+    _install_client_sequence(monkeypatch, [client])
+    suite = AttackSuite(source="unit", attacks=[_attack_case(response_schemas={})])
+
+    results = execute_attack_suite(
+        suite,
+        base_url="https://example.com",
+        built_in_auth_configs=[
+            BuiltInAuthConfig(
+                name="session-user",
+                strategy="login_form_cookie",
+                endpoint="/login",
+                request_form={"username": "demo", "password": "pw"},
+            )
+        ],
+    )
+
+    assert client.requests[0]["url"] == "https://example.com/login"
+    assert client.requests[1]["headers"]["Cookie"] == "session=abc123"
+    assert results.results[0].status_code == 422
+    assert results.results[0].flagged is False
 
 
 def test_execute_attack_suite_profiles_flags_anonymous_access(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add built-in auth config loading plus runtime bearer/session acquisition and one-shot 401 refresh handling
- integrate named auth configs with run, profiles, reporting diagnostics, and checked-in examples
- add loader, runner, CLI, docs, and example coverage for built-in auth flows

## Testing
- Ruff checks passed on the touched Python files
- Python bytecode compilation passed on the touched Python files
- tests/test_docs.py passed locally
- full pytest is not available in this host macOS Python 3.9 environment because project dependencies like yaml and httpx are missing here; rely on GitHub Actions for full validation