### PR TITLE
[codex] Add README coverage badge

### DIFF
--- a/.github/workflows/main-maintenance.yml
+++ b/.github/workflows/main-maintenance.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   actions: read
-  contents: read
+  contents: write
 
 concurrency:
   group: main-maintenance-${{ github.ref }}
@@ -53,6 +53,15 @@ jobs:
           name: main-maintenance-coverage
           path: coverage.json
           if-no-files-found: error
+
+      - name: Publish coverage badge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/sync_coverage_badge.py publish \
+            --coverage-json coverage.json \
+            --checkout-dir "${{ runner.temp }}/coverage-badge" \
+            --remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
       - name: Find previous successful coverage baseline
         id: previous-baseline

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # knives-out
 
 [![CI](https://github.com/keithwegner/knives-out/actions/workflows/ci.yml/badge.svg)](https://github.com/keithwegner/knives-out/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/keithwegner/knives-out/badges/coverage-badge.json)](https://github.com/keithwegner/knives-out/actions/workflows/main-maintenance.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -368,8 +368,10 @@ The `main-maintenance.yml` workflow currently runs:
 - `python scripts/check_markdown_links.py README.md docs`
 - `python scripts/sync_wiki.py render --out-dir ...`
 - `pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json`
+- `python scripts/sync_coverage_badge.py publish ...`
 
 After the full test pass, it uploads `coverage.json` as the `main-maintenance-coverage` artifact,
-downloads the previous successful artifact from the same workflow on `main`, and fails if total
-coverage drops. The first successful run seeds that baseline automatically, so there is no separate
-manual setup step.
+publishes a Shields-compatible `coverage-badge.json` file to the repo's `badges` branch for the
+README badge, downloads the previous successful artifact from the same workflow on `main`, and
+fails if total coverage drops. The first successful run seeds both the baseline and badge branch
+automatically, so there is no separate manual setup step.

--- a/scripts/sync_coverage_badge.py
+++ b/scripts/sync_coverage_badge.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BADGE_BRANCH = "badges"
+BADGE_PATH = "coverage-badge.json"
+SYNC_COMMIT_MESSAGE = "docs: sync coverage badge"
+BOT_NAME = "github-actions[bot]"
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    committed: bool
+    coverage_percent: float
+    branch: str
+    badge_path: str
+
+
+def load_coverage_percent(path: Path) -> float:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    totals = payload.get("totals", {})
+    if "percent_covered" in totals:
+        return float(totals["percent_covered"])
+    if "percent_covered_display" in totals:
+        return float(totals["percent_covered_display"])
+    raise ValueError(f"Could not find total coverage percentage in {path}")
+
+
+def badge_color(coverage_percent: float) -> str:
+    if coverage_percent >= 95:
+        return "brightgreen"
+    if coverage_percent >= 90:
+        return "green"
+    if coverage_percent >= 80:
+        return "yellowgreen"
+    if coverage_percent >= 70:
+        return "yellow"
+    if coverage_percent >= 60:
+        return "orange"
+    return "red"
+
+
+def render_badge_payload(coverage_percent: float) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "label": "coverage",
+        "message": f"{coverage_percent:.1f}%",
+        "color": badge_color(coverage_percent),
+    }
+
+
+def write_badge(path: Path, payload: dict[str, object]) -> bool:
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    previous = path.read_text(encoding="utf-8") if path.exists() else None
+    if previous == rendered:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered, encoding="utf-8")
+    return True
+
+
+def git_output(args: list[str], *, cwd: Path | None = None) -> str:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def run_command(args: list[str], *, cwd: Path | None = None) -> None:
+    subprocess.run(args, cwd=cwd, check=True)
+
+
+def derive_repo_remote(repo_root: Path) -> str:
+    return git_output(["git", "-C", str(repo_root), "remote", "get-url", "origin"])
+
+
+def ensure_git_checkout(checkout_dir: Path) -> None:
+    if not checkout_dir.exists():
+        checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+        run_command(["git", "init", str(checkout_dir)])
+        return
+
+    if not (checkout_dir / ".git").exists():
+        raise SystemExit(f"{checkout_dir} exists but is not a git checkout.")
+
+
+def ensure_remote(checkout_dir: Path, remote: str) -> None:
+    remotes = git_output(["git", "-C", str(checkout_dir), "remote"]).splitlines()
+    if "origin" in remotes:
+        run_command(["git", "-C", str(checkout_dir), "remote", "set-url", "origin", remote])
+        return
+    run_command(["git", "-C", str(checkout_dir), "remote", "add", "origin", remote])
+
+
+def ensure_git_identity(checkout_dir: Path) -> None:
+    name_result = subprocess.run(
+        ["git", "-C", str(checkout_dir), "config", "--get", "user.name"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    email_result = subprocess.run(
+        ["git", "-C", str(checkout_dir), "config", "--get", "user.email"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if not name_result.stdout.strip():
+        run_command(["git", "-C", str(checkout_dir), "config", "user.name", BOT_NAME])
+    if not email_result.stdout.strip():
+        run_command(["git", "-C", str(checkout_dir), "config", "user.email", BOT_EMAIL])
+
+
+def clear_checkout_contents(checkout_dir: Path) -> None:
+    for path in checkout_dir.iterdir():
+        if path.name == ".git":
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def checkout_branch(checkout_dir: Path, branch: str) -> None:
+    fetch = subprocess.run(
+        ["git", "-C", str(checkout_dir), "fetch", "--depth=1", "origin", branch],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if fetch.returncode == 0:
+        run_command(["git", "-C", str(checkout_dir), "checkout", "-B", branch, "FETCH_HEAD"])
+        return
+
+    run_command(["git", "-C", str(checkout_dir), "checkout", "--orphan", branch])
+    clear_checkout_contents(checkout_dir)
+
+
+def has_staged_changes(repo_dir: Path, path: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "diff", "--cached", "--quiet", "--", path],
+        check=False,
+    )
+    return result.returncode == 1
+
+
+def publish_badge(
+    repo_root: Path,
+    coverage_json: Path,
+    checkout_dir: Path,
+    *,
+    remote: str | None = None,
+    branch: str = BADGE_BRANCH,
+    badge_path: str = BADGE_PATH,
+) -> PublishResult:
+    remote = remote or derive_repo_remote(repo_root)
+    coverage_percent = load_coverage_percent(coverage_json)
+    payload = render_badge_payload(coverage_percent)
+
+    ensure_git_checkout(checkout_dir)
+    ensure_remote(checkout_dir, remote)
+    checkout_branch(checkout_dir, branch)
+    ensure_git_identity(checkout_dir)
+
+    badge_file = checkout_dir / badge_path
+    write_badge(badge_file, payload)
+
+    run_command(["git", "-C", str(checkout_dir), "add", "--", badge_path])
+    if not has_staged_changes(checkout_dir, badge_path):
+        return PublishResult(
+            committed=False,
+            coverage_percent=coverage_percent,
+            branch=branch,
+            badge_path=badge_path,
+        )
+
+    run_command(["git", "-C", str(checkout_dir), "commit", "-m", SYNC_COMMIT_MESSAGE])
+    run_command(["git", "-C", str(checkout_dir), "push", "origin", branch])
+    return PublishResult(
+        committed=True,
+        coverage_percent=coverage_percent,
+        branch=branch,
+        badge_path=badge_path,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render or publish the README coverage badge.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    render_parser = subparsers.add_parser("render", help="Render the coverage badge payload.")
+    render_parser.add_argument("--coverage-json", type=Path, required=True)
+    render_parser.add_argument("--out", type=Path, required=True)
+
+    publish_parser = subparsers.add_parser("publish", help="Publish the coverage badge branch.")
+    publish_parser.add_argument("--coverage-json", type=Path, required=True)
+    publish_parser.add_argument("--checkout-dir", type=Path, required=True)
+    publish_parser.add_argument("--remote", help="Override the git remote URL to publish to.")
+    publish_parser.add_argument("--branch", default=BADGE_BRANCH)
+    publish_parser.add_argument("--badge-path", default=BADGE_PATH)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "render":
+        coverage_percent = load_coverage_percent(args.coverage_json)
+        payload = render_badge_payload(coverage_percent)
+        changed = write_badge(args.out, payload)
+        print(f"Rendered coverage badge at {args.out} for {coverage_percent:.1f}% coverage.")
+        if not changed:
+            print("Coverage badge content was already up to date.")
+        return
+
+    publish_result = publish_badge(
+        ROOT,
+        args.coverage_json,
+        args.checkout_dir,
+        remote=args.remote,
+        branch=args.branch,
+        badge_path=args.badge_path,
+    )
+    if publish_result.committed:
+        print(
+            "Published coverage badge "
+            f"({publish_result.coverage_percent:.1f}%) "
+            f"to {publish_result.branch}:{publish_result.badge_path}."
+        )
+    else:
+        print(
+            "Coverage badge already matched "
+            f"{publish_result.coverage_percent:.1f}% on "
+            f"{publish_result.branch}:{publish_result.badge_path}."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -13,6 +13,8 @@ MAIN_MAINTENANCE_WORKFLOW = ROOT / ".github" / "workflows" / "main-maintenance.y
 def test_readme_includes_ci_guidance() -> None:
     readme = README.read_text(encoding="utf-8")
 
+    assert "coverage-badge.json" in readme
+    assert "actions/workflows/main-maintenance.yml" in readme
     assert "Project wiki:" in readme
     assert "https://github.com/keithwegner/knives-out/wiki" in readme
     assert "## CI usage" in readme
@@ -103,6 +105,7 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "--path /draft-orders/{draftId}" in ci_doc
     assert "Promote qualifying findings" in ci_doc
     assert "pytest --cov=src/knives_out --cov-report=term-missing" in ci_doc
+    assert "coverage-badge.json" in ci_doc
     assert "--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py" in ci_doc
     assert "--format html" in ci_doc
     assert "--artifact-root artifacts" in ci_doc
@@ -129,6 +132,7 @@ def test_main_maintenance_workflow_checks_docs_links_and_coverage_regressions() 
     assert "- main" in workflow
     assert "actions/upload-artifact@v6" in workflow
     assert "actions/github-script@v7" in workflow
+    assert "contents: write" in workflow
     assert "ruff check ." in workflow
     assert "ruff format --check ." in workflow
     assert "tests/test_maintenance_scripts.py" in workflow
@@ -141,6 +145,9 @@ def test_main_maintenance_workflow_checks_docs_links_and_coverage_regressions() 
         in workflow
     )
     assert "main-maintenance-coverage" in workflow
+    assert "python scripts/sync_coverage_badge.py publish" in workflow
+    assert "coverage-badge" in workflow
+    assert "x-access-token:${GITHUB_TOKEN}" in workflow
     assert 'workflow_id: "main-maintenance.yml"' in workflow
     assert "python scripts/check_coverage_drop.py" in workflow
 

--- a/tests/test_maintenance_scripts.py
+++ b/tests/test_maintenance_scripts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -9,6 +10,7 @@ from textwrap import dedent
 ROOT = Path(__file__).resolve().parents[1]
 LINK_CHECKER_PATH = ROOT / "scripts" / "check_markdown_links.py"
 COVERAGE_CHECKER_PATH = ROOT / "scripts" / "check_coverage_drop.py"
+COVERAGE_BADGE_SYNC_PATH = ROOT / "scripts" / "sync_coverage_badge.py"
 
 
 def _load_module(name: str, path: Path):
@@ -22,6 +24,7 @@ def _load_module(name: str, path: Path):
 
 
 LINK_CHECKER = _load_module("check_markdown_links", LINK_CHECKER_PATH)
+COVERAGE_BADGE_SYNC = _load_module("sync_coverage_badge", COVERAGE_BADGE_SYNC_PATH)
 
 
 def _run_script(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -47,6 +50,20 @@ def _write_coverage(path: Path, percent: float) -> None:
         + "\n",
         encoding="utf-8",
     )
+
+
+def _run_git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _git_output(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
 
 def test_markdown_link_checker_accepts_existing_paths_anchors_and_code_samples(
@@ -181,3 +198,84 @@ def test_coverage_drop_check_passes_when_coverage_improves(tmp_path: Path) -> No
 
     assert result.returncode == 0
     assert "coverage improved by 2.00 percentage points" in result.stdout.lower()
+
+
+def test_render_coverage_badge_uses_expected_label_message_and_color() -> None:
+    payload = COVERAGE_BADGE_SYNC.render_badge_payload(92.34)
+
+    assert payload == {
+        "schemaVersion": 1,
+        "label": "coverage",
+        "message": "92.3%",
+        "color": "green",
+    }
+
+
+def test_render_coverage_badge_write_is_stable_when_content_matches(tmp_path: Path) -> None:
+    badge_file = tmp_path / "coverage-badge.json"
+    payload = COVERAGE_BADGE_SYNC.render_badge_payload(88.8)
+
+    first = COVERAGE_BADGE_SYNC.write_badge(badge_file, payload)
+    second = COVERAGE_BADGE_SYNC.write_badge(badge_file, payload)
+
+    assert first is True
+    assert second is False
+
+
+def test_publish_coverage_badge_commits_changes_then_noops_when_content_matches(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Codex")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "codex@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Codex")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "codex@example.com")
+
+    remote_dir = tmp_path / "badges.git"
+    coverage_json = tmp_path / "coverage.json"
+    checkout_dir = tmp_path / "badge-checkout"
+    inspect_dir = tmp_path / "inspect"
+    _write_coverage(coverage_json, 91.25)
+
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=badges", str(remote_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    first_publish = COVERAGE_BADGE_SYNC.publish_badge(
+        ROOT,
+        coverage_json,
+        checkout_dir,
+        remote=str(remote_dir),
+    )
+
+    assert first_publish.committed is True
+    assert first_publish.coverage_percent == 91.25
+
+    subprocess.run(
+        ["git", "clone", str(remote_dir), str(inspect_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    first_head = _git_output(["rev-parse", "HEAD"], cwd=inspect_dir)
+    published_badge = json.loads((inspect_dir / "coverage-badge.json").read_text(encoding="utf-8"))
+
+    assert published_badge["message"] == "91.2%"
+    assert published_badge["label"] == "coverage"
+
+    second_publish = COVERAGE_BADGE_SYNC.publish_badge(
+        ROOT,
+        coverage_json,
+        checkout_dir,
+        remote=str(remote_dir),
+    )
+
+    assert second_publish.committed is False
+
+    _run_git(["pull", "--ff-only"], cwd=inspect_dir)
+    second_head = _git_output(["rev-parse", "HEAD"], cwd=inspect_dir)
+
+    assert second_head == first_head


### PR DESCRIPTION
## Summary
- add a dynamic README coverage badge backed by a repo-owned `badges` branch payload
- publish `coverage-badge.json` from `main-maintenance.yml` after each successful coverage run
- add script and test coverage for badge rendering and branch publishing

Closes #39

## Testing
- `python3 -m ruff check scripts/sync_coverage_badge.py tests/test_docs.py tests/test_maintenance_scripts.py`
- `python3 -m ruff format --check scripts/sync_coverage_badge.py tests/test_docs.py tests/test_maintenance_scripts.py`
- `python3 -m pytest tests/test_maintenance_scripts.py tests/test_docs.py tests/test_sync_wiki.py`
- `python3 scripts/check_markdown_links.py README.md docs`
- `python3 scripts/sync_coverage_badge.py render --coverage-json /tmp/coverage-badge-smoke/coverage.json --out /tmp/coverage-badge-smoke/coverage-badge.json`

## Notes
- The full project test matrix still depends on Python 3.12 in CI because the local host Python is 3.9.
- The first merged `main-maintenance.yml` run after this PR will bootstrap the `badges` branch automatically.