### PR TITLE
[codex] Improve auth and extension coverage

### DIFF
--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -87,3 +87,85 @@ def test_load_auth_configs_validates_required_strategy_fields(tmp_path: Path) ->
 
     with pytest.raises(ValueError, match="static_bearer auth requires 'token'"):
         load_auth_configs(config_path)
+
+
+def test_load_auth_configs_rejects_conflicting_request_payload_shapes(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n"
+        "  - name: broken\n"
+        "    strategy: client_credentials\n"
+        "    endpoint: /oauth/token\n"
+        "    token_pointer: /access_token\n"
+        "    request_json:\n"
+        "      grant_type: client_credentials\n"
+        "    request_form:\n"
+        "      grant_type: client_credentials\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Use only one of 'request_json' or 'request_form'"):
+        load_auth_configs(config_path)
+
+
+def test_load_auth_configs_requires_endpoint_and_token_pointer_for_token_flows(
+    tmp_path: Path,
+) -> None:
+    endpoint_path = tmp_path / "missing-endpoint.yml"
+    endpoint_path.write_text(
+        "auth:\n"
+        "  - name: broken\n"
+        "    strategy: client_credentials\n"
+        "    token_pointer: /access_token\n",
+        encoding="utf-8",
+    )
+    token_pointer_path = tmp_path / "missing-token-pointer.yml"
+    token_pointer_path.write_text(
+        "auth:\n  - name: broken\n    strategy: client_credentials\n    endpoint: /oauth/token\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="client_credentials auth requires 'endpoint'"):
+        load_auth_configs(endpoint_path)
+    with pytest.raises(ValueError, match="client_credentials auth requires 'token_pointer'"):
+        load_auth_configs(token_pointer_path)
+
+
+def test_load_auth_configs_rejects_non_mapping_documents(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="top-level mapping"):
+        load_auth_configs(config_path)
+
+
+def test_load_auth_configs_rejects_duplicate_names_case_insensitively(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n"
+        "  - name: User\n"
+        "    strategy: static_bearer\n"
+        "    token: user-token\n"
+        "  - name: user\n"
+        "    strategy: static_bearer\n"
+        "    token: other-token\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate auth config name 'user'"):
+        load_auth_configs(config_path)
+
+
+def test_select_auth_configs_reports_missing_names(tmp_path: Path) -> None:
+    config_path = tmp_path / "auth.yml"
+    config_path.write_text(
+        "auth:\n"
+        "  - name: user\n"
+        "    strategy: static_bearer\n"
+        "    token: user-token\n",
+        encoding="utf-8",
+    )
+    auth_file = load_auth_configs(config_path)
+
+    with pytest.raises(ValueError, match="Unknown auth config name\\(s\\): admin"):
+        select_auth_configs(auth_file, include_names=["admin"])

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -159,10 +159,7 @@ def test_load_auth_configs_rejects_duplicate_names_case_insensitively(tmp_path: 
 def test_select_auth_configs_reports_missing_names(tmp_path: Path) -> None:
     config_path = tmp_path / "auth.yml"
     config_path.write_text(
-        "auth:\n"
-        "  - name: user\n"
-        "    strategy: static_bearer\n"
-        "    token: user-token\n",
+        "auth:\n  - name: user\n    strategy: static_bearer\n    token: user-token\n",
         encoding="utf-8",
     )
     auth_file = load_auth_configs(config_path)

--- a/tests/test_builtin_auth.py
+++ b/tests/test_builtin_auth.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from knives_out.auth_config import BuiltInAuthConfig
+from knives_out.auth_plugins import PreparedRequest, RequestExecution, RuntimeContext
+from knives_out.builtin_auth import BuiltInAuthPlugin, _status_matches_expected
+
+
+class _Client:
+    def __init__(self, responses: list[httpx.Response] | None = None) -> None:
+        self.responses = list(responses or [])
+        self.requests: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
+        self.requests.append({"method": method, "url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError("No response queued.")
+        return self.responses.pop(0)
+
+
+def _context(*, client: _Client | None = None) -> RuntimeContext:
+    return RuntimeContext(
+        client=client or _Client(),
+        base_url="https://example.com/",
+        scope="suite",
+    )
+
+
+def _request() -> PreparedRequest:
+    return PreparedRequest(
+        phase="request",
+        attack_id="atk_test",
+        name="Test attack",
+        kind="missing_auth",
+        operation_id="listPets",
+        method="GET",
+        path="/pets",
+        description="Test attack",
+    )
+
+
+def test_status_matches_expected_accepts_ranges_and_exact_codes() -> None:
+    assert _status_matches_expected(204, ["", "2xx"]) is True
+    assert _status_matches_expected(401, ["200", "401"]) is True
+    assert _status_matches_expected(None, ["2xx"]) is False
+    assert _status_matches_expected(500, ["2xx", "401"]) is False
+
+
+def test_static_bearer_templates_can_resolve_env_and_nested_values(monkeypatch) -> None:
+    monkeypatch.setenv("KNIVES_OUT_TOKEN", "env-token")
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="user",
+            strategy="static_bearer",
+            token="{{env.KNIVES_OUT_TOKEN}}",
+            query_name="access_token",
+        )
+    )
+    context = _context()
+    request = _request()
+
+    plugin.before_suite(context)
+    plugin.before_request(request, context)
+
+    assert request.headers["Authorization"] == "Bearer env-token"
+    assert request.query["access_token"] == "env-token"
+    assert context.auth_events[0].success is True
+
+
+def test_static_bearer_records_failure_for_missing_env(monkeypatch) -> None:
+    monkeypatch.delenv("KNIVES_OUT_TOKEN", raising=False)
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="user",
+            strategy="static_bearer",
+            token="{{env.KNIVES_OUT_TOKEN}}",
+        )
+    )
+    context = _context()
+
+    plugin.before_suite(context)
+
+    bundle = context.state[plugin._state_key]
+    assert bundle["last_error"] == "Missing environment variable 'KNIVES_OUT_TOKEN'."
+    assert context.auth_events[0].success is False
+
+
+def test_auth_request_kwargs_support_json_headers_query_and_form_templating() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_headers={"X-Trace": "{{token}}"},
+            request_query={"tenant": "{{tenant}}"},
+            request_json={"refresh_token": "{{token}}"},
+            token_pointer="/access_token",
+        )
+    )
+    bundle = {"values": {"token": "abc123", "tenant": "acme"}}
+
+    request_kwargs = plugin._auth_request_kwargs(bundle)
+
+    assert request_kwargs == {
+        "params": {"tenant": "acme"},
+        "headers": {"X-Trace": "abc123"},
+        "json": {"refresh_token": "abc123"},
+    }
+
+
+def test_login_form_cookie_reuses_existing_session_for_same_client() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="session",
+            strategy="login_form_cookie",
+            endpoint="/login",
+            request_form={"username": "demo"},
+        )
+    )
+    context = _context()
+    context.state[plugin._state_key] = {"session_ready": True, "client_id": id(context.client)}
+
+    assert plugin._ensure_ready(context, trigger="workflow") is True
+    assert context.auth_events == []
+
+
+def test_bundle_replaces_non_mapping_state_and_before_workflow_prepares_auth() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="user",
+            strategy="static_bearer",
+            token="workflow-token",
+        )
+    )
+    context = _context()
+    context.state[plugin._state_key] = "broken"
+
+    plugin.before_workflow(None, context)
+
+    bundle = context.state[plugin._state_key]
+    assert bundle["token"] == "workflow-token"
+    assert context.auth_events[0].success is True
+
+
+def test_before_request_skips_reacquire_after_failed_request_for_same_client() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    context = _context()
+    context.state[plugin._state_key] = {"last_error": "boom", "client_id": id(context.client)}
+    request = _request()
+
+    plugin.before_request(request, context)
+
+    assert request.headers == {}
+    assert context.auth_events == []
+
+
+def test_after_request_avoids_retry_when_refresh_disabled() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+            refresh_on_401=False,
+        )
+    )
+    context = _context()
+    request = _request()
+    execution = RequestExecution(
+        url="https://example.com/pets",
+        headers={},
+        query={},
+        response=httpx.Response(401),
+        error=None,
+        duration_ms=1.0,
+    )
+
+    plugin.after_request(request, context, execution)
+
+    assert execution.retry_requested is False
+    assert context.auth_events == []
+
+
+def test_after_request_marks_retry_when_refresh_succeeds() -> None:
+    client = _Client(
+        [
+            httpx.Response(200, json={"access_token": "fresh-token", "expires_in": 60}),
+        ]
+    )
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+            expires_in_pointer="/expires_in",
+        )
+    )
+    context = _context(client=client)
+    context.state[plugin._state_key] = {"token": "expired-token"}
+    request = _request()
+    execution = RequestExecution(
+        url="https://example.com/pets",
+        headers={},
+        query={},
+        response=httpx.Response(401),
+        error=None,
+        duration_ms=1.0,
+    )
+
+    plugin.after_request(request, context, execution)
+
+    bundle = context.state[plugin._state_key]
+    assert execution.retry_requested is True
+    assert bundle["token"] == "fresh-token"
+    assert bundle["retried_request_key"] == "request:atk_test"
+    assert context.auth_events[0].phase == "refresh"
+
+
+def test_after_request_does_not_retry_same_request_twice() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    context = _context()
+    request = _request()
+    context.state[plugin._state_key] = {"retried_request_key": "request:atk_test"}
+    execution = RequestExecution(
+        url="https://example.com/pets",
+        headers={},
+        query={},
+        response=httpx.Response(401),
+        error=None,
+        duration_ms=1.0,
+    )
+
+    plugin.after_request(request, context, execution)
+
+    assert execution.retry_requested is False
+    assert context.auth_events == []
+
+
+def test_after_request_does_not_retry_when_previous_refresh_failed() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    context = _context()
+    request = _request()
+    context.state[plugin._state_key] = {
+        "last_error": "invalid credentials",
+        "client_id": id(context.client),
+    }
+    execution = RequestExecution(
+        url="https://example.com/pets",
+        headers={},
+        query={},
+        response=httpx.Response(401),
+        error=None,
+        duration_ms=1.0,
+    )
+
+    plugin.after_request(request, context, execution)
+
+    assert execution.retry_requested is False
+    assert context.auth_events == []
+
+
+def test_template_resolution_preserves_non_string_types() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="static_bearer",
+            token="dev-token",
+        )
+    )
+
+    rendered = plugin._resolve_templates(
+        {
+            "count": "{{count}}",
+            "items": ["{{count}}", "prefix-{{token}}"],
+            "enabled": True,
+        },
+        {"count": 3, "token": "abc"},
+    )
+
+    assert rendered == {"count": 3, "items": [3, "prefix-abc"], "enabled": True}
+
+
+def test_exact_placeholder_errors_when_value_missing() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="static_bearer",
+            token="dev-token",
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="Missing auth template value 'missing'"):
+        plugin._resolve_templates("{{missing}}", {})
+
+
+def test_before_request_injects_raw_token_when_header_scheme_disabled() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="static_bearer",
+            token="dev-token",
+            header_scheme=None,
+            header_name="X-Token",
+        )
+    )
+    context = _context()
+    request = _request()
+
+    plugin.before_request(request, context)
+
+    assert request.headers["X-Token"] == "dev-token"
+
+
+def test_acquire_fails_when_endpoint_missing_after_configuration_change() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    plugin.config.endpoint = None
+    context = _context()
+
+    assert plugin._acquire(context, phase="acquire", trigger="suite") is False
+    assert "missing an endpoint" in context.state[plugin._state_key]["last_error"]
+
+
+def test_acquire_fails_for_non_json_auth_response() -> None:
+    client = _Client([httpx.Response(200, text="not-json")])
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    context = _context(client=client)
+
+    assert plugin._acquire(context, phase="acquire", trigger="suite") is False
+    assert "not valid JSON" in context.state[plugin._state_key]["last_error"]
+
+
+def test_acquire_fails_when_token_pointer_missing_after_configuration_change() -> None:
+    client = _Client([httpx.Response(200, json={"access_token": "token"})])
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    plugin.config.token_pointer = None
+    context = _context(client=client)
+
+    assert plugin._acquire(context, phase="acquire", trigger="suite") is False
+    assert "missing token_pointer" in context.state[plugin._state_key]["last_error"]
+
+
+def test_expired_token_triggers_refresh_even_when_expiry_pointer_is_missing() -> None:
+    client = _Client([httpx.Response(200, json={"access_token": "fresh-token"})])
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+            expires_in_pointer="/missing",
+        )
+    )
+    context = _context(client=client)
+    context.state[plugin._state_key] = {"token": "expired-token", "expires_at": 0}
+
+    assert plugin._ensure_ready(context, trigger="workflow") is True
+    assert context.state[plugin._state_key]["token"] == "fresh-token"
+    assert context.auth_events[0].phase == "refresh"
+
+
+def test_after_request_skips_when_refresh_already_in_progress() -> None:
+    plugin = BuiltInAuthPlugin(
+        BuiltInAuthConfig(
+            name="service",
+            strategy="client_credentials",
+            endpoint="/oauth/token",
+            request_form={"grant_type": "client_credentials"},
+            token_pointer="/access_token",
+        )
+    )
+    context = _context()
+    context.state[plugin._state_key] = {"retry_in_progress": True}
+    execution = RequestExecution(
+        url="https://example.com/pets",
+        headers={},
+        query={},
+        response=httpx.Response(401),
+        error=None,
+        duration_ms=1.0,
+    )
+
+    plugin.after_request(_request(), context, execution)
+
+    assert execution.retry_requested is False

--- a/tests/test_extension_coverage.py
+++ b/tests/test_extension_coverage.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from knives_out.attack_packs import (
+    _attack_pack_from_module,
+    _coerce_attack_pack,
+    load_module_attack_packs,
+)
+from knives_out.attack_packs import (
+    _module_name_for_path as attack_pack_module_name,
+)
+from knives_out.auth_plugins import (
+    _auth_plugin_from_module,
+    _coerce_auth_plugin,
+    _looks_like_runtime_plugin,
+    extract_json_pointer,
+    load_module_auth_plugins,
+)
+from knives_out.auth_plugins import (
+    _module_name_for_path as auth_plugin_module_name,
+)
+from knives_out.example_packs import generate_unexpected_header_attack
+from knives_out.example_workflow_packs import generate_listed_id_lookup_workflows
+from knives_out.models import AttackCase, LoadedOperations, OperationSpec
+from knives_out.spec_loader import (
+    is_graphql_schema_path,
+    is_learned_model_path,
+    load_operations_with_warnings,
+)
+from knives_out.workflow_packs import (
+    _coerce_workflow_pack,
+    _workflow_pack_from_module,
+    load_module_workflow_packs,
+)
+from knives_out.workflow_packs import (
+    _module_name_for_path as workflow_pack_module_name,
+)
+
+
+class _PluginLike:
+    def before_request(self, request, context) -> None:
+        request.headers["Authorization"] = "Bearer plugin-like"
+
+
+def _operation() -> OperationSpec:
+    return OperationSpec(
+        operation_id="getPet",
+        method="GET",
+        path="/pets/{petId}",
+        tags=["pets"],
+        auth_required=True,
+    )
+
+
+def test_module_name_helpers_are_stable_for_same_path(tmp_path: Path) -> None:
+    module_path = tmp_path / "plugin.py"
+    module_path.write_text("", encoding="utf-8")
+
+    assert attack_pack_module_name(module_path) == attack_pack_module_name(module_path)
+    assert workflow_pack_module_name(module_path) == workflow_pack_module_name(module_path)
+    assert auth_plugin_module_name(module_path) == auth_plugin_module_name(module_path)
+
+
+def test_attack_pack_coercion_supports_callable_and_object_generate() -> None:
+    callable_pack = _coerce_attack_pack(
+        lambda operation: [
+            {
+                "id": f"atk_{operation.operation_id}_callable",
+                "name": "Callable pack",
+                "kind": "callable_probe",
+                "operation_id": operation.operation_id,
+                "method": operation.method,
+                "path": operation.path,
+                "description": "Callable pack",
+            }
+        ],
+        name_hint="callable-pack",
+    )
+
+    class _ObjectPack:
+        name = "object-pack"
+
+        def generate(self, operation: OperationSpec):
+            return [
+                {
+                    "id": f"atk_{operation.operation_id}_object",
+                    "name": "Object pack",
+                    "kind": "object_probe",
+                    "operation_id": operation.operation_id,
+                    "method": operation.method,
+                    "path": operation.path,
+                    "description": "Object pack",
+                }
+            ]
+
+    object_pack = _coerce_attack_pack(_ObjectPack(), name_hint="fallback-name")
+
+    assert callable_pack.generate(_operation())[0].kind == "callable_probe"
+    assert object_pack.name == "object-pack"
+    assert object_pack.generate(_operation())[0].kind == "object_probe"
+
+
+def test_attack_pack_loader_validates_paths_and_module_shape(tmp_path: Path, monkeypatch) -> None:
+    missing_path = tmp_path / "missing.py"
+    with pytest.raises(ValueError, match="Attack pack module path does not exist"):
+        load_module_attack_packs([missing_path])
+
+    invalid_module = tmp_path / "invalid_pack.py"
+    invalid_module.write_text("value = 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must define 'attack_pack' or 'generate'"):
+        load_module_attack_packs([invalid_module])
+
+    module_path = tmp_path / "pack.py"
+    module_path.write_text("attack_pack = 1\n", encoding="utf-8")
+    monkeypatch.setattr("knives_out.attack_packs.util.spec_from_file_location", lambda *args: None)
+    with pytest.raises(ValueError, match="Could not load attack pack module"):
+        load_module_attack_packs([module_path])
+
+
+def test_attack_pack_module_supports_generate_export_and_invalid_values() -> None:
+    module = type(
+        "GenerateModule",
+        (),
+        {
+            "generate": lambda operation: [
+                {
+                    "id": "atk_generate",
+                    "name": "Generate export",
+                    "kind": "generate_probe",
+                    "operation_id": operation.operation_id,
+                    "method": operation.method,
+                    "path": operation.path,
+                    "description": "Generate export",
+                }
+            ]
+        },
+    )
+
+    loaded = _attack_pack_from_module(module, name_hint="generate-module")
+
+    assert loaded.generate(_operation())[0].kind == "generate_probe"
+    with pytest.raises(ValueError, match="must be a callable"):
+        _coerce_attack_pack(1, name_hint="invalid")
+
+
+def test_workflow_pack_coercion_supports_callable_and_object_generate() -> None:
+    request_attack = generate_unexpected_header_attack(_operation())[0]
+    callable_pack = _coerce_workflow_pack(
+        lambda operations, request_attacks: [
+            {
+                "id": "wf_callable",
+                "name": "Callable workflow",
+                "kind": request_attacks[0].kind,
+                "operation_id": request_attacks[0].operation_id,
+                "method": request_attacks[0].method,
+                "path": request_attacks[0].path,
+                "description": "Callable workflow",
+                "terminal_attack": request_attacks[0],
+            }
+        ],
+        name_hint="callable-workflow",
+    )
+
+    class _ObjectWorkflowPack:
+        name = "object-workflow"
+
+        def generate(self, operations, request_attacks):
+            return [
+                {
+                    "id": "wf_object",
+                    "name": "Object workflow",
+                    "kind": request_attacks[0].kind,
+                    "operation_id": request_attacks[0].operation_id,
+                    "method": request_attacks[0].method,
+                    "path": request_attacks[0].path,
+                    "description": "Object workflow",
+                    "terminal_attack": request_attacks[0],
+                }
+            ]
+
+    object_pack = _coerce_workflow_pack(_ObjectWorkflowPack(), name_hint="fallback-workflow")
+
+    assert callable_pack.generate([_operation()], [request_attack])[0].type == "workflow"
+    assert object_pack.name == "object-workflow"
+    assert object_pack.generate([_operation()], [request_attack])[0].type == "workflow"
+
+
+def test_workflow_pack_loader_validates_paths_and_module_shape(tmp_path: Path, monkeypatch) -> None:
+    missing_path = tmp_path / "missing.py"
+    with pytest.raises(ValueError, match="Workflow pack module path does not exist"):
+        load_module_workflow_packs([missing_path])
+
+    invalid_module = tmp_path / "invalid_pack.py"
+    invalid_module.write_text("value = 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must define 'workflow_pack' or 'generate'"):
+        load_module_workflow_packs([invalid_module])
+
+    module_path = tmp_path / "pack.py"
+    module_path.write_text("workflow_pack = 1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "knives_out.workflow_packs.util.spec_from_file_location",
+        lambda *args: None,
+    )
+    with pytest.raises(ValueError, match="Could not load workflow pack module"):
+        load_module_workflow_packs([module_path])
+
+
+def test_workflow_pack_module_supports_generate_export_and_invalid_values() -> None:
+    request_attack = generate_unexpected_header_attack(_operation())[0]
+    module = type(
+        "GenerateWorkflowModule",
+        (),
+        {
+            "generate": lambda operations, request_attacks: [
+                {
+                    "id": "wf_generate",
+                    "name": "Generate workflow export",
+                    "kind": request_attacks[0].kind,
+                    "operation_id": request_attacks[0].operation_id,
+                    "method": request_attacks[0].method,
+                    "path": request_attacks[0].path,
+                    "description": "Generate workflow export",
+                    "terminal_attack": request_attacks[0],
+                }
+            ]
+        },
+    )
+
+    loaded = _workflow_pack_from_module(module, name_hint="generate-workflow-module")
+
+    assert loaded.generate([_operation()], [request_attack])[0].type == "workflow"
+    with pytest.raises(ValueError, match="must be a callable"):
+        _coerce_workflow_pack(1, name_hint="invalid")
+
+
+def test_auth_plugin_utilities_cover_pointer_and_plugin_coercion() -> None:
+    payload = {"a/b": {"~key": 3}, "items": [1, {"id": 7}]}
+
+    assert extract_json_pointer(payload, "") == payload
+    assert extract_json_pointer({"a/b": {"~key": 3}}, "/a~1b/~0key") == 3
+    assert extract_json_pointer({"items": [1, {"id": 7}]}, "/items/1/id") == 7
+    with pytest.raises(ValueError, match="Invalid JSON pointer"):
+        extract_json_pointer({}, "id")
+    with pytest.raises(ValueError, match="Expected array index"):
+        extract_json_pointer(["x"], "/value")
+    with pytest.raises(ValueError, match="did not match the response body"):
+        extract_json_pointer({"items": []}, "/items/0")
+    with pytest.raises(ValueError, match="did not match the response body"):
+        extract_json_pointer("x", "/value")
+
+    assert _looks_like_runtime_plugin(_PluginLike()) is True
+    loaded = _coerce_auth_plugin(_PluginLike(), name_hint="plugin-like")
+    assert loaded.name == "plugin-like"
+    assert _coerce_auth_plugin(loaded.plugin, name_hint="runtime-plugin").name == "runtime-plugin"
+
+    class _PluginSubclass(_PluginLike):
+        pass
+
+    subclass_loaded = _coerce_auth_plugin(_PluginSubclass, name_hint="plugin-subclass")
+    assert subclass_loaded.name == "plugin-subclass"
+
+    def _factory():
+        return loaded
+
+    built = _coerce_auth_plugin(_factory, name_hint="factory")
+    assert built is loaded
+
+    with pytest.raises(ValueError, match="must be a RuntimePlugin"):
+        _coerce_auth_plugin(object(), name_hint="invalid")
+
+
+def test_auth_plugin_loader_validates_paths_and_module_shape(tmp_path: Path, monkeypatch) -> None:
+    missing_path = tmp_path / "missing.py"
+    with pytest.raises(ValueError, match="Auth plugin module path does not exist"):
+        load_module_auth_plugins([missing_path])
+
+    invalid_module = tmp_path / "invalid_plugin.py"
+    invalid_module.write_text("value = 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must define 'auth_plugin', 'plugin', or 'build_plugin'"):
+        load_module_auth_plugins([invalid_module])
+
+    module_path = tmp_path / "plugin.py"
+    module_path.write_text("plugin = 1\n", encoding="utf-8")
+    monkeypatch.setattr("knives_out.auth_plugins.util.spec_from_file_location", lambda *args: None)
+    with pytest.raises(ValueError, match="Could not load auth plugin module"):
+        load_module_auth_plugins([module_path])
+
+
+def test_auth_plugin_from_module_supports_plugin_and_factory_exports() -> None:
+    plugin_module = type("PluginModule", (), {"plugin": _PluginLike()})
+    loaded_plugin = _auth_plugin_from_module(plugin_module, name_hint="plugin-module")
+    assert loaded_plugin.name == "plugin-module"
+
+    factory_module = type(
+        "FactoryModule",
+        (),
+        {
+            "build_plugin": lambda: _PluginLike(),
+        },
+    )
+    loaded_factory = _auth_plugin_from_module(factory_module, name_hint="factory-module")
+    assert loaded_factory.name == "factory-module"
+
+
+def test_example_attack_pack_adds_probe_header_without_mutating_operation() -> None:
+    operation = OperationSpec(
+        operation_id="getPet",
+        method="GET",
+        path="/pets/{petId}",
+        observed_examples=[
+            {
+                "headers": {"Authorization": "Bearer keep-me"},
+            }
+        ],
+    )
+
+    attack = generate_unexpected_header_attack(operation)[0]
+
+    assert attack.headers["X-Knives-Out-Probe"] == "unexpected-header"
+    assert operation.observed_examples[0].headers == {"Authorization": "Bearer keep-me"}
+
+
+def test_example_workflow_pack_generates_lookup_workflow_and_skips_non_matching_attacks() -> None:
+    operations = [
+        OperationSpec(operation_id="listPets", method="GET", path="/pets"),
+        _operation(),
+    ]
+    matching = AttackCase(
+        id="atk_get_pet",
+        name="Get pet",
+        kind="wrong_type_param",
+        operation_id="getPet",
+        method="GET",
+        path="/pets/{petId}",
+        tags=["pets"],
+        auth_required=True,
+        description="Get pet",
+        path_params={"petId": "123"},
+    )
+    ignored = AttackCase(
+        id="atk_other",
+        name="Other",
+        kind="wrong_type_param",
+        operation_id="listPets",
+        method="GET",
+        path="/pets",
+        description="Other",
+    )
+
+    workflows = generate_listed_id_lookup_workflows(operations, [matching, ignored])
+
+    assert len(workflows) == 1
+    workflow = workflows[0]
+    assert workflow.setup_steps[0].extracts[0].json_pointer == "/0/id"
+    assert workflow.terminal_attack.path_params["petId"] == "{{id}}"
+    assert matching.path_params["petId"] == "123"
+
+
+def test_example_workflow_pack_returns_empty_when_no_producer_exists() -> None:
+    workflows = generate_listed_id_lookup_workflows(
+        [_operation()],
+        [generate_unexpected_header_attack(_operation())[0]],
+    )
+
+    assert workflows == []
+
+
+def test_spec_loader_detects_known_input_types_and_routes(monkeypatch, tmp_path: Path) -> None:
+    learned_path = tmp_path / "learned.json"
+    learned_path.write_text(json.dumps({"artifact_type": "learned-model"}), encoding="utf-8")
+    graphql_path = tmp_path / "schema.json"
+    graphql_path.write_text(json.dumps({"data": {"__schema": {}}}), encoding="utf-8")
+    invalid_path = tmp_path / "broken.json"
+    invalid_path.write_text("{", encoding="utf-8")
+
+    assert is_learned_model_path(learned_path) is True
+    assert is_graphql_schema_path(graphql_path) is True
+    assert is_graphql_schema_path(tmp_path / "schema.graphql") is True
+    assert is_graphql_schema_path(invalid_path) is False
+
+    learned_result = LoadedOperations(operations=[])
+    graphql_result = LoadedOperations(source_kind="graphql", operations=[])
+    openapi_result = LoadedOperations(operations=[])
+
+    monkeypatch.setattr(
+        "knives_out.spec_loader.load_learned_model_with_warnings",
+        lambda path: learned_result,
+    )
+    monkeypatch.setattr(
+        "knives_out.spec_loader.load_graphql_operations_with_warnings",
+        lambda path, endpoint: graphql_result,
+    )
+    monkeypatch.setattr(
+        "knives_out.spec_loader.load_openapi_operations",
+        lambda path: openapi_result,
+    )
+
+    openapi_path = tmp_path / "spec.yaml"
+    openapi_path.write_text(
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\npaths: {}\n",
+        encoding="utf-8",
+    )
+
+    assert load_operations_with_warnings(learned_path) is learned_result
+    assert (
+        load_operations_with_warnings(graphql_path, graphql_endpoint="/api/graphql")
+        is graphql_result
+    )
+    assert load_operations_with_warnings(openapi_path) is openapi_result
+
+
+def test_runtime_context_build_url_handles_relative_and_absolute_urls() -> None:
+    from knives_out.auth_plugins import RuntimeContext
+
+    context = RuntimeContext(client=httpx.Client(), base_url="https://example.com/", scope="suite")
+
+    assert context.build_url("/pets") == "https://example.com/pets"
+    assert context.build_url("https://other.example.com/pets") == "https://other.example.com/pets"

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -165,3 +165,29 @@ def test_filter_attack_suite_matches_workflow_tags_and_paths() -> None:
     )
 
     assert [attack.id for attack in filtered.attacks] == ["wf_post_auth"]
+
+
+def test_filter_attack_suite_applies_exclude_filters() -> None:
+    filtered = filter_attack_suite(
+        _suite(),
+        exclude_operations=["createpet"],
+        exclude_methods=["get"],
+        exclude_paths=["/pets"],
+    )
+
+    assert filtered.attacks == []
+
+
+def test_filter_attack_suite_applies_include_kind_filter() -> None:
+    filtered = filter_attack_suite(_suite(), include_kinds=["missing_auth"])
+
+    assert [attack.id for attack in filtered.attacks] == [
+        "atk_get_missing",
+        "atk_post_auth",
+    ]
+
+
+def test_filter_attack_suite_excludes_matching_tags() -> None:
+    filtered = filter_attack_suite(_suite(), exclude_tags=["write"])
+
+    assert [attack.id for attack in filtered.attacks] == ["atk_get_missing"]

--- a/tests/test_suppressions.py
+++ b/tests/test_suppressions.py
@@ -7,9 +7,12 @@ import pytest
 from knives_out.models import AttackResult
 from knives_out.suppressions import (
     SuppressionRule,
+    SuppressionsFile,
+    load_suppressions,
     merge_suppressions,
     suppression_identity,
     triage_rule_for_result,
+    write_suppressions,
 )
 
 
@@ -67,3 +70,53 @@ def test_merge_suppressions_deduplicates_generated_entries() -> None:
 
     assert len(merged) == 1
     assert suppression_identity(merged[0]) == suppression_identity(rule)
+
+
+@pytest.mark.parametrize(
+    ("rule_kwargs", "expected"),
+    [
+        ({"issue": "unexpected_success"}, False),
+        ({"operation_id": "listWidgets"}, False),
+        ({"method": "GET"}, False),
+        ({"path": "/other"}, False),
+        ({"kind": "missing_auth"}, False),
+        ({"tags": ["admin"]}, False),
+        ({"method": "post", "issue": "server_error"}, True),
+    ],
+)
+def test_suppression_rule_matches_all_supported_selectors(
+    rule_kwargs: dict[str, object],
+    expected: bool,
+) -> None:
+    rule = SuppressionRule(reason="known issue", owner="api-team", **rule_kwargs)
+
+    assert rule.matches(_result()) is expected
+
+
+def test_load_suppressions_rejects_non_mapping_documents(tmp_path) -> None:
+    path = tmp_path / "suppressions.yml"
+    path.write_text("- invalid\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="top-level mapping"):
+        load_suppressions(path)
+
+
+def test_load_suppressions_wraps_validation_errors(tmp_path) -> None:
+    path = tmp_path / "suppressions.yml"
+    path.write_text(
+        "suppressions:\n  - reason: missing selector\n    owner: api-team\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="at least one matching selector"):
+        load_suppressions(path)
+
+
+def test_write_suppressions_round_trips_rules(tmp_path) -> None:
+    path = tmp_path / "suppressions.yml"
+    expected = triage_rule_for_result(_result())
+
+    write_suppressions(path, SuppressionsFile(suppressions=[expected]))
+    loaded = load_suppressions(path)
+
+    assert loaded.suppressions[0].attack_id == expected.attack_id


### PR DESCRIPTION
## Summary
- add focused built-in auth coverage for refresh, templating, and failure paths
- cover attack pack, workflow pack, auth plugin, and example extension helpers
- expand auth config, filtering, and suppression edge-case tests to bring total coverage back to 90%

## Validation
- `./.venv/bin/ruff check tests/test_builtin_auth.py tests/test_extension_coverage.py tests/test_auth_config.py tests/test_filtering.py tests/test_suppressions.py`
- `./.venv/bin/pytest tests/test_builtin_auth.py tests/test_extension_coverage.py tests/test_auth_config.py tests/test_filtering.py tests/test_suppressions.py -q`
- `./.venv/bin/pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json`