### PR TITLE
[codex] Add main maintenance workflow

### DIFF
--- a/.github/workflows/main-maintenance.yml
+++ b/.github/workflows/main-maintenance.yml
@@ -1,0 +1,121 @@
+name: main-maintenance
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: main-maintenance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Repository docs and examples checks
+        run: |
+          pytest tests/test_docs.py tests/test_sync_wiki.py tests/test_examples.py tests/test_maintenance_scripts.py
+
+      - name: Validate markdown links
+        run: python scripts/check_markdown_links.py README.md docs
+
+      - name: Render wiki pages
+        run: python scripts/sync_wiki.py render --out-dir "${{ runner.temp }}/wiki-render"
+
+      - name: Run test suite with coverage
+        run: pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json
+
+      - name: Upload coverage baseline artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: main-maintenance-coverage
+          path: coverage.json
+          if-no-files-found: error
+
+      - name: Find previous successful coverage baseline
+        id: previous-baseline
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "main-maintenance.yml",
+              branch: "main",
+              status: "success",
+              per_page: 100,
+            });
+
+            const previousRun = runs.find((run) => run.id !== context.runId);
+            if (!previousRun) {
+              core.info("No previous successful maintenance run found.");
+              return;
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: previousRun.id,
+                per_page: 100,
+              },
+            );
+            const artifact = artifacts.find(
+              (candidate) => candidate.name === "main-maintenance-coverage",
+            );
+
+            if (!artifact) {
+              core.info(
+                `Run ${previousRun.id} did not publish a main-maintenance-coverage artifact.`,
+              );
+              return;
+            }
+
+            core.setOutput("artifact_url", artifact.archive_download_url);
+            core.setOutput("run_id", String(previousRun.id));
+
+      - name: Download previous coverage baseline
+        if: steps.previous-baseline.outputs.artifact_url != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p previous-coverage
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "${{ steps.previous-baseline.outputs.artifact_url }}" \
+            -o previous-coverage.zip
+          unzip -p previous-coverage.zip coverage.json > previous-coverage/coverage.json
+
+      - name: Fail on coverage drops
+        env:
+          BASELINE_RUN_ID: ${{ steps.previous-baseline.outputs.run_id }}
+        run: |
+          args=(--current coverage.json --summary-file "$GITHUB_STEP_SUMMARY")
+          if [[ -n "${BASELINE_RUN_ID}" ]]; then
+            args+=(--previous previous-coverage/coverage.json --baseline-label "run ${BASELINE_RUN_ID}")
+          fi
+          python scripts/check_coverage_drop.py "${args[@]}"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -316,10 +316,21 @@ To promote only new regressions, pass the same baseline file you use with `verif
 
 ## Coverage in repository CI
 
-The repository's own `ci.yml` now runs:
+The repository now has two complementary repository workflows:
+
+- `ci.yml` runs on pushes and pull requests to keep the main Python test and lint loop fast
+- `main-maintenance.yml` runs on pushes to `main` and `workflow_dispatch` for deeper post-merge maintenance checks
+
+The `main-maintenance.yml` workflow currently runs:
 
 - `ruff check .`
 - `ruff format --check .`
-- `pytest --cov=src/knives_out --cov-report=term-missing`
+- `pytest tests/test_docs.py tests/test_sync_wiki.py tests/test_examples.py tests/test_maintenance_scripts.py`
+- `python scripts/check_markdown_links.py README.md docs`
+- `python scripts/sync_wiki.py render --out-dir ...`
+- `pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json`
 
-Coverage is printed in CI for visibility, but there is no hard percentage gate yet.
+After the full test pass, it uploads `coverage.json` as the `main-maintenance-coverage` artifact,
+downloads the previous successful artifact from the same workflow on `main`, and fails if total
+coverage drops. The first successful run seeds that baseline automatically, so there is no separate
+manual setup step.

--- a/scripts/check_coverage_drop.py
+++ b/scripts/check_coverage_drop.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_coverage_percent(path: Path) -> float:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    totals = payload.get("totals", {})
+    if "percent_covered" in totals:
+        return float(totals["percent_covered"])
+    if "percent_covered_display" in totals:
+        return float(totals["percent_covered_display"])
+    raise ValueError(f"Could not find total coverage percentage in {path}")
+
+
+def summarize_coverage(
+    *,
+    current_percent: float,
+    previous_percent: float | None,
+    baseline_label: str,
+) -> list[str]:
+    lines = [
+        "## Coverage summary",
+        f"- Current coverage: {current_percent:.2f}%",
+    ]
+    if previous_percent is None:
+        lines.append("- Baseline coverage: unavailable")
+        lines.append(
+            "- Result: no previous successful baseline was available, so no drop check ran."
+        )
+        return lines
+
+    delta = current_percent - previous_percent
+    lines.append(f"- Baseline coverage ({baseline_label}): {previous_percent:.2f}%")
+    if delta < 0:
+        lines.append(f"- Result: coverage dropped by {abs(delta):.2f} percentage points.")
+    elif delta > 0:
+        lines.append(f"- Result: coverage improved by {delta:.2f} percentage points.")
+    else:
+        lines.append("- Result: coverage stayed flat.")
+    return lines
+
+
+def write_summary(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fail when coverage drops against a prior baseline."
+    )
+    parser.add_argument(
+        "--current",
+        type=Path,
+        required=True,
+        help="Path to the current coverage JSON.",
+    )
+    parser.add_argument("--previous", type=Path, help="Path to the previous coverage JSON.")
+    parser.add_argument(
+        "--baseline-label",
+        default="previous successful run",
+        help="Human-readable label for the previous baseline.",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        help="Optional file to write a markdown summary into, such as $GITHUB_STEP_SUMMARY.",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=0.01,
+        help="Allowed drop in coverage percentage points before failing.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    current_percent = load_coverage_percent(args.current)
+    previous_percent = None
+    if args.previous and args.previous.exists():
+        previous_percent = load_coverage_percent(args.previous)
+
+    lines = summarize_coverage(
+        current_percent=current_percent,
+        previous_percent=previous_percent,
+        baseline_label=args.baseline_label,
+    )
+    print("\n".join(lines))
+    if args.summary_file:
+        write_summary(args.summary_file, lines)
+
+    if previous_percent is None:
+        return 0
+
+    if current_percent + args.tolerance < previous_percent:
+        print(
+            f"Coverage dropped from {previous_percent:.2f}% to {current_percent:.2f}%.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "tel:")
+
+
+def collect_markdown_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(
+                sorted(candidate for candidate in path.rglob("*.md") if candidate.is_file())
+            )
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def strip_fenced_code_blocks(text: str) -> str:
+    return re.sub(r"```[\s\S]*?```", "", text)
+
+
+def slugify_heading(heading: str) -> str:
+    slug = heading.strip().lower()
+    slug = re.sub(r"[`*_~]", "", slug)
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"\s+", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    return slug.strip("-")
+
+
+def collect_anchors(markdown: str) -> set[str]:
+    anchors: set[str] = set()
+    seen: dict[str, int] = {}
+    for line in markdown.splitlines():
+        match = HEADING_RE.match(line)
+        if not match:
+            continue
+        base = slugify_heading(match.group(2))
+        if not base:
+            continue
+        count = seen.get(base, 0)
+        anchor = base if count == 0 else f"{base}-{count}"
+        seen[base] = count + 1
+        anchors.add(anchor)
+    return anchors
+
+
+def validate_markdown_file(path: Path) -> list[str]:
+    markdown = path.read_text(encoding="utf-8")
+    text = strip_fenced_code_blocks(markdown)
+    errors: list[str] = []
+    local_anchors = collect_anchors(markdown)
+
+    for target in MARKDOWN_LINK_RE.findall(text):
+        if target.startswith(EXTERNAL_PREFIXES):
+            continue
+        if target.startswith("#"):
+            if target.removeprefix("#") not in local_anchors:
+                errors.append(f"{path}: missing anchor {target}")
+            continue
+
+        path_part, _, fragment = target.partition("#")
+        target_path = (path.parent / path_part).resolve()
+        if not target_path.exists():
+            errors.append(f"{path}: missing path {path_part}")
+            continue
+        if fragment and target_path.suffix.lower() == ".md":
+            target_anchors = collect_anchors(target_path.read_text(encoding="utf-8"))
+            if fragment not in target_anchors:
+                errors.append(f"{path}: missing anchor #{fragment} in {path_part}")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate repo-local markdown links and anchors."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Markdown files or directories to scan.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    files = collect_markdown_files(args.paths)
+    if not files:
+        print("No markdown files found.", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    for path in files:
+        errors.extend(validate_markdown_file(path))
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(f"Validated markdown links in {len(files)} file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -81,9 +81,7 @@ def validate_markdown_file(path: Path) -> list[str]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Validate repo-local markdown links and anchors."
-    )
+    parser = argparse.ArgumentParser(description="Validate repo-local markdown links and anchors.")
     parser.add_argument(
         "paths",
         nargs="+",

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -7,6 +7,7 @@ ARCHITECTURE_DOC = ROOT / "docs" / "architecture.md"
 ROADMAP_DOC = ROOT / "docs" / "roadmap.md"
 DEV_WORKFLOW = ROOT / ".github" / "workflows" / "dev-environment-example.yml"
 SYNC_WIKI_WORKFLOW = ROOT / ".github" / "workflows" / "sync-wiki.yml"
+MAIN_MAINTENANCE_WORKFLOW = ROOT / ".github" / "workflows" / "main-maintenance.yml"
 
 
 def test_readme_includes_ci_guidance() -> None:
@@ -108,6 +109,31 @@ def test_sync_wiki_workflow_uses_dedicated_secret_and_sync_script() -> None:
     assert "WIKI_PUSH_TOKEN" in workflow
     assert "python scripts/sync_wiki.py publish" in workflow
     assert "github.repository }}.wiki.git" in workflow
+
+
+def test_main_maintenance_workflow_checks_docs_links_and_coverage_regressions() -> None:
+    workflow = MAIN_MAINTENANCE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "branches:" in workflow
+    assert "- main" in workflow
+    assert "actions/upload-artifact@v6" in workflow
+    assert "actions/github-script@v7" in workflow
+    assert "ruff check ." in workflow
+    assert "ruff format --check ." in workflow
+    assert "tests/test_maintenance_scripts.py" in workflow
+    assert "python scripts/check_markdown_links.py README.md docs" in workflow
+    assert (
+        'python scripts/sync_wiki.py render --out-dir "${{ runner.temp }}/wiki-render"'
+        in workflow
+    )
+    assert (
+        "pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json"
+        in workflow
+    )
+    assert "main-maintenance-coverage" in workflow
+    assert 'workflow_id: "main-maintenance.yml"' in workflow
+    assert "python scripts/check_coverage_drop.py" in workflow
 
 
 def test_roadmap_and_architecture_describe_next_milestones() -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -124,8 +124,7 @@ def test_main_maintenance_workflow_checks_docs_links_and_coverage_regressions() 
     assert "tests/test_maintenance_scripts.py" in workflow
     assert "python scripts/check_markdown_links.py README.md docs" in workflow
     assert (
-        'python scripts/sync_wiki.py render --out-dir "${{ runner.temp }}/wiki-render"'
-        in workflow
+        'python scripts/sync_wiki.py render --out-dir "${{ runner.temp }}/wiki-render"' in workflow
     )
     assert (
         "pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json"

--- a/tests/test_maintenance_scripts.py
+++ b/tests/test_maintenance_scripts.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK_CHECKER_PATH = ROOT / "scripts" / "check_markdown_links.py"
+COVERAGE_CHECKER_PATH = ROOT / "scripts" / "check_coverage_drop.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+LINK_CHECKER = _load_module("check_markdown_links", LINK_CHECKER_PATH)
+
+
+def _run_script(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(path), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_coverage(path: Path, percent: float) -> None:
+    path.write_text(
+        dedent(
+            f"""
+            {{
+              "totals": {{
+                "percent_covered": {percent}
+              }}
+            }}
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_markdown_link_checker_accepts_existing_paths_anchors_and_code_samples(
+    tmp_path: Path,
+) -> None:
+    guide = tmp_path / "guide.md"
+    guide.write_text(
+        dedent(
+            """
+            # Guide
+
+            ## Next Steps
+
+            Details.
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        dedent(
+            """
+            # Title
+
+            See [Guide](guide.md#next-steps) and [Local](#details).
+
+            ```md
+            [Ignored](missing.md)
+            ```
+
+            ## Details
+
+            Done.
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert LINK_CHECKER.validate_markdown_file(readme) == []
+
+
+def test_markdown_link_checker_reports_missing_paths_and_anchors(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        dedent(
+            """
+            # Title
+
+            See [Missing file](missing.md), [Missing local anchor](#nope), and
+            [Missing remote anchor](guide.md#nope).
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    guide = tmp_path / "guide.md"
+    guide.write_text("# Guide\n", encoding="utf-8")
+
+    errors = LINK_CHECKER.validate_markdown_file(readme)
+
+    assert f"{readme}: missing path missing.md" in errors
+    assert f"{readme}: missing anchor #nope" in errors
+    assert f"{readme}: missing anchor #nope in guide.md" in errors
+
+
+def test_markdown_link_checker_cli_scans_directories(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "guide.md").write_text("# Guide\n", encoding="utf-8")
+
+    result = _run_script(LINK_CHECKER_PATH, str(docs_dir))
+
+    assert result.returncode == 0
+    assert "Validated markdown links in 1 file(s)." in result.stdout
+
+
+def test_coverage_drop_check_passes_without_previous_baseline(tmp_path: Path) -> None:
+    current = tmp_path / "coverage.json"
+    summary = tmp_path / "summary.md"
+    _write_coverage(current, 91.5)
+
+    result = _run_script(
+        COVERAGE_CHECKER_PATH,
+        "--current",
+        str(current),
+        "--summary-file",
+        str(summary),
+    )
+
+    assert result.returncode == 0
+    assert "Baseline coverage: unavailable" in result.stdout
+    assert "no drop check ran" in summary.read_text(encoding="utf-8")
+
+
+def test_coverage_drop_check_fails_when_coverage_drops(tmp_path: Path) -> None:
+    current = tmp_path / "current.json"
+    previous = tmp_path / "previous.json"
+    _write_coverage(current, 88.0)
+    _write_coverage(previous, 90.0)
+
+    result = _run_script(
+        COVERAGE_CHECKER_PATH,
+        "--current",
+        str(current),
+        "--previous",
+        str(previous),
+        "--baseline-label",
+        "run 42",
+    )
+
+    assert result.returncode == 1
+    assert "Baseline coverage (run 42): 90.00%" in result.stdout
+    assert "coverage dropped by 2.00 percentage points" in result.stdout.lower()
+    assert "Coverage dropped from 90.00% to 88.00%." in result.stderr
+
+
+def test_coverage_drop_check_passes_when_coverage_improves(tmp_path: Path) -> None:
+    current = tmp_path / "current.json"
+    previous = tmp_path / "previous.json"
+    _write_coverage(current, 92.0)
+    _write_coverage(previous, 90.0)
+
+    result = _run_script(
+        COVERAGE_CHECKER_PATH,
+        "--current",
+        str(current),
+        "--previous",
+        str(previous),
+    )
+
+    assert result.returncode == 0
+    assert "coverage improved by 2.00 percentage points" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add a dedicated `main-maintenance.yml` workflow for pushes to `main` and manual dispatches
- validate repo-local markdown links, wiki rendering, and maintenance helper scripts before the full coverage run
- upload a coverage artifact and fail when coverage drops versus the previous successful maintenance run

Closes #36

## Testing
- `python3 -m ruff check scripts/check_coverage_drop.py scripts/check_markdown_links.py tests/test_maintenance_scripts.py tests/test_docs.py`
- `python3 -m pytest tests/test_maintenance_scripts.py tests/test_docs.py tests/test_sync_wiki.py`
- `python3 scripts/check_markdown_links.py README.md docs`
- `python3 scripts/sync_wiki.py render --out-dir /tmp/knives-out-wiki-render-main-maintenance`
- `python3 -m pytest tests/test_examples.py` *(not runnable in this local host because only Python 3.9 is available and the project requires Python 3.12 for `datetime.UTC`; covered by GitHub Actions instead)*