### PR TITLE
[codex] Add persisting baseline deltas to reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ knives-out report results.json --out report.md
 ```
 
 You can include a prior `results.json` as a baseline to add regression sections for new, resolved,
-and persisting findings:
+and persisting findings. Persisting entries also show whether severity, confidence, status, or
+schema outcome drifted since the baseline:
 
 ```bash
 knives-out report results.json --baseline previous-results.json --out report.md

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -330,7 +330,8 @@ per-profile outcome tables for deeper authorization review.
 
 ## Optional: baseline-aware report
 
-You can also render a Markdown report that highlights new, resolved, and persisting findings:
+You can also render a Markdown report that highlights new, resolved, and persisting findings,
+including delta notes when a persisting finding changed severity, confidence, status, or schema:
 
 ```yaml
 - name: Render baseline-aware report

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -652,9 +652,12 @@ def render_html_report(
         persisting_delta_count = sum(
             1 for finding in comparison.persisting_findings if finding.has_delta
         )
-        persisting_rows = "".join(
-            _persisting_finding_row_html(finding) for finding in comparison.persisting_findings
-        ) or "<tr><td colspan='9' class='muted'>No persisting findings.</td></tr>"
+        persisting_rows = (
+            "".join(
+                _persisting_finding_row_html(finding) for finding in comparison.persisting_findings
+            )
+            or "<tr><td colspan='9' class='muted'>No persisting findings.</td></tr>"
+        )
         diff_panels = (
             "<section class='panel'>"
             "<h2>Regression summary</h2>"

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -32,6 +32,20 @@ def _finding_table_rows(findings: list[ComparedFinding]) -> list[str]:
     return rows
 
 
+def _persisting_table_rows(findings: list[ComparedFinding]) -> list[str]:
+    rows: list[str] = []
+    for finding in findings:
+        result = finding.result
+        status = str(result.status_code) if result.status_code is not None else "-"
+        schema = "mismatch" if result.response_schema_valid is False else "-"
+        rows.append(
+            f"| {result.name} | {result.kind} | {status} | "
+            f"{result.issue or '-'} | {result.severity} | {result.confidence} | "
+            f"{schema} | {finding.delta_summary} | `{result.url}` |"
+        )
+    return rows
+
+
 def _suppressed_table_rows(findings: list[SuppressedFinding]) -> list[str]:
     rows: list[str] = []
     for finding in findings:
@@ -224,6 +238,10 @@ def render_markdown_report(
         lines.append(f"- Resolved findings: **{len(comparison.resolved_findings)}**")
         lines.append(f"- Persisting findings: **{len(comparison.persisting_findings)}**")
         lines.append(
+            "- Persisting findings with delta: "
+            f"**{sum(1 for finding in comparison.persisting_findings if finding.has_delta)}**"
+        )
+        lines.append(
             f"- Suppressed current findings: **{len(comparison.suppressed_current_findings)}**"
         )
 
@@ -248,11 +266,13 @@ def render_markdown_report(
         lines.append("")
         lines.append("## Persisting findings")
         lines.append("")
-        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
-        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
-        lines.extend(_finding_table_rows(comparison.persisting_findings))
+        lines.append(
+            "| Attack | Kind | Status | Issue | Severity | Confidence | Schema | Delta | URL |"
+        )
+        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- | --- |")
+        lines.extend(_persisting_table_rows(comparison.persisting_findings))
         if not comparison.persisting_findings:
-            lines.append("| None | - | - | - | - | - | - | - |")
+            lines.append("| None | - | - | - | - | - | - | - | - |")
 
     lines.append("")
     lines.append("## Detailed results")
@@ -371,6 +391,25 @@ def _summary_card_html(label: str, value: str) -> str:
         f"<span class='label'>{escape(label)}</span>"
         f"<strong>{escape(value)}</strong>"
         "</div>"
+    )
+
+
+def _persisting_finding_row_html(finding: ComparedFinding) -> str:
+    result = finding.result
+    status = str(result.status_code) if result.status_code is not None else "-"
+    schema = "mismatch" if result.response_schema_valid is False else "-"
+    return (
+        "<tr>"
+        f"<td>{escape(result.name)}</td>"
+        f"<td>{escape(result.kind)}</td>"
+        f"<td>{escape(status)}</td>"
+        f"<td>{escape(result.issue or '-')}</td>"
+        f"<td>{escape(result.severity)}</td>"
+        f"<td>{escape(result.confidence)}</td>"
+        f"<td>{escape(schema)}</td>"
+        f"<td>{escape(finding.delta_summary)}</td>"
+        f"<td><code>{escape(result.url)}</code></td>"
+        "</tr>"
     )
 
 
@@ -610,6 +649,12 @@ def render_html_report(
 
     diff_panels = ""
     if baseline is not None:
+        persisting_delta_count = sum(
+            1 for finding in comparison.persisting_findings if finding.has_delta
+        )
+        persisting_rows = "".join(
+            _persisting_finding_row_html(finding) for finding in comparison.persisting_findings
+        ) or "<tr><td colspan='9' class='muted'>No persisting findings.</td></tr>"
         diff_panels = (
             "<section class='panel'>"
             "<h2>Regression summary</h2>"
@@ -618,7 +663,16 @@ def render_html_report(
             f"{_summary_card_html('New findings', str(len(comparison.new_findings)))}"
             f"{_summary_card_html('Resolved findings', str(len(comparison.resolved_findings)))}"
             f"{_summary_card_html('Persisting findings', str(len(comparison.persisting_findings)))}"
+            f"{_summary_card_html('Persisting with delta', str(persisting_delta_count))}"
             "</div></section>"
+            "<section class='panel'>"
+            "<h2>Persisting findings</h2>"
+            "<table>"
+            "<thead><tr><th>Attack</th><th>Kind</th><th>Status</th><th>Issue</th>"
+            "<th>Severity</th><th>Confidence</th><th>Schema</th><th>Delta</th><th>URL</th></tr></thead>"
+            f"<tbody>{persisting_rows}</tbody>"
+            "</table>"
+            "</section>"
         )
 
     cards_html = "".join(

--- a/src/knives_out/verification.py
+++ b/src/knives_out/verification.py
@@ -60,9 +60,7 @@ class ComparedFinding:
         if self.baseline.severity != self.current.severity:
             fragments.append(f"severity {self.baseline.severity} -> {self.current.severity}")
         if self.baseline.confidence != self.current.confidence:
-            fragments.append(
-                f"confidence {self.baseline.confidence} -> {self.current.confidence}"
-            )
+            fragments.append(f"confidence {self.baseline.confidence} -> {self.current.confidence}")
         if self.baseline.status_code != self.current.status_code:
             previous_status = (
                 str(self.baseline.status_code) if self.baseline.status_code is not None else "-"
@@ -72,9 +70,7 @@ class ComparedFinding:
             )
             fragments.append(f"status {previous_status} -> {current_status}")
         if self.baseline.response_schema_valid != self.current.response_schema_valid:
-            previous_schema = (
-                "mismatch" if self.baseline.response_schema_valid is False else "ok"
-            )
+            previous_schema = "mismatch" if self.baseline.response_schema_valid is False else "ok"
             current_schema = "mismatch" if self.current.response_schema_valid is False else "ok"
             fragments.append(f"schema {previous_schema} -> {current_schema}")
         return fragments

--- a/src/knives_out/verification.py
+++ b/src/knives_out/verification.py
@@ -51,6 +51,42 @@ class ComparedFinding:
             raise ValueError("ComparedFinding requires a flagged result with an issue.")
         return issue
 
+    @property
+    def delta_fragments(self) -> list[str]:
+        if self.current is None or self.baseline is None:
+            return []
+
+        fragments: list[str] = []
+        if self.baseline.severity != self.current.severity:
+            fragments.append(f"severity {self.baseline.severity} -> {self.current.severity}")
+        if self.baseline.confidence != self.current.confidence:
+            fragments.append(
+                f"confidence {self.baseline.confidence} -> {self.current.confidence}"
+            )
+        if self.baseline.status_code != self.current.status_code:
+            previous_status = (
+                str(self.baseline.status_code) if self.baseline.status_code is not None else "-"
+            )
+            current_status = (
+                str(self.current.status_code) if self.current.status_code is not None else "-"
+            )
+            fragments.append(f"status {previous_status} -> {current_status}")
+        if self.baseline.response_schema_valid != self.current.response_schema_valid:
+            previous_schema = (
+                "mismatch" if self.baseline.response_schema_valid is False else "ok"
+            )
+            current_schema = "mismatch" if self.current.response_schema_valid is False else "ok"
+            fragments.append(f"schema {previous_schema} -> {current_schema}")
+        return fragments
+
+    @property
+    def has_delta(self) -> bool:
+        return bool(self.delta_fragments)
+
+    @property
+    def delta_summary(self) -> str:
+        return "; ".join(self.delta_fragments) or "unchanged"
+
 
 @dataclass(frozen=True)
 class ResultComparison:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,10 +185,10 @@ def test_report_command_supports_baseline(tmp_path: Path) -> None:
                 name="Persisting mismatch",
                 method="POST",
                 url="https://example.com/pets",
-                status_code=200,
+                status_code=500,
                 flagged=True,
                 issue="response_schema_mismatch",
-                severity="medium",
+                severity="high",
                 confidence="high",
             ),
         ),
@@ -203,11 +203,11 @@ def test_report_command_supports_baseline(tmp_path: Path) -> None:
                 name="Persisting mismatch",
                 method="POST",
                 url="https://example.com/pets",
-                status_code=200,
+                status_code=401,
                 flagged=True,
                 issue="response_schema_mismatch",
                 severity="medium",
-                confidence="high",
+                confidence="low",
             ),
             AttackResult(
                 attack_id="atk_old",
@@ -243,6 +243,8 @@ def test_report_command_supports_baseline(tmp_path: Path) -> None:
     assert "## New findings" in report
     assert "## Resolved findings" in report
     assert "## Persisting findings" in report
+    assert "Persisting findings with delta: **1**" in report
+    assert "severity medium -> high; confidence low -> high; status 401 -> 500" in report
 
 
 def test_report_command_supports_html_and_artifact_links(tmp_path: Path) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -480,6 +480,52 @@ def test_render_markdown_report_with_baseline_shows_regression_sections() -> Non
     assert "Persisting mismatch" in report
 
 
+def test_render_markdown_report_shows_persisting_deltas() -> None:
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ],
+    )
+    baseline = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=401,
+                flagged=True,
+                issue="server_error",
+                severity="medium",
+                confidence="low",
+            )
+        ],
+    )
+
+    report = render_markdown_report(current, baseline=baseline)
+
+    assert "Persisting findings with delta: **1**" in report
+    assert "severity medium -> high; confidence low -> high; status 401 -> 500" in report
+
+
 def test_render_markdown_report_shows_suppressed_findings() -> None:
     results = AttackResults(
         source="unit",
@@ -1456,6 +1502,53 @@ def test_render_html_report_shows_artifact_index_and_profile_outcomes(tmp_path: 
     assert "wf_lookup-step-01.json" in report
     assert "<h4>Profile outcomes</h4>" in report
     assert "anonymous (anonymous)" in report
+
+
+def test_render_html_report_shows_persisting_deltas() -> None:
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ],
+    )
+    baseline = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=401,
+                flagged=True,
+                issue="server_error",
+                severity="medium",
+                confidence="low",
+            )
+        ],
+    )
+
+    report = render_html_report(current, baseline=baseline)
+
+    assert "Persisting with delta" in report
+    assert "<h2>Persisting findings</h2>" in report
+    assert "severity medium -&gt; high; confidence low -&gt; high; status 401 -&gt; 500" in report
 
 
 def test_render_html_report_shows_auth_summary() -> None:

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -63,6 +63,32 @@ def test_compare_attack_results_classifies_new_resolved_and_persisting_findings(
     assert [finding.attack_id for finding in comparison.persisting_findings] == ["atk_shared"]
 
 
+def test_compare_attack_results_exposes_persisting_deltas() -> None:
+    current = _results(
+        _finding("atk_shared", issue="server_error", severity="high", confidence="high"),
+    )
+    baseline = _results(
+        _finding("atk_shared", issue="server_error", severity="medium", confidence="low"),
+    )
+    current.results[0].status_code = 500
+    baseline.results[0].status_code = 401
+
+    comparison = compare_attack_results(current, baseline)
+
+    assert len(comparison.persisting_findings) == 1
+    finding = comparison.persisting_findings[0]
+    assert finding.has_delta is True
+    assert finding.delta_fragments == [
+        "severity medium -> high",
+        "confidence low -> high",
+        "status 401 -> 500",
+    ]
+    assert (
+        finding.delta_summary
+        == "severity medium -> high; confidence low -> high; status 401 -> 500"
+    )
+
+
 def test_compare_attack_results_ignores_non_flagged_results() -> None:
     current = _results(
         _finding("atk_flagged", issue="server_error", severity="high", confidence="high"),


### PR DESCRIPTION
## Summary
- add delta metadata for persisting baseline findings
- surface persisting severity/confidence/status/schema drift in Markdown and HTML reports
- document the new baseline-aware review detail

## Issues
- Closes #53
- Follow-on: #54

## Validation
- `python3 -m ruff check src/knives_out/verification.py src/knives_out/reporting.py tests/test_verification.py tests/test_runner.py tests/test_cli.py`
- `python3 -m pytest tests/test_verification.py tests/test_runner.py tests/test_cli.py` *(blocked locally: system `python3` is 3.9 and repo imports require 3.12)*
- `python3.12 -m pytest tests/test_verification.py tests/test_runner.py tests/test_cli.py` *(blocked locally: pytest and project deps are not installed for 3.12 in this environment)*
