### PR TITLE
[codex] add inspect json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Inspect the sample specs:
 knives-out inspect examples/openapi/petstore.yaml
 knives-out inspect examples/openapi/storefront.yaml --tag orders
 knives-out inspect examples/graphql/library.graphql
+knives-out inspect examples/openapi/storefront.yaml --tag orders --format json
 ```
 
 Generate attacks:
@@ -287,6 +288,14 @@ You can filter inspection to exact tags or paths:
 knives-out inspect examples/openapi/storefront.yaml \
   --tag orders \
   --path /draft-orders/{draftId}
+```
+
+When you want to hand the inventory to CI or wrapper tooling, switch to JSON output:
+
+```bash
+knives-out inspect examples/openapi/storefront.yaml \
+  --tag orders \
+  --format json
 ```
 
 ### `generate`

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
@@ -80,6 +81,11 @@ class ReportFormatOption(StrEnum):
     html = "html"
 
 
+class InspectFormatOption(StrEnum):
+    text = "text"
+    json = "json"
+
+
 def _parse_key_value(items: list[str] | None, *, separator: str) -> dict[str, Any]:
     parsed: dict[str, Any] = {}
     for item in items or []:
@@ -116,6 +122,26 @@ def _print_preflight_warnings(warnings: list[PreflightWarning]) -> None:
 
     console.print("")
     console.print(table)
+
+
+def _inspect_payload(
+    *,
+    spec: Path,
+    source_kind: str,
+    operation_count: int,
+    operations: list[Any],
+    warnings: list[PreflightWarning],
+    learned_workflow_count: int,
+) -> dict[str, Any]:
+    return {
+        "source": str(spec),
+        "source_kind": source_kind,
+        "operation_count": operation_count,
+        "operations": [operation.model_dump(mode="json") for operation in operations],
+        "warning_count": len(warnings),
+        "warnings": [warning.model_dump(mode="json") for warning in warnings],
+        "learned_workflow_count": learned_workflow_count,
+    }
 
 
 def _load_attack_results_or_error(path: Path, *, label: str) -> AttackResults:
@@ -313,6 +339,10 @@ def inspect(
         list[str] | None,
         typer.Option(help="Exclude operations for these exact OpenAPI paths. Repeatable."),
     ] = None,
+    format: Annotated[
+        InspectFormatOption,
+        typer.Option(help="Output format for inspection results."),
+    ] = InspectFormatOption.text,
 ) -> None:
     """Show the operations discovered in an OpenAPI, GraphQL, or learned model."""
     loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
@@ -323,6 +353,21 @@ def inspect(
         include_tags=tag,
         exclude_tags=exclude_tag,
     )
+    learned_workflow_count = (
+        len(loaded.learned_model.workflows) if loaded.learned_model is not None else 0
+    )
+
+    if format == InspectFormatOption.json:
+        payload = _inspect_payload(
+            spec=spec,
+            source_kind=loaded.source_kind,
+            operation_count=len(operations),
+            operations=operations,
+            warnings=loaded.warnings,
+            learned_workflow_count=learned_workflow_count,
+        )
+        typer.echo(json.dumps(payload, indent=2))
+        return
 
     table = Table(title=f"knives-out inspect: {spec}")
     table.add_column("Operation ID")
@@ -355,7 +400,7 @@ def inspect(
     console.print(table)
     console.print(f"\nFound {len(operations)} operations.")
     if loaded.learned_model is not None:
-        console.print(f"Learned workflows: {len(loaded.learned_model.workflows)}.")
+        console.print(f"Learned workflows: {learned_workflow_count}.")
     _print_preflight_warnings(loaded.warnings)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 from textwrap import dedent
@@ -115,6 +116,68 @@ def test_inspect_command_supports_graphql_schema(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "Found 4 operations." in result.stdout
     assert "/api/graphql" in result.stdout
+
+
+def test_inspect_command_supports_json_output(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "knives_out.cli.load_operations_with_warnings",
+        lambda spec, **_: LoadedOperations(
+            source_kind="learned",
+            operations=[
+                {
+                    "operation_id": "listPets",
+                    "method": "GET",
+                    "path": "/pets",
+                    "tags": ["pets", "read"],
+                    "parameters": [{"name": "limit", "location": "query"}],
+                    "auth_required": False,
+                    "learned_confidence": 0.75,
+                },
+                {
+                    "operation_id": "createPet",
+                    "method": "POST",
+                    "path": "/pets",
+                    "tags": ["pets", "write"],
+                    "request_body_schema": {"type": "object"},
+                    "auth_required": True,
+                },
+            ],
+            warnings=[
+                PreflightWarning(
+                    code="missing_request_schema",
+                    message="Request body is declared but no usable schema was found.",
+                    operation_id="createPet",
+                    method="POST",
+                    path="/pets",
+                )
+            ],
+            learned_model={
+                "workflows": [
+                    {
+                        "id": "wf_create_pet",
+                        "name": "Create pet flow",
+                        "producer_operation_id": "createPet",
+                        "consumer_operation_id": "listPets",
+                    }
+                ]
+            },
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["inspect", str(EXAMPLE_SPEC), "--tag", "write", "--format", "json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["source"] == str(EXAMPLE_SPEC)
+    assert payload["source_kind"] == "learned"
+    assert payload["operation_count"] == 1
+    assert payload["warning_count"] == 1
+    assert payload["learned_workflow_count"] == 1
+    assert [operation["operation_id"] for operation in payload["operations"]] == ["createPet"]
+    assert payload["warnings"][0]["code"] == "missing_request_schema"
 
 
 def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -32,6 +32,7 @@ def test_readme_includes_ci_guidance() -> None:
     assert "--auto-workflows" in readme
     assert "--tag orders" in readme
     assert "--path /draft-orders/{draftId}" in readme
+    assert "--format json" in readme
     assert "knives-out report results.json --format html" in readme
     assert "--artifact-root artifacts" in readme
     assert "report.html" in readme


### PR DESCRIPTION
## Summary
- add `--format text|json` to `knives-out inspect`
- emit machine-readable inspection payloads for filtered operations, warnings, and learned workflow counts
- document the new JSON mode and cover it with CLI/docs tests

## Validation
- `.venv/bin/pytest tests/test_cli.py tests/test_docs.py`
- `.venv/bin/ruff check src/knives_out/cli.py tests/test_cli.py tests/test_docs.py`
- `.venv/bin/knives-out inspect examples/openapi/storefront.yaml --tag orders --format json`

Closes #50
