### PR TITLE
Add GraphQL response-shape validation

### DIFF
--- a/src/knives_out/graphql_loader.py
+++ b/src/knives_out/graphql_loader.py
@@ -19,7 +19,7 @@ from graphql import (
     get_named_type,
 )
 
-from knives_out.models import LoadedOperations, OperationSpec, ParameterSpec
+from knives_out.models import LoadedOperations, OperationSpec, ParameterSpec, ResponseSpec
 
 
 def _load_graphql_schema(path: str | Path) -> GraphQLSchema:
@@ -79,6 +79,77 @@ def _json_schema_for_input_type(type_: Any) -> tuple[dict[str, Any], bool]:
     return {"type": "string"}, False
 
 
+def _nullable_schema(schema: dict[str, Any], *, nullable: bool) -> dict[str, Any]:
+    if not nullable:
+        return schema
+    return {**schema, "nullable": True}
+
+
+def _json_schema_for_output_type(type_: Any) -> dict[str, Any]:
+    if isinstance(type_, GraphQLNonNull):
+        schema = dict(_json_schema_for_output_type(type_.of_type))
+        schema.pop("nullable", None)
+        return schema
+
+    named_type = get_named_type(type_)
+    nullable = not isinstance(type_, GraphQLNonNull)
+
+    if isinstance(type_, GraphQLList):
+        item_schema = _json_schema_for_output_type(type_.of_type)
+        return _nullable_schema({"type": "array", "items": item_schema}, nullable=nullable)
+
+    if isinstance(named_type, GraphQLScalarType):
+        scalar_name = named_type.name
+        if scalar_name == "Int":
+            return _nullable_schema({"type": "integer"}, nullable=nullable)
+        if scalar_name == "Float":
+            return _nullable_schema({"type": "number"}, nullable=nullable)
+        if scalar_name == "Boolean":
+            return _nullable_schema({"type": "boolean"}, nullable=nullable)
+        return _nullable_schema({"type": "string"}, nullable=nullable)
+
+    if isinstance(named_type, GraphQLEnumType):
+        return _nullable_schema(
+            {"type": "string", "enum": list(named_type.values)},
+            nullable=nullable,
+        )
+
+    if isinstance(named_type, GraphQLObjectType):
+        return _nullable_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "__typename": {
+                        "type": "string",
+                        "const": named_type.name,
+                    }
+                },
+                "required": ["__typename"],
+            },
+            nullable=nullable,
+        )
+
+    if isinstance(named_type, (GraphQLInterfaceType, GraphQLUnionType)):
+        possible_types = [
+            possible.name for possible in named_type.schema.get_possible_types(named_type)
+        ]
+        typename_schema: dict[str, Any] = {"type": "string"}
+        if possible_types:
+            typename_schema["enum"] = possible_types
+        return _nullable_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "__typename": typename_schema,
+                },
+                "required": ["__typename"],
+            },
+            nullable=nullable,
+        )
+
+    return _nullable_schema({"type": "string"}, nullable=nullable)
+
+
 def _selection_set_for_output_type(type_: Any) -> str:
     named_type = get_named_type(type_)
     if isinstance(named_type, (GraphQLObjectType, GraphQLInterfaceType, GraphQLUnionType)):
@@ -135,6 +206,22 @@ def _request_body_schema(document: str, variables_schema: dict[str, Any]) -> dic
     return schema
 
 
+def _response_schema(field_name: str, field: Any) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "object",
+                "properties": {
+                    field_name: _json_schema_for_output_type(field.type),
+                },
+                "required": [field_name],
+            }
+        },
+        "required": ["data"],
+    }
+
+
 def _operation_specs(
     *,
     root: GraphQLObjectType | None,
@@ -172,6 +259,12 @@ def _operation_specs(
                 request_body_required=True,
                 request_body_schema=_request_body_schema(document, variables_schema),
                 request_body_content_type="application/json",
+                response_schemas={
+                    "200": ResponseSpec(
+                        content_type="application/json",
+                        schema_def=_response_schema(field_name, field),
+                    )
+                },
                 graphql_operation_type=operation_type,
                 graphql_document=document,
                 graphql_variables_schema=variables_schema,

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -466,6 +466,12 @@ def _validate_response_schema(
     attack: AttackCase,
     response: httpx.Response,
 ) -> tuple[str | None, bool | None, str | None]:
+    if (
+        "graphql_error" in {expected.strip().lower() for expected in attack.expected_outcomes}
+        and _response_has_graphql_errors(response)
+    ):
+        return None, None, None
+
     matched_status, response_spec = _matched_response_schema(attack, response.status_code)
     if response_spec is None:
         return None, None, None

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -466,10 +466,9 @@ def _validate_response_schema(
     attack: AttackCase,
     response: httpx.Response,
 ) -> tuple[str | None, bool | None, str | None]:
-    if (
-        "graphql_error" in {expected.strip().lower() for expected in attack.expected_outcomes}
-        and _response_has_graphql_errors(response)
-    ):
+    if "graphql_error" in {
+        expected.strip().lower() for expected in attack.expected_outcomes
+    } and _response_has_graphql_errors(response):
         return None, None, None
 
     matched_status, response_spec = _matched_response_schema(attack, response.status_code)

--- a/tests/test_graphql_generator.py
+++ b/tests/test_graphql_generator.py
@@ -30,5 +30,24 @@ def test_generate_graphql_attack_suite_emits_variable_mutations() -> None:
     )
     assert wrong_type_attack.path == "/graphql"
     assert wrong_type_attack.expected_outcomes == ["graphql_error", "4xx"]
+    assert wrong_type_attack.response_schemas["200"].schema_def == {
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "object",
+                "properties": {
+                    "createBook": {
+                        "type": "object",
+                        "properties": {
+                            "__typename": {"type": "string", "const": "Book"},
+                        },
+                        "required": ["__typename"],
+                    }
+                },
+                "required": ["createBook"],
+            }
+        },
+        "required": ["data"],
+    }
     assert wrong_type_attack.body_json["query"].startswith("mutation CreateBook")
     assert "variables" in wrong_type_attack.body_json

--- a/tests/test_graphql_loader.py
+++ b/tests/test_graphql_loader.py
@@ -66,6 +66,27 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
         "properties": {"id": {"type": "string"}},
         "required": ["id"],
     }
+    assert book.response_schemas["200"].content_type == "application/json"
+    assert book.response_schemas["200"].schema_def == {
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "object",
+                "properties": {
+                    "book": {
+                        "type": "object",
+                        "properties": {
+                            "__typename": {"type": "string", "const": "Book"},
+                        },
+                        "required": ["__typename"],
+                        "nullable": True,
+                    }
+                },
+                "required": ["book"],
+            }
+        },
+        "required": ["data"],
+    }
 
     create_book = operations[-1]
     assert create_book.graphql_operation_type == "mutation"
@@ -83,6 +104,25 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
             }
         },
         "required": ["input"],
+    }
+    assert create_book.response_schemas["200"].schema_def == {
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "object",
+                "properties": {
+                    "createBook": {
+                        "type": "object",
+                        "properties": {
+                            "__typename": {"type": "string", "const": "Book"},
+                        },
+                        "required": ["__typename"],
+                    }
+                },
+                "required": ["createBook"],
+            }
+        },
+        "required": ["data"],
     }
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1310,6 +1310,34 @@ def test_execute_attack_suite_treats_graphql_errors_as_expected_failures(monkeyp
                         "variables": {"id": 123},
                     },
                     expected_outcomes=["graphql_error", "4xx"],
+                    response_schemas={
+                        "200": {
+                            "content_type": "application/json",
+                            "schema_def": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "type": "object",
+                                        "properties": {
+                                            "book": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "__typename": {
+                                                        "type": "string",
+                                                        "const": "Book",
+                                                    }
+                                                },
+                                                "required": ["__typename"],
+                                                "nullable": True,
+                                            }
+                                        },
+                                        "required": ["book"],
+                                    }
+                                },
+                                "required": ["data"],
+                            },
+                        }
+                    },
                 )
             ],
         ),
@@ -1320,6 +1348,8 @@ def test_execute_attack_suite_treats_graphql_errors_as_expected_failures(monkeyp
     assert result.flagged is False
     assert result.issue is None
     assert result.status_code == 200
+    assert result.response_schema_status is None
+    assert result.response_schema_valid is None
 
 
 def test_execute_attack_suite_flags_graphql_success_without_errors(monkeypatch) -> None:
@@ -1354,6 +1384,71 @@ def test_execute_attack_suite_flags_graphql_success_without_errors(monkeypatch) 
     result = results.results[0]
     assert result.flagged is True
     assert result.issue == "unexpected_success"
+
+
+def test_execute_attack_suite_flags_graphql_response_shape_mismatch(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(200, json={"data": {"book": {"id": "book-1"}}}),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                AttackCase(
+                    id="atk_graphql_shape",
+                    name="Wrong-type GraphQL variable",
+                    kind="wrong_type_variable",
+                    operation_id="book",
+                    method="POST",
+                    path="/graphql",
+                    description="Wrong type for GraphQL variable.",
+                    body_json={
+                        "query": "query Book($id: ID!) { book(id: $id) { __typename } }",
+                        "variables": {"id": 123},
+                    },
+                    expected_outcomes=["graphql_error", "4xx"],
+                    response_schemas={
+                        "200": {
+                            "content_type": "application/json",
+                            "schema_def": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "type": "object",
+                                        "properties": {
+                                            "book": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "__typename": {
+                                                        "type": "string",
+                                                        "const": "Book",
+                                                    }
+                                                },
+                                                "required": ["__typename"],
+                                                "nullable": True,
+                                            }
+                                        },
+                                        "required": ["book"],
+                                    }
+                                },
+                                "required": ["data"],
+                            },
+                        }
+                    },
+                )
+            ],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "response_schema_mismatch"
+    assert result.response_schema_status == "200"
+    assert result.response_schema_valid is False
+    assert result.response_schema_error == "$.data.book: missing required property '__typename'"
 
 
 def test_render_markdown_report_shows_workflow_sections() -> None:


### PR DESCRIPTION
## Summary
- derive GraphQL success-response schemas from the selected root field type
- attach 200 response schemas to generated GraphQL operations and attacks
- skip schema validation when a GraphQL error response is explicitly expected
- add loader, generator, and runner coverage for GraphQL response-shape validation

Closes #45

## Verification
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest tests/test_graphql_loader.py tests/test_graphql_generator.py tests/test_runner.py -q`
- `.venv/bin/python -m ruff check src/knives_out/graphql_loader.py src/knives_out/runner.py tests/test_graphql_loader.py tests/test_graphql_generator.py tests/test_runner.py`