### PR TITLE
[codex] add local API and JSON summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .mypy_cache/
 .venv/
 venv/
+.knives-out-api/
 dist/
 build/
 .coverage

--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ Verify findings against the default CI policy:
 knives-out verify results.json
 ```
 
+Generate a machine-readable summary for dashboards or CI annotations:
+
+```bash
+knives-out summary results.json --out summary.json
+```
+
 Promote qualifying findings back into a reusable regression suite:
 
 ```bash
@@ -203,6 +209,41 @@ Generate a review-ready suppressions file for known findings:
 ```bash
 knives-out triage results.json --out .knives-out-ignore.yml
 ```
+
+## Local API
+
+`knives-out` can also run as a local-first HTTP API instead of only as a CLI.
+
+Start it on the loopback interface:
+
+```bash
+knives-out serve --host 127.0.0.1 --port 8787
+```
+
+By default the API stores job state and request/response artifacts under `.knives-out-api/`.
+Set `KNIVES_OUT_API_DATA_DIR` if you want that store somewhere else.
+
+The synchronous endpoints mirror the short CLI flows:
+
+- `POST /v1/inspect`
+- `POST /v1/generate`
+- `POST /v1/discover`
+- `POST /v1/report`
+- `POST /v1/summary`
+- `POST /v1/verify`
+- `POST /v1/promote`
+- `POST /v1/triage`
+
+Longer execution runs use a job resource instead:
+
+- `POST /v1/runs`
+- `GET /v1/jobs/{id}`
+- `GET /v1/jobs/{id}/result`
+- `GET /v1/jobs/{id}/artifacts`
+
+The API accepts uploaded source content and JSON artifacts in the request body. It does not expose
+arbitrary server-side file reads. FastAPI also publishes the schema at `/openapi.json` and the
+interactive docs at `/docs`.
 
 ## CI usage
 
@@ -238,6 +279,9 @@ For built-in gating, use `knives-out verify` after `run`. It can fail on qualify
 current run, or only on new qualifying findings when you also pass `--baseline previous-results.json`.
 With a baseline, both `verify` and baseline-aware `report` also summarize persisting findings whose
 status, severity, confidence, or schema outcome drifted between runs.
+When you want a compact machine-readable artifact for dashboards, annotations, or follow-on
+automation, `knives-out summary results.json --out summary.json` emits the same counts and top
+findings as structured JSON.
 When you want stateful coverage, generate with `--auto-workflows` first, then add
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
 you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
@@ -252,6 +296,9 @@ GraphQL schemas follow the same `inspect` / `generate` / `run` / `report` / `ver
 `generate` automatically emitting variable-coercion attacks from SDL or introspection input.
 Shadow Twin capture and discovery fit the same path too:
 `capture -> discover -> generate -> run -> report -> verify`.
+If you want to drive that workflow from another local tool instead of shelling out, `knives-out serve`
+now exposes the same core actions over HTTP with background `run` jobs, summary responses, and
+artifact download routes.
 If you keep a `.knives-out-ignore.yml` file in the repo root, `report`, `verify`, and `promote`
 will load it automatically. Use `knives-out triage results.json` to seed new entries when you want
 to capture known findings without hand-writing YAML. For authorization-focused regression coverage,
@@ -728,12 +775,15 @@ knives-out run attacks.json \
 
 ## Roadmap
 
-The built-in auth/config milestone is now shipped, and Shadow Twin learned-model capture is now
-available. The next likely milestone is:
+The built-in auth/config milestone, deeper GraphQL coverage, and Shadow Twin learned-model capture
+are now available. The next likely milestone is:
 
 - **v0.11:** deeper GraphQL coverage with response validation, federation awareness, and
-  subscription support as staged scope
+  mixed-protocol reporting is now shipped
+- **v0.12:** a local-first HTTP API with shared service-layer execution, JSON-first endpoints,
+  and background run jobs with artifact retrieval
 
 After that, the likely follow-on is richer CI and report navigation for large regression programs.
 LLM application testing stays deferred until after that API-focused expansion. See
 `docs/architecture.md` and `docs/roadmap.md` for the current milestone notes.
+Shadow Twin learned-model capture is now available.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ also produces a linked `report.html` with an artifact index and detailed result 
 
 For built-in gating, use `knives-out verify` after `run`. It can fail on qualifying findings in the
 current run, or only on new qualifying findings when you also pass `--baseline previous-results.json`.
+With a baseline, both `verify` and baseline-aware `report` also summarize persisting findings whose
+status, severity, confidence, or schema outcome drifted between runs.
 When you want stateful coverage, generate with `--auto-workflows` first, then add
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
 you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
@@ -416,7 +418,7 @@ knives-out report results.json --out report.md
 ```
 
 You can include a prior `results.json` as a baseline to add regression sections for new, resolved,
-and persisting findings:
+and persisting findings, plus a delta summary when a persisting finding changed:
 
 ```bash
 knives-out report results.json --baseline previous-results.json --out report.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,12 +10,17 @@ The project starts with a deliberately narrow architecture:
 - **Simple triage**
 
 The core idea is that generation, execution, and reporting are separate concerns.
+Both the CLI and the HTTP API now sit on top of `services.py` so they can share the same behavior
+without shelling out or forking a second workflow stack.
 
 ## Module layout
 
 ```text
 src/knives_out/
   cli.py             # Typer entrypoint
+  api.py             # FastAPI entrypoint and route wiring
+  api_models.py      # HTTP request/response models
+  api_store.py       # Filesystem-backed API job/artifact persistence
   capture.py         # Reverse-proxy capture and NDJSON helpers
   learned_discovery.py  # Capture/HAR inference into learned models
   learned_loader.py  # Learned-model loading
@@ -30,6 +35,7 @@ src/knives_out/
   builtin_auth.py    # Built-in bearer/session acquisition and refresh runtime
   auth_plugins.py    # Auth/session plugin helpers
   profiles.py        # Multi-profile loading and comparison inputs
+  services.py        # Shared CLI/API orchestration helpers
   reporting.py       # Markdown and HTML report rendering
   verification.py    # CI policy checks
   promotion.py       # Regression-suite promotion from results
@@ -69,7 +75,11 @@ That JSON should become the contract between future generators and future runner
 `runner.py` executes the saved suite against a concrete base URL. Runtime auth, query values,
 profile-specific defaults, built-in auth acquisition/refresh, and workflow state are merged at
 this phase rather than baked into generation. For GraphQL attacks, a `200` response with an `errors`
-array is treated as an expected validation failure instead of an unexpected success.
+array is treated as an expected validation failure instead of an unexpected success, and
+GraphQL response-shape validation now checks returned `data` against the generated selection shape
+with federation-aware hints when mismatches cross entity or abstract-type boundaries.
+That shipped GraphQL response-shape validation, federation awareness, and clearer mixed-protocol
+diagnostics without changing the core pipeline shape.
 
 ### 5. Report findings
 
@@ -86,6 +96,14 @@ Today, a result is typically flagged when it produces:
 - a learned stale-reference or missing-setup path that succeeds unexpectedly
 - a high-signal authorization comparison issue across profiles
 
+### 6. Serve or script the workflow
+
+`services.py` exposes the shared orchestration layer for inspection, generation, execution,
+reporting, verification, promotion, and triage. `cli.py` is now a thin Typer adapter on top of
+those helpers, and `api.py` exposes the same behavior over a local-first FastAPI surface.
+Long-running API execution uses a filesystem-backed job store in `api_store.py` so local tools can
+poll for status and fetch artifacts without introducing a database in the first version.
+
 ## Why save attacks as JSON?
 
 This is the most important architectural choice in the first version.
@@ -101,10 +119,10 @@ It gives the project:
 
 ## Expected near-term evolution
 
-The next milestone work should extend the current architecture in two directions:
+The next milestone work should extend the current architecture in four directions:
 
-1. stronger GraphQL response-shape validation, federation awareness, and staged subscription
-   support on top of the protocol loader
+1. richer local API ergonomics on top of the shared service layer, including better artifact
+   browsing and job summaries
 2. richer Shadow Twin inference around state machines, confidence review, and ownership-sensitive
    workflows
 3. clearer CI and artifact navigation for large regression suites

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -197,6 +197,31 @@ attacks target invalid variables, required-variable removal, and type coercion f
       --out graphql-attacks.json
 ```
 
+## Optional: local HTTP API
+
+If another local tool needs to drive the workflow without shelling out to the CLI, start the
+server on loopback:
+
+```yaml
+- name: Start local knives-out API
+  run: knives-out serve --host 127.0.0.1 --port 8787
+```
+
+The API mirrors the same JSON artifacts through `POST /v1/inspect`, `POST /v1/generate`,
+`POST /v1/discover`, `POST /v1/report`, `POST /v1/summary`, `POST /v1/verify`, `POST /v1/promote`,
+`POST /v1/triage`, and background `POST /v1/runs` jobs with `GET /v1/jobs/{id}` polling.
+Use `KNIVES_OUT_API_DATA_DIR` when you want the job store somewhere other than `.knives-out-api/`.
+
+## Optional: machine-readable summary export
+
+When CI, chatops, or downstream dashboards need a compact JSON artifact instead of full Markdown or
+HTML, render a summary file after execution:
+
+```yaml
+- name: Build machine-readable summary
+  run: knives-out summary results.json --out summary.json
+```
+
 ## Optional: Shadow Twin learned models
 
 Shadow Twin adds a capture/discover front end for real-behavior API learning when the checked-in

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -102,6 +102,8 @@ findings:
 
 The tool does not fetch that baseline for you. Your workflow is responsible for placing
 `previous-results.json` in the workspace before this step.
+When you use a baseline, `verify` also prints a compact summary for persisting findings whose
+status, severity, confidence, or schema outcome changed between runs.
 
 ## Optional: checked-in suppressions
 
@@ -339,6 +341,9 @@ You can also render a Markdown report that highlights new, resolved, and persist
       --baseline previous-results.json \
       --out report.md
 ```
+
+That baseline-aware report includes the usual new/resolved/persisting sections plus a
+`Persisting deltas` section for persisting findings that drifted between runs.
 
 ## Optional: HTML report and artifact index
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,22 +23,25 @@ guesswork.
     `login_json_bearer`, and `login_form_cookie`
 - v0.10: Shadow Twin learned-model capture and discovery
   - ships local reverse-proxy capture, HAR import, learned-model artifacts, and learned workflow attacks
+- v0.11: deeper GraphQL coverage
+  - ships response-shape validation, federation-aware diagnostics, and protocol-aware reporting
 
-## v0.11 — deeper GraphQL coverage
+## v0.12 — local-first HTTP API
 
-The next likely milestone is a GraphQL-focused expansion on top of the loader and runner we now
-have. The strongest targets are:
+The next likely milestone is an API expansion on top of the shared load/generate/run/report
+pipeline we now have. The strongest targets are:
 
-- response-shape validation against declared GraphQL result structure
-- federation awareness and clearer subgraph-related diagnostics
-- staged subscription coverage that still fits the current generate/run/report pipeline
-- better protocol-aware reporting for mixed OpenAPI and GraphQL programs
+- a local-only FastAPI server that mirrors the current CLI surface
+- synchronous endpoints for inspect, generate, discover, report, verify, promote, and triage
+- background run jobs with polling and artifact retrieval
+- a shared service layer so the CLI and API do not drift apart
 
-## v0.12 — richer CI and triage ergonomics
+## v0.13 — richer CI and triage ergonomics
 
-After the GraphQL pass, the next best leverage point is day-to-day review ergonomics:
+After the API pass, the next best leverage point is day-to-day review ergonomics:
 
 - stronger artifact navigation for large suites
+- machine-readable summary exports for CI annotations and dashboards
 - better suppression and baseline review flows
 - clearer auth diagnostic summaries in HTML and Markdown reports
 - smaller, higher-signal CI summaries for long-lived regression programs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,14 @@ authors = [
   { name = "Keith Wegner" }
 ]
 dependencies = [
+  "fastapi>=0.115.0",
   "graphql-core>=3.2.6",
   "httpx>=0.27.0",
   "pydantic>=2.8.0",
   "PyYAML>=6.0.2",
   "rich>=13.7.0",
   "typer>=0.12.3",
+  "uvicorn>=0.32.0",
 ]
 
 [project.optional-dependencies]

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import os
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+
+from knives_out.api_models import (
+    ApiJobStatus,
+    ArtifactListResponse,
+    DeltaChangeResponse,
+    DiscoverRequest,
+    DiscoverResponse,
+    FindingSummaryResponse,
+    GenerateRequest,
+    GenerateResponse,
+    InspectRequest,
+    InspectResponse,
+    JobRecord,
+    JobStatusResponse,
+    PromoteRequest,
+    PromoteResponse,
+    ReportRequest,
+    ReportResponse,
+    RunRequest,
+    SummaryRequest,
+    SummaryResponse,
+    TriageRequest,
+    TriageResponse,
+    VerifyRequest,
+    VerifyResponse,
+)
+from knives_out.api_store import JobNotFoundError, JobStore
+from knives_out.models import AttackResults
+from knives_out.services import (
+    InlineInput,
+    discover_model_inline,
+    generate_suite_from_inline,
+    inspect_source_inline,
+    promote_results_from_models,
+    render_report_from_models,
+    run_suite_from_inline,
+    summarize_results_from_models,
+    triage_results_from_model,
+    verify_results_from_models,
+)
+
+
+def _finding_summary(finding) -> FindingSummaryResponse:
+    result = finding.result
+    delta_changes = []
+    if finding.delta is not None:
+        delta_changes = [
+            DeltaChangeResponse(
+                field=change.field,
+                baseline=change.baseline,
+                current=change.current,
+            )
+            for change in finding.delta.changes
+        ]
+    return FindingSummaryResponse(
+        change=finding.change,
+        attack_id=result.attack_id,
+        name=result.name,
+        protocol="rest" if result.protocol == "openapi" else result.protocol,
+        issue=result.issue,
+        severity=result.severity,
+        confidence=result.confidence,
+        status_code=result.status_code,
+        url=result.url,
+        delta_changes=delta_changes,
+    )
+
+
+def _verify_response(verification) -> VerifyResponse:
+    comparison = verification.comparison
+    return VerifyResponse(
+        passed=verification.passed,
+        baseline_used=verification.baseline_used,
+        min_severity=verification.min_severity,
+        min_confidence=verification.min_confidence,
+        current_findings_count=len(comparison.current_findings),
+        new_findings_count=len(comparison.new_findings),
+        resolved_findings_count=len(comparison.resolved_findings),
+        persisting_findings_count=len(comparison.persisting_findings),
+        suppressed_current_findings_count=len(comparison.suppressed_current_findings),
+        failing_findings=[_finding_summary(finding) for finding in verification.failing_findings],
+        new_findings=[_finding_summary(finding) for finding in comparison.new_findings],
+        resolved_findings=[_finding_summary(finding) for finding in comparison.resolved_findings],
+        persisting_findings=[
+            _finding_summary(finding) for finding in comparison.persisting_findings
+        ],
+    )
+
+
+def _inline(source) -> InlineInput:
+    return InlineInput(name=source.name, content=source.content)
+
+
+def _default_data_dir() -> Path:
+    configured = os.environ.get("KNIVES_OUT_API_DATA_DIR")
+    if configured:
+        return Path(configured)
+    return Path.cwd() / ".knives-out-api"
+
+
+def _run_job_worker(job_store: JobStore, job_id: str, request: RunRequest) -> None:
+    record = job_store.load_job(job_id).model_copy(
+        update={"status": ApiJobStatus.running, "started_at": datetime.now(UTC)}
+    )
+    job_store.update_job(record)
+    try:
+        run_result = run_suite_from_inline(
+            request.suite,
+            base_url=request.base_url,
+            default_headers=request.headers,
+            default_query=request.query,
+            timeout_seconds=request.timeout,
+            artifact_dir=job_store.artifact_dir(job_id) if request.store_artifacts else None,
+            auth_plugin_names=request.auth_plugin_names,
+            auth_config_yaml=request.auth_config_yaml,
+            auth_profile_names=request.auth_profile_names,
+            profile_file_yaml=request.profile_file_yaml,
+            profile_names=request.profile_names,
+            operation=request.operation,
+            exclude_operation=request.exclude_operation,
+            method=request.method,
+            exclude_method=request.exclude_method,
+            kind=request.kind,
+            exclude_kind=request.exclude_kind,
+            tag=request.tag,
+            exclude_tag=request.exclude_tag,
+            path=request.path,
+            exclude_path=request.exclude_path,
+        )
+        job_store.write_result(job_id, run_result.results)
+        completed = record.model_copy(
+            update={
+                "status": ApiJobStatus.completed,
+                "completed_at": datetime.now(UTC),
+                "attack_count": len(run_result.suite.attacks),
+            }
+        )
+        job_store.update_job(completed)
+    except Exception as exc:  # noqa: BLE001
+        failed = record.model_copy(
+            update={
+                "status": ApiJobStatus.failed,
+                "completed_at": datetime.now(UTC),
+                "error": str(exc),
+            }
+        )
+        job_store.update_job(failed)
+
+
+def create_app(*, data_dir: Path | None = None) -> FastAPI:
+    app = FastAPI(
+        title="knives-out API",
+        version="0.11.0",
+        description="Local-first API for adversarial API testing from specs and observed traffic.",
+    )
+    app.state.job_store = JobStore(data_dir or _default_data_dir())
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/inspect", response_model=InspectResponse)
+    def inspect_endpoint(request: InspectRequest) -> InspectResponse:
+        result = inspect_source_inline(
+            _inline(request.source),
+            graphql_endpoint=request.graphql_endpoint,
+            tag=request.tag or None,
+            exclude_tag=request.exclude_tag or None,
+            path=request.path or None,
+            exclude_path=request.exclude_path or None,
+        )
+        return InspectResponse(
+            source_kind=result.loaded.source_kind,
+            operations=result.operations,
+            warnings=result.loaded.warnings,
+            learned_workflow_count=len(result.loaded.learned_model.workflows)
+            if result.loaded.learned_model is not None
+            else 0,
+        )
+
+    @app.post("/v1/generate", response_model=GenerateResponse)
+    def generate_endpoint(request: GenerateRequest) -> GenerateResponse:
+        result = generate_suite_from_inline(
+            _inline(request.source),
+            graphql_endpoint=request.graphql_endpoint,
+            operation=request.operation or None,
+            exclude_operation=request.exclude_operation or None,
+            method=request.method or None,
+            exclude_method=request.exclude_method or None,
+            kind=request.kind or None,
+            exclude_kind=request.exclude_kind or None,
+            tag=request.tag or None,
+            exclude_tag=request.exclude_tag or None,
+            path=request.path or None,
+            exclude_path=request.exclude_path or None,
+            pack_names=request.pack_names or None,
+            auto_workflows=request.auto_workflows,
+            workflow_pack_names=request.workflow_pack_names or None,
+        )
+        return GenerateResponse(
+            source_kind=result.loaded.source_kind,
+            suite=result.suite,
+            warnings=result.loaded.warnings,
+        )
+
+    @app.post("/v1/discover", response_model=DiscoverResponse)
+    def discover_endpoint(request: DiscoverRequest) -> DiscoverResponse:
+        learned_model = discover_model_inline([_inline(current) for current in request.inputs])
+        return DiscoverResponse(learned_model=learned_model)
+
+    @app.post("/v1/report", response_model=ReportResponse)
+    def report_endpoint(request: ReportRequest) -> ReportResponse:
+        rendered = render_report_from_models(
+            request.results,
+            baseline=request.baseline,
+            suppressions_yaml=request.suppressions_yaml,
+            format=request.format.value,
+        )
+        return ReportResponse(format=request.format, content=rendered)
+
+    @app.post("/v1/summary", response_model=SummaryResponse)
+    def summary_endpoint(request: SummaryRequest) -> SummaryResponse:
+        summary = summarize_results_from_models(
+            request.results,
+            baseline=request.baseline,
+            suppressions_yaml=request.suppressions_yaml,
+            top_limit=request.top_limit,
+        )
+        return SummaryResponse(**summary.model_dump(mode="python"))
+
+    @app.post("/v1/verify", response_model=VerifyResponse)
+    def verify_endpoint(request: VerifyRequest) -> VerifyResponse:
+        verification = verify_results_from_models(
+            request.results,
+            baseline=request.baseline,
+            suppressions_yaml=request.suppressions_yaml,
+            min_severity=request.min_severity,
+            min_confidence=request.min_confidence,
+        )
+        return _verify_response(verification)
+
+    @app.post("/v1/promote", response_model=PromoteResponse)
+    def promote_endpoint(request: PromoteRequest) -> PromoteResponse:
+        promotion = promote_results_from_models(
+            request.results,
+            request.attacks,
+            baseline=request.baseline,
+            suppressions_yaml=request.suppressions_yaml,
+            min_severity=request.min_severity,
+            min_confidence=request.min_confidence,
+        )
+        return PromoteResponse(
+            promoted_suite=promotion.promoted_suite,
+            promoted_attack_ids=promotion.promoted_attack_ids,
+            baseline_used=promotion.verification.baseline_used,
+        )
+
+    @app.post("/v1/triage", response_model=TriageResponse)
+    def triage_endpoint(request: TriageRequest) -> TriageResponse:
+        suppressions_file, added_count = triage_results_from_model(
+            request.results,
+            existing_suppressions_yaml=request.existing_suppressions_yaml,
+        )
+        return TriageResponse(suppressions=suppressions_file, added_count=added_count)
+
+    @app.post("/v1/runs", response_model=JobStatusResponse)
+    def create_run_job(request: RunRequest) -> JobStatusResponse:
+        job_store: JobStore = app.state.job_store
+        record = job_store.create_job(
+            JobRecord(base_url=request.base_url, attack_count=len(request.suite.attacks))
+        )
+        thread = threading.Thread(
+            target=_run_job_worker,
+            args=(job_store, record.id, request),
+            daemon=True,
+        )
+        thread.start()
+        return job_store.job_status_response(record.id)
+
+    @app.get("/v1/jobs/{job_id}", response_model=JobStatusResponse)
+    def get_job(job_id: str) -> JobStatusResponse:
+        job_store: JobStore = app.state.job_store
+        try:
+            return job_store.job_status_response(job_id)
+        except JobNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Job not found.") from exc
+
+    @app.get("/v1/jobs/{job_id}/result", response_model=AttackResults)
+    def get_job_result(job_id: str) -> AttackResults:
+        job_store: JobStore = app.state.job_store
+        try:
+            return job_store.load_result(job_id)
+        except JobNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Job result not available.") from exc
+
+    @app.get("/v1/jobs/{job_id}/artifacts", response_model=ArtifactListResponse)
+    def get_job_artifacts(job_id: str) -> ArtifactListResponse:
+        job_store: JobStore = app.state.job_store
+        try:
+            job_store.load_job(job_id)
+            return job_store.artifact_list_response(job_id)
+        except JobNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Job not found.") from exc
+
+    @app.get("/v1/jobs/{job_id}/artifacts/{artifact_name:path}")
+    def get_job_artifact(job_id: str, artifact_name: str):
+        job_store: JobStore = app.state.job_store
+        try:
+            path = job_store.artifact_path_for_name(job_id, artifact_name)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Artifact not found.") from exc
+        return FileResponse(path)
+
+    return app
+
+
+app = create_app()

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from knives_out.models import (
+    AttackResults,
+    AttackSuite,
+    LearnedModel,
+    OperationSpec,
+    PreflightWarning,
+    ResultsSummary,
+    SourceKind,
+)
+from knives_out.suppressions import SuppressionsFile
+
+
+class ApiReportFormat(StrEnum):
+    markdown = "markdown"
+    html = "html"
+
+
+class ApiJobStatus(StrEnum):
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+
+
+class SourcePayload(BaseModel):
+    name: str
+    content: str
+
+
+class InspectRequest(BaseModel):
+    source: SourcePayload
+    graphql_endpoint: str = "/graphql"
+    tag: list[str] = Field(default_factory=list)
+    exclude_tag: list[str] = Field(default_factory=list)
+    path: list[str] = Field(default_factory=list)
+    exclude_path: list[str] = Field(default_factory=list)
+
+
+class InspectResponse(BaseModel):
+    source_kind: SourceKind
+    operations: list[OperationSpec]
+    warnings: list[PreflightWarning] = Field(default_factory=list)
+    learned_workflow_count: int = 0
+
+
+class GenerateRequest(BaseModel):
+    source: SourcePayload
+    graphql_endpoint: str = "/graphql"
+    operation: list[str] = Field(default_factory=list)
+    exclude_operation: list[str] = Field(default_factory=list)
+    method: list[str] = Field(default_factory=list)
+    exclude_method: list[str] = Field(default_factory=list)
+    kind: list[str] = Field(default_factory=list)
+    exclude_kind: list[str] = Field(default_factory=list)
+    tag: list[str] = Field(default_factory=list)
+    exclude_tag: list[str] = Field(default_factory=list)
+    path: list[str] = Field(default_factory=list)
+    exclude_path: list[str] = Field(default_factory=list)
+    pack_names: list[str] = Field(default_factory=list)
+    auto_workflows: bool = False
+    workflow_pack_names: list[str] = Field(default_factory=list)
+
+
+class GenerateResponse(BaseModel):
+    source_kind: SourceKind
+    suite: AttackSuite
+    warnings: list[PreflightWarning] = Field(default_factory=list)
+
+
+class DiscoverRequest(BaseModel):
+    inputs: list[SourcePayload]
+
+
+class DiscoverResponse(BaseModel):
+    learned_model: LearnedModel
+
+
+class RunRequest(BaseModel):
+    suite: AttackSuite
+    base_url: str
+    headers: dict[str, str] = Field(default_factory=dict)
+    query: dict[str, Any] = Field(default_factory=dict)
+    timeout: float = 10.0
+    store_artifacts: bool = True
+    auth_plugin_names: list[str] = Field(default_factory=list)
+    auth_config_yaml: str | None = None
+    auth_profile_names: list[str] = Field(default_factory=list)
+    profile_file_yaml: str | None = None
+    profile_names: list[str] = Field(default_factory=list)
+    operation: list[str] = Field(default_factory=list)
+    exclude_operation: list[str] = Field(default_factory=list)
+    method: list[str] = Field(default_factory=list)
+    exclude_method: list[str] = Field(default_factory=list)
+    kind: list[str] = Field(default_factory=list)
+    exclude_kind: list[str] = Field(default_factory=list)
+    tag: list[str] = Field(default_factory=list)
+    exclude_tag: list[str] = Field(default_factory=list)
+    path: list[str] = Field(default_factory=list)
+    exclude_path: list[str] = Field(default_factory=list)
+
+
+class DeltaChangeResponse(BaseModel):
+    field: str
+    baseline: str
+    current: str
+
+
+class FindingSummaryResponse(BaseModel):
+    change: str
+    attack_id: str
+    name: str
+    protocol: str
+    issue: str | None = None
+    severity: str
+    confidence: str
+    status_code: int | None = None
+    url: str
+    delta_changes: list[DeltaChangeResponse] = Field(default_factory=list)
+
+
+class SummaryRequest(BaseModel):
+    results: AttackResults
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    top_limit: int = Field(default=10, ge=0)
+
+
+class VerifyRequest(BaseModel):
+    results: AttackResults
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    min_severity: str = "high"
+    min_confidence: str = "medium"
+
+
+class VerifyResponse(BaseModel):
+    passed: bool
+    baseline_used: bool
+    min_severity: str
+    min_confidence: str
+    current_findings_count: int
+    new_findings_count: int
+    resolved_findings_count: int
+    persisting_findings_count: int
+    suppressed_current_findings_count: int
+    failing_findings: list[FindingSummaryResponse] = Field(default_factory=list)
+    new_findings: list[FindingSummaryResponse] = Field(default_factory=list)
+    resolved_findings: list[FindingSummaryResponse] = Field(default_factory=list)
+    persisting_findings: list[FindingSummaryResponse] = Field(default_factory=list)
+
+
+class ReportRequest(BaseModel):
+    results: AttackResults
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    format: ApiReportFormat = ApiReportFormat.markdown
+
+
+class ReportResponse(BaseModel):
+    format: ApiReportFormat
+    content: str
+
+
+class SummaryResponse(ResultsSummary):
+    pass
+
+
+class PromoteRequest(BaseModel):
+    results: AttackResults
+    attacks: AttackSuite
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    min_severity: str = "high"
+    min_confidence: str = "medium"
+
+
+class PromoteResponse(BaseModel):
+    promoted_suite: AttackSuite
+    promoted_attack_ids: list[str]
+    baseline_used: bool
+
+
+class TriageRequest(BaseModel):
+    results: AttackResults
+    existing_suppressions_yaml: str | None = None
+
+
+class TriageResponse(BaseModel):
+    suppressions: SuppressionsFile
+    added_count: int
+
+
+class JobRecord(BaseModel):
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    kind: str = "run"
+    status: ApiJobStatus = ApiJobStatus.pending
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    base_url: str
+    attack_count: int
+    error: str | None = None
+
+
+class JobStatusResponse(BaseModel):
+    id: str
+    kind: str
+    status: ApiJobStatus
+    created_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    base_url: str
+    attack_count: int
+    error: str | None = None
+    result_available: bool = False
+    artifact_names: list[str] = Field(default_factory=list)
+
+
+class ArtifactListResponse(BaseModel):
+    job_id: str
+    artifacts: list[str] = Field(default_factory=list)

--- a/src/knives_out/api_store.py
+++ b/src/knives_out/api_store.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from knives_out.api_models import ArtifactListResponse, JobRecord, JobStatusResponse
+from knives_out.models import AttackResults
+
+
+class JobNotFoundError(FileNotFoundError):
+    pass
+
+
+class JobStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.jobs_dir = root / "jobs"
+        self.jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    def create_job(self, record: JobRecord) -> JobRecord:
+        job_dir = self.job_dir(record.id)
+        job_dir.mkdir(parents=True, exist_ok=True)
+        self._write_record(record)
+        self.artifact_dir(record.id).mkdir(parents=True, exist_ok=True)
+        return record
+
+    def job_dir(self, job_id: str) -> Path:
+        return self.jobs_dir / job_id
+
+    def artifact_dir(self, job_id: str) -> Path:
+        return self.job_dir(job_id) / "artifacts"
+
+    def record_path(self, job_id: str) -> Path:
+        return self.job_dir(job_id) / "job.json"
+
+    def result_path(self, job_id: str) -> Path:
+        return self.job_dir(job_id) / "result.json"
+
+    def _write_record(self, record: JobRecord) -> None:
+        self.record_path(record.id).write_text(
+            record.model_dump_json(indent=2, exclude_none=True),
+            encoding="utf-8",
+        )
+
+    def load_job(self, job_id: str) -> JobRecord:
+        path = self.record_path(job_id)
+        if not path.exists():
+            raise JobNotFoundError(job_id)
+        return JobRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def update_job(self, record: JobRecord) -> JobRecord:
+        self._write_record(record)
+        return record
+
+    def write_result(self, job_id: str, results: AttackResults) -> None:
+        self.result_path(job_id).write_text(
+            results.model_dump_json(indent=2, exclude_none=True),
+            encoding="utf-8",
+        )
+
+    def load_result(self, job_id: str) -> AttackResults:
+        path = self.result_path(job_id)
+        if not path.exists():
+            raise JobNotFoundError(job_id)
+        return AttackResults.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def result_exists(self, job_id: str) -> bool:
+        return self.result_path(job_id).exists()
+
+    def list_artifacts(self, job_id: str) -> list[str]:
+        artifact_dir = self.artifact_dir(job_id)
+        if not artifact_dir.exists():
+            return []
+        return sorted(
+            path.relative_to(artifact_dir).as_posix()
+            for path in artifact_dir.rglob("*")
+            if path.is_file()
+        )
+
+    def artifact_list_response(self, job_id: str) -> ArtifactListResponse:
+        return ArtifactListResponse(job_id=job_id, artifacts=self.list_artifacts(job_id))
+
+    def artifact_path_for_name(self, job_id: str, name: str) -> Path:
+        candidate = (self.artifact_dir(job_id) / name).resolve()
+        artifact_root = self.artifact_dir(job_id).resolve()
+        if artifact_root not in candidate.parents and candidate != artifact_root:
+            raise FileNotFoundError(name)
+        if not candidate.exists() or not candidate.is_file():
+            raise FileNotFoundError(name)
+        return candidate
+
+    def job_status_response(self, job_id: str) -> JobStatusResponse:
+        record = self.load_job(job_id)
+        return JobStatusResponse(
+            id=record.id,
+            kind=record.kind,
+            status=record.status,
+            created_at=record.created_at,
+            started_at=record.started_at,
+            completed_at=record.completed_at,
+            base_url=record.base_url,
+            attack_count=record.attack_count,
+            error=record.error,
+            result_available=self.result_exists(job_id),
+            artifact_names=self.list_artifacts(job_id),
+        )

--- a/src/knives_out/api_store.py
+++ b/src/knives_out/api_store.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from time import sleep
+from uuid import uuid4
+
+from pydantic import ValidationError
 
 from knives_out.api_models import ArtifactListResponse, JobRecord, JobStatusResponse
 from knives_out.models import AttackResults
@@ -35,33 +39,54 @@ class JobStore:
     def result_path(self, job_id: str) -> Path:
         return self.job_dir(job_id) / "result.json"
 
+    def _write_json_atomic(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
+        temp_path.write_text(content, encoding="utf-8")
+        temp_path.replace(path)
+
+    def _load_json_with_retries(self, path: Path, model):
+        last_error: ValidationError | None = None
+        for attempt in range(5):
+            raw = path.read_text(encoding="utf-8")
+            try:
+                return model.model_validate_json(raw)
+            except ValidationError as exc:
+                last_error = exc
+                if attempt == 4:
+                    raise
+                sleep(0.01)
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError(f"Unable to load JSON from {path}.")
+
     def _write_record(self, record: JobRecord) -> None:
-        self.record_path(record.id).write_text(
+        self._write_json_atomic(
+            self.record_path(record.id),
             record.model_dump_json(indent=2, exclude_none=True),
-            encoding="utf-8",
         )
 
     def load_job(self, job_id: str) -> JobRecord:
         path = self.record_path(job_id)
         if not path.exists():
             raise JobNotFoundError(job_id)
-        return JobRecord.model_validate_json(path.read_text(encoding="utf-8"))
+        return self._load_json_with_retries(path, JobRecord)
 
     def update_job(self, record: JobRecord) -> JobRecord:
         self._write_record(record)
         return record
 
     def write_result(self, job_id: str, results: AttackResults) -> None:
-        self.result_path(job_id).write_text(
+        self._write_json_atomic(
+            self.result_path(job_id),
             results.model_dump_json(indent=2, exclude_none=True),
-            encoding="utf-8",
         )
 
     def load_result(self, job_id: str) -> AttackResults:
         path = self.result_path(job_id)
         if not path.exists():
             raise JobNotFoundError(job_id)
-        return AttackResults.model_validate_json(path.read_text(encoding="utf-8"))
+        return self._load_json_with_retries(path, AttackResults)
 
     def result_exists(self, job_id: str) -> bool:
         return self.result_path(job_id).exists()

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -217,6 +217,33 @@ def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> Non
     console.print(table)
 
 
+def _print_persisting_delta_findings(findings: list[ComparedFinding]) -> None:
+    delta_findings = [
+        finding for finding in findings if finding.delta is not None and finding.delta.changed
+    ]
+    if not delta_findings:
+        return
+
+    table = Table(title="Persisting findings with deltas")
+    table.add_column("Attack")
+    table.add_column("Issue")
+    table.add_column("Changes")
+
+    for finding in delta_findings:
+        changes = ", ".join(
+            f"{change.field} {change.baseline} -> {change.current}"
+            for change in (finding.delta.changes if finding.delta is not None else [])
+        )
+        table.add_row(
+            finding.result.name,
+            finding.result.issue or "-",
+            changes,
+        )
+
+    console.print("")
+    console.print(table)
+
+
 @app.command()
 def capture(
     target_base_url: Annotated[
@@ -771,17 +798,24 @@ def verify(
     )
     _print_suppression_summary(suppressions_path, suppression_rules)
     if verification.baseline_used:
+        persisting_deltas = [
+            finding
+            for finding in comparison.persisting_findings
+            if finding.delta is not None and finding.delta.changed
+        ]
         console.print(
             "Compared current findings against a baseline. "
             f"New: {len(comparison.new_findings)}, "
             f"Resolved: {len(comparison.resolved_findings)}, "
             f"Persisting: {len(comparison.persisting_findings)}, "
+            f"Persisting with deltas: {len(persisting_deltas)}, "
             f"Suppressed current: {len(comparison.suppressed_current_findings)}."
         )
         _print_compared_findings(
             "New findings meeting policy",
             verification.failing_findings,
         )
+        _print_persisting_delta_findings(comparison.persisting_findings)
     else:
         console.print(
             "Evaluated current flagged findings only. "

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -1,59 +1,38 @@
 from __future__ import annotations
 
+import json
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
-from pydantic import ValidationError
+import uvicorn
 from rich.console import Console
 from rich.table import Table
 
-from knives_out.attack_packs import load_attack_packs
-from knives_out.auth_config import (
-    auth_config_map,
-    auth_profiles_from_configs,
-    load_auth_configs,
-    select_auth_configs,
-)
-from knives_out.auth_plugins import PluginRuntimeError, load_auth_plugins
+from knives_out.api import create_app
+from knives_out.auth_plugins import PluginRuntimeError
 from knives_out.capture import serve_capture_proxy
-from knives_out.filtering import filter_attack_suite, filter_operations
-from knives_out.generator import generate_attack_suite
-from knives_out.learned_discovery import discover_learned_model
-from knives_out.models import AttackResults, AuthProfile, PreflightWarning
-from knives_out.profiles import (
-    load_auth_profiles,
-    resolve_auth_profile_modules,
-    select_auth_profiles,
-)
-from knives_out.promotion import PromotionError, promote_attack_suite
-from knives_out.reporting import (
-    load_attack_results,
-    render_html_report,
-    render_markdown_report,
-)
-from knives_out.runner import (
-    execute_attack_suite,
-    execute_attack_suite_profiles,
-    load_attack_suite,
-)
-from knives_out.spec_loader import load_operations_with_warnings
-from knives_out.suppressions import (
+from knives_out.models import AttackResults, PreflightWarning
+from knives_out.promotion import PromotionError
+from knives_out.services import (
     DEFAULT_SUPPRESSIONS_PATH,
     SuppressionRule,
-    SuppressionsFile,
-    load_suppressions,
-    merge_suppressions,
-    triage_rule_for_result,
-    write_suppressions,
+    discover_model_paths,
+    generate_suite_from_path,
+    inspect_source_path,
+    load_attack_results_or_raise,
+    load_attack_suite_or_raise,
+    load_suppressions_or_default,
+    parse_key_value_map,
+    promote_results_from_paths,
+    render_report_from_paths,
+    run_suite,
+    summarize_results_from_paths,
+    triage_results_from_path,
+    verify_results_from_paths,
 )
-from knives_out.verification import (
-    ComparedFinding,
-    compare_attack_results,
-    evaluate_verification,
-)
-from knives_out.workflow_packs import load_workflow_packs
+from knives_out.verification import ComparedFinding
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -78,20 +57,6 @@ class ConfidenceThresholdOption(StrEnum):
 class ReportFormatOption(StrEnum):
     markdown = "markdown"
     html = "html"
-
-
-def _parse_key_value(items: list[str] | None, *, separator: str) -> dict[str, Any]:
-    parsed: dict[str, Any] = {}
-    for item in items or []:
-        if separator not in item:
-            raise typer.BadParameter(f"Expected '{separator}' in value: {item!r}")
-        key, value = item.split(separator, 1)
-        key = key.strip()
-        value = value.strip()
-        if not key:
-            raise typer.BadParameter(f"Missing key in value: {item!r}")
-        parsed[key] = value
-    return parsed
 
 
 def _warning_target(warning: PreflightWarning) -> str:
@@ -120,67 +85,18 @@ def _print_preflight_warnings(warnings: list[PreflightWarning]) -> None:
 
 def _load_attack_results_or_error(path: Path, *, label: str) -> AttackResults:
     try:
-        return load_attack_results(path)
-    except (OSError, ValidationError, ValueError) as exc:
-        raise typer.BadParameter(f"Could not read {label} results file '{path}': {exc}") from exc
+        return load_attack_results_or_raise(path, label=label)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _load_suppressions_or_error(
     path: Path | None,
 ) -> tuple[Path | None, list[SuppressionRule]]:
-    resolved_path = path
-    if resolved_path is None and DEFAULT_SUPPRESSIONS_PATH.exists():
-        resolved_path = DEFAULT_SUPPRESSIONS_PATH
-    if resolved_path is None:
-        return None, []
-
     try:
-        suppressions_file = load_suppressions(resolved_path)
-    except (OSError, ValueError) as exc:
-        raise typer.BadParameter(
-            f"Could not read suppressions file '{resolved_path}': {exc}"
-        ) from exc
-
-    return resolved_path, suppressions_file.suppressions
-
-
-def _load_auth_profiles_or_error(
-    path: Path | None,
-    *,
-    include_names: list[str] | None = None,
-) -> list[AuthProfile]:
-    if path is None:
-        if include_names:
-            raise typer.BadParameter("--profile requires --profile-file.")
-        return []
-
-    try:
-        profiles_file = load_auth_profiles(path)
-        selected_profiles = select_auth_profiles(profiles_file, include_names=include_names)
-        return resolve_auth_profile_modules(selected_profiles, relative_to=path)
-    except (OSError, ValueError) as exc:
-        raise typer.BadParameter(f"Could not read auth profile file '{path}': {exc}") from exc
-
-
-def _load_auth_configs_or_error(
-    path: Path | None,
-    *,
-    include_names: list[str] | None = None,
-):
-    if path is None:
-        if include_names:
-            raise typer.BadParameter("--auth-profile requires --auth-config.")
-        return []
-
-    try:
-        auth_file = load_auth_configs(path)
-        selected_configs = select_auth_configs(auth_file, include_names=include_names)
-    except (OSError, ValueError) as exc:
-        raise typer.BadParameter(f"Could not read auth config file '{path}': {exc}") from exc
-
-    if not selected_configs:
-        raise typer.BadParameter(f"Auth config file '{path}' did not define any auth entries.")
-    return selected_configs
+        return load_suppressions_or_default(path)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _print_suppression_summary(
@@ -197,6 +113,7 @@ def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> Non
         return
 
     table = Table(title=title)
+    table.add_column("Protocol")
     table.add_column("Attack")
     table.add_column("Issue")
     table.add_column("Severity")
@@ -206,6 +123,7 @@ def _print_compared_findings(title: str, findings: list[ComparedFinding]) -> Non
     for finding in findings:
         result = finding.result
         table.add_row(
+            "rest" if result.protocol == "openapi" else result.protocol,
             result.name,
             result.issue or "-",
             result.severity,
@@ -225,6 +143,7 @@ def _print_persisting_delta_findings(findings: list[ComparedFinding]) -> None:
         return
 
     table = Table(title="Persisting findings with deltas")
+    table.add_column("Protocol")
     table.add_column("Attack")
     table.add_column("Issue")
     table.add_column("Changes")
@@ -235,6 +154,7 @@ def _print_persisting_delta_findings(findings: list[ComparedFinding]) -> None:
             for change in (finding.delta.changes if finding.delta is not None else [])
         )
         table.add_row(
+            "rest" if finding.result.protocol == "openapi" else finding.result.protocol,
             finding.result.name,
             finding.result.issue or "-",
             changes,
@@ -308,7 +228,7 @@ def discover(
     ] = Path("learned-model.json"),
 ) -> None:
     """Discover a replayable learned API model from captured traffic."""
-    learned_model = discover_learned_model(inputs)
+    learned_model = discover_model_paths(inputs)
     out.write_text(learned_model.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     console.print(
         f"Wrote learned model with {len(learned_model.operations)} operation(s) and "
@@ -342,14 +262,16 @@ def inspect(
     ] = None,
 ) -> None:
     """Show the operations discovered in an OpenAPI, GraphQL, or learned model."""
-    loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
-    operations = filter_operations(
-        loaded.operations,
-        include_paths=path,
-        exclude_paths=exclude_path,
-        include_tags=tag,
-        exclude_tags=exclude_tag,
+    inspected = inspect_source_path(
+        spec,
+        graphql_endpoint=graphql_endpoint,
+        tag=tag,
+        exclude_tag=exclude_tag,
+        path=path,
+        exclude_path=exclude_path,
     )
+    loaded = inspected.loaded
+    operations = inspected.operations
 
     table = Table(title=f"knives-out inspect: {spec}")
     table.add_column("Operation ID")
@@ -467,34 +389,27 @@ def generate(
 
     Filters are applied after attack generation and before the suite is written.
     """
-    loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
-    operations = loaded.operations
-    attack_packs = load_attack_packs(entry_point_names=pack, module_paths=pack_module)
-    workflow_packs = load_workflow_packs(
-        entry_point_names=workflow_pack,
-        module_paths=workflow_pack_module,
-    )
-    suite = generate_attack_suite(
-        operations,
-        source=str(spec),
-        extra_packs=attack_packs,
+    generated = generate_suite_from_path(
+        spec,
+        graphql_endpoint=graphql_endpoint,
+        operation=operation,
+        exclude_operation=exclude_operation,
+        method=method,
+        exclude_method=exclude_method,
+        kind=kind,
+        exclude_kind=exclude_kind,
+        tag=tag,
+        exclude_tag=exclude_tag,
+        path=path,
+        exclude_path=exclude_path,
+        pack_names=pack,
+        pack_module_paths=pack_module,
         auto_workflows=auto_workflows,
-        workflow_packs=workflow_packs,
-        learned_model=loaded.learned_model,
+        workflow_pack_names=workflow_pack,
+        workflow_pack_module_paths=workflow_pack_module,
     )
-    suite = filter_attack_suite(
-        suite,
-        include_operations=operation,
-        exclude_operations=exclude_operation,
-        include_methods=method,
-        exclude_methods=exclude_method,
-        include_kinds=kind,
-        exclude_kinds=exclude_kind,
-        include_paths=path,
-        exclude_paths=exclude_path,
-        include_tags=tag,
-        exclude_tags=exclude_tag,
-    )
+    loaded = generated.loaded
+    suite = generated.suite
     out.write_text(suite.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     workflow_count = sum(1 for attack in suite.attacks if attack.type == "workflow")
     request_count = len(suite.attacks) - workflow_count
@@ -603,80 +518,38 @@ def run(
 
     Filters are applied to the loaded suite before any requests are executed.
     """
-    suite = load_attack_suite(attacks)
-    suite = filter_attack_suite(
-        suite,
-        include_operations=operation,
-        exclude_operations=exclude_operation,
-        include_methods=method,
-        exclude_methods=exclude_method,
-        include_kinds=kind,
-        exclude_kinds=exclude_kind,
-        include_paths=path,
-        exclude_paths=exclude_path,
-        include_tags=tag,
-        exclude_tags=exclude_tag,
-    )
-    default_headers = _parse_key_value(header, separator=":")
-    default_query = _parse_key_value(query, separator="=")
-    auth_profiles = _load_auth_profiles_or_error(profile_file, include_names=profile)
-    built_in_auth_configs = _load_auth_configs_or_error(auth_config, include_names=auth_profile)
-    built_in_auth_by_name = auth_config_map(built_in_auth_configs)
-    global_auth_plugin_modules = [str(path.resolve()) for path in auth_plugin_module or []]
-
-    if auth_profiles or built_in_auth_configs:
-        if not auth_profiles:
-            auth_profiles = auth_profiles_from_configs(built_in_auth_configs)
-        auth_profiles = [
-            auth_profile.model_copy(
-                update={
-                    "auth_plugins": [*(auth_plugin or []), *auth_profile.auth_plugins],
-                    "auth_plugin_modules": [
-                        *global_auth_plugin_modules,
-                        *auth_profile.auth_plugin_modules,
-                    ],
-                }
-            )
-            for auth_profile in auth_profiles
-        ]
-        auth_plugins = None
-    else:
-        try:
-            auth_plugins = load_auth_plugins(
-                entry_point_names=auth_plugin,
-                module_paths=auth_plugin_module,
-            )
-        except ValueError as exc:
-            raise typer.BadParameter(str(exc)) from exc
-
     try:
-        if auth_profiles:
-            results = execute_attack_suite_profiles(
-                suite,
-                base_url=base_url,
-                profiles=auth_profiles,
-                default_headers=default_headers,
-                default_query=default_query,
-                timeout_seconds=timeout,
-                artifact_dir=artifact_dir,
-                built_in_auth_configs=built_in_auth_by_name,
-            )
-        else:
-            results = execute_attack_suite(
-                suite,
-                base_url=base_url,
-                default_headers=default_headers,
-                default_query=default_query,
-                timeout_seconds=timeout,
-                artifact_dir=artifact_dir,
-                auth_plugins=auth_plugins,
-                built_in_auth_configs=built_in_auth_configs,
-            )
+        run_result = run_suite(
+            load_attack_suite_or_raise(attacks),
+            base_url=base_url,
+            default_headers=parse_key_value_map(header, separator=":"),
+            default_query=parse_key_value_map(query, separator="="),
+            timeout_seconds=timeout,
+            artifact_dir=artifact_dir,
+            auth_plugin_names=auth_plugin,
+            auth_plugin_module_paths=auth_plugin_module,
+            auth_config_path=auth_config,
+            auth_profile_names=auth_profile,
+            profile_file_path=profile_file,
+            profile_names=profile,
+            operation=operation,
+            exclude_operation=exclude_operation,
+            method=method,
+            exclude_method=exclude_method,
+            kind=kind,
+            exclude_kind=exclude_kind,
+            tag=tag,
+            exclude_tag=exclude_tag,
+            path=path,
+            exclude_path=exclude_path,
+        )
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
     except PluginRuntimeError as exc:
         console.print(f"[red]Auth plugin error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
+    suite = run_result.suite
+    results = run_result.results
     out.write_text(results.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
 
     flagged = sum(1 for result in results.results if result.flagged)
@@ -724,34 +597,71 @@ def report(
     ] = None,
 ) -> None:
     """Render a report from a results file."""
-    attack_results = _load_attack_results_or_error(results, label="current")
-    baseline_results = (
-        _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
-    )
-    suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
-
-    if format is ReportFormatOption.html:
-        rendered = render_html_report(
-            attack_results,
-            baseline=baseline_results,
-            suppressions=suppression_rules,
+    try:
+        report_result = render_report_from_paths(
+            results,
+            baseline_path=baseline,
+            suppressions_path=suppressions,
+            format=format.value,
             artifact_root=artifact_root,
         )
-    else:
-        rendered = render_markdown_report(
-            attack_results,
-            baseline=baseline_results,
-            suppressions=suppression_rules,
-        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
     if out is None:
-        _print_suppression_summary(suppressions_path, suppression_rules)
-        console.print(rendered)
+        _print_suppression_summary(report_result.suppressions_path, report_result.suppressions)
+        console.print(report_result.rendered)
         return
 
-    out.write_text(rendered, encoding="utf-8")
-    _print_suppression_summary(suppressions_path, suppression_rules)
+    out.write_text(report_result.rendered, encoding="utf-8")
+    _print_suppression_summary(report_result.suppressions_path, report_result.suppressions)
     console.print(f"Wrote report to [bold]{out}[/bold].")
+
+
+@app.command()
+def summary(
+    results: Path,
+    baseline: Annotated[
+        Path | None,
+        typer.Option(help="Optional baseline results file for regression comparison."),
+    ] = None,
+    suppressions: Annotated[
+        Path | None,
+        typer.Option(
+            help="Optional suppressions file. Defaults to .knives-out-ignore.yml if present."
+        ),
+    ] = None,
+    out: Annotated[
+        Path | None,
+        typer.Option(help="Optional summary JSON output file."),
+    ] = None,
+    top: Annotated[
+        int,
+        typer.Option(help="How many top active findings to include in the summary."),
+    ] = 10,
+) -> None:
+    """Render a machine-readable JSON summary from a results file."""
+    try:
+        summary_result = summarize_results_from_paths(
+            results,
+            baseline_path=baseline,
+            suppressions_path=suppressions,
+            top_limit=top,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    rendered = json.dumps(
+        summary_result.summary.model_dump(mode="json", exclude_none=True),
+        indent=2,
+    )
+    if out is None:
+        typer.echo(rendered)
+        return
+
+    out.write_text(rendered + "\n", encoding="utf-8")
+    _print_suppression_summary(summary_result.suppressions_path, summary_result.suppressions)
+    console.print(f"Wrote summary JSON to [bold]{out}[/bold].")
 
 
 @app.command()
@@ -777,18 +687,17 @@ def verify(
     ] = ConfidenceThresholdOption.medium,
 ) -> None:
     """Verify results against CI policy, optionally compared to a baseline."""
-    attack_results = _load_attack_results_or_error(results, label="current")
-    baseline_results = (
-        _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
-    )
-    suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
-    verification = evaluate_verification(
-        attack_results,
-        baseline=baseline_results,
-        min_severity=min_severity.value,
-        min_confidence=min_confidence.value,
-        suppressions=suppression_rules,
-    )
+    try:
+        verify_result = verify_results_from_paths(
+            results,
+            baseline_path=baseline,
+            suppressions_path=suppressions,
+            min_severity=min_severity.value,
+            min_confidence=min_confidence.value,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    verification = verify_result.verification
     comparison = verification.comparison
 
     console.print(
@@ -796,7 +705,7 @@ def verify(
         f"severity >= [bold]{min_severity.value}[/bold], "
         f"confidence >= [bold]{min_confidence.value}[/bold]."
     )
-    _print_suppression_summary(suppressions_path, suppression_rules)
+    _print_suppression_summary(verify_result.suppressions_path, verify_result.suppressions)
     if verification.baseline_used:
         persisting_deltas = [
             finding
@@ -867,29 +776,21 @@ def promote(
     ] = ConfidenceThresholdOption.medium,
 ) -> None:
     """Promote qualifying findings back into a reusable attack suite."""
-    current_results = _load_attack_results_or_error(results, label="current")
-    baseline_results = (
-        _load_attack_results_or_error(baseline, label="baseline") if baseline is not None else None
-    )
-    suppressions_path, suppression_rules = _load_suppressions_or_error(suppressions)
-
     try:
-        attack_suite = load_attack_suite(attacks)
-    except (OSError, ValidationError, ValueError) as exc:
-        raise typer.BadParameter(f"Could not read attacks file '{attacks}': {exc}") from exc
-
-    try:
-        promotion = promote_attack_suite(
-            current_results,
-            attack_suite,
-            baseline=baseline_results,
+        promote_result = promote_results_from_paths(
+            results,
+            attacks,
+            baseline_path=baseline,
+            suppressions_path=suppressions,
             min_severity=min_severity.value,
             min_confidence=min_confidence.value,
-            suppressions=suppression_rules,
         )
     except PromotionError as exc:
         console.print(f"[red]Promotion error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    promotion = promote_result.promotion
 
     out.write_text(
         promotion.promoted_suite.model_dump_json(indent=2, exclude_none=True),
@@ -901,7 +802,7 @@ def promote(
         f"severity >= [bold]{min_severity.value}[/bold], "
         f"confidence >= [bold]{min_confidence.value}[/bold]."
     )
-    _print_suppression_summary(suppressions_path, suppression_rules)
+    _print_suppression_summary(promote_result.suppressions_path, promote_result.suppressions)
     if promotion.verification.baseline_used:
         console.print(
             "Promoted new qualifying attacks against a baseline. "
@@ -926,30 +827,35 @@ def triage(
     ] = DEFAULT_SUPPRESSIONS_PATH,
 ) -> None:
     """Append review-ready suppressions for current active findings."""
-    current_results = _load_attack_results_or_error(results, label="current")
-
-    existing_file = SuppressionsFile()
-    if out.exists():
-        try:
-            existing_file = load_suppressions(out)
-        except (OSError, ValueError) as exc:
-            raise typer.BadParameter(f"Could not read suppressions file '{out}': {exc}") from exc
-
-    comparison = compare_attack_results(
-        current_results,
-        suppressions=existing_file.suppressions,
-    )
-    generated_rules = [triage_rule_for_result(result) for result in comparison.current_findings]
-    merged_rules = merge_suppressions(existing_file.suppressions, generated_rules)
-    added_count = len(merged_rules) - len(existing_file.suppressions)
-
-    write_suppressions(out, SuppressionsFile(suppressions=merged_rules))
+    try:
+        triage_result = triage_results_from_path(results, out_path=out)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
     console.print(
-        f"Triaged {len(comparison.current_findings)} active finding(s). "
-        f"Added {added_count} suppression rule(s)."
+        f"Triaged {len(triage_result.comparison.current_findings)} active finding(s). "
+        f"Added {triage_result.added_count} suppression rule(s)."
     )
     console.print(f"Wrote suppressions to [bold]{out}[/bold].")
+
+
+@app.command()
+def serve(
+    host: Annotated[
+        str,
+        typer.Option(help="Host interface for the local knives-out API."),
+    ] = "127.0.0.1",
+    port: Annotated[
+        int,
+        typer.Option(help="Port for the local knives-out API."),
+    ] = 8787,
+    data_dir: Annotated[
+        Path | None,
+        typer.Option(help="Optional data directory for API jobs and artifacts."),
+    ] = None,
+) -> None:
+    """Start the local-first knives-out HTTP API."""
+    uvicorn.run(create_app(data_dir=data_dir), host=host, port=port)
 
 
 def main() -> None:

--- a/src/knives_out/generator.py
+++ b/src/knives_out/generator.py
@@ -1473,6 +1473,7 @@ def _graphql_attack_from_mutation(
         name=mutation.name,
         kind=mutation.kind,
         operation_id=operation.operation_id,
+        protocol=operation.protocol,
         method=operation.method,
         path=operation.path,
         tags=_tags_for_attack(operation),
@@ -1482,6 +1483,10 @@ def _graphql_attack_from_mutation(
         content_type="application/json",
         expected_outcomes=_graphql_expected_outcomes(),
         response_schemas=_response_schemas_for_attack(operation),
+        graphql_root_field_name=operation.graphql_root_field_name,
+        graphql_output_shape=operation.graphql_output_shape,
+        graphql_federated=operation.graphql_federated,
+        graphql_entity_types=list(operation.graphql_entity_types),
     )
 
 
@@ -1502,6 +1507,7 @@ def _generate_graphql_attacks_for_operation(operation: OperationSpec) -> list[At
                 name="Missing request body",
                 kind="missing_request_body",
                 operation_id=operation.operation_id,
+                protocol=operation.protocol,
                 method=operation.method,
                 path=operation.path,
                 tags=_tags_for_attack(operation),
@@ -1510,6 +1516,10 @@ def _generate_graphql_attacks_for_operation(operation: OperationSpec) -> list[At
                 omit_body=True,
                 expected_outcomes=_graphql_expected_outcomes(),
                 response_schemas=_response_schemas_for_attack(operation),
+                graphql_root_field_name=operation.graphql_root_field_name,
+                graphql_output_shape=operation.graphql_output_shape,
+                graphql_federated=operation.graphql_federated,
+                graphql_entity_types=list(operation.graphql_entity_types),
             )
         )
 
@@ -1519,6 +1529,7 @@ def _generate_graphql_attacks_for_operation(operation: OperationSpec) -> list[At
             name="Malformed JSON body",
             kind="malformed_json_body",
             operation_id=operation.operation_id,
+            protocol=operation.protocol,
             method=operation.method,
             path=operation.path,
             tags=_tags_for_attack(operation),
@@ -1528,6 +1539,10 @@ def _generate_graphql_attacks_for_operation(operation: OperationSpec) -> list[At
             content_type="application/json",
             expected_outcomes=_graphql_expected_outcomes(),
             response_schemas=_response_schemas_for_attack(operation),
+            graphql_root_field_name=operation.graphql_root_field_name,
+            graphql_output_shape=operation.graphql_output_shape,
+            graphql_federated=operation.graphql_federated,
+            graphql_entity_types=list(operation.graphql_entity_types),
         )
     )
 

--- a/src/knives_out/graphql_loader.py
+++ b/src/knives_out/graphql_loader.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from graphql import (
     GraphQLEnumType,
+    GraphQLField,
     GraphQLInputObjectType,
     GraphQLInterfaceType,
     GraphQLList,
@@ -14,12 +15,18 @@ from graphql import (
     GraphQLScalarType,
     GraphQLSchema,
     GraphQLUnionType,
+    Undefined,
     build_client_schema,
     build_schema,
     get_named_type,
 )
 
-from knives_out.models import LoadedOperations, OperationSpec, ParameterSpec
+from knives_out.models import (
+    GraphQLOutputShape,
+    LoadedOperations,
+    OperationSpec,
+    ParameterSpec,
+)
 
 
 def _load_graphql_schema(path: str | Path) -> GraphQLSchema:
@@ -79,11 +86,205 @@ def _json_schema_for_input_type(type_: Any) -> tuple[dict[str, Any], bool]:
     return {"type": "string"}, False
 
 
-def _selection_set_for_output_type(type_: Any) -> str:
-    named_type = get_named_type(type_)
-    if isinstance(named_type, (GraphQLObjectType, GraphQLInterfaceType, GraphQLUnionType)):
-        return "{ __typename }"
-    return ""
+def _required_argument(argument: Any) -> bool:
+    return isinstance(argument.type, GraphQLNonNull) and argument.default_value is Undefined
+
+
+def _selectable_field(field: GraphQLField) -> bool:
+    return not any(_required_argument(argument) for argument in field.args.values())
+
+
+def _federated_entity_type(type_: Any) -> bool:
+    directives = getattr(getattr(type_, "ast_node", None), "directives", None) or []
+    return any(getattr(directive.name, "value", None) == "key" for directive in directives)
+
+
+def _graphql_shape(
+    type_: Any,
+    *,
+    schema: GraphQLSchema,
+    depth: int = 0,
+    seen: tuple[str, ...] = (),
+    federated_schema: bool = False,
+) -> tuple[GraphQLOutputShape, str]:
+    nullable = not isinstance(type_, GraphQLNonNull)
+    inner_type = type_.of_type if isinstance(type_, GraphQLNonNull) else type_
+
+    if isinstance(inner_type, GraphQLList):
+        item_shape, item_selection = _graphql_shape(
+            inner_type.of_type,
+            schema=schema,
+            depth=depth,
+            seen=seen,
+            federated_schema=federated_schema,
+        )
+        return (
+            GraphQLOutputShape(
+                kind="list",
+                type_name=str(get_named_type(inner_type)),
+                nullable=nullable,
+                item_shape=item_shape,
+                federation_hint=(
+                    "Selection crosses a federated list boundary."
+                    if federated_schema and item_shape.kind in {"object", "interface", "union"}
+                    else None
+                ),
+            ),
+            item_selection,
+        )
+
+    named_type = get_named_type(inner_type)
+    if isinstance(named_type, GraphQLScalarType):
+        return (
+            GraphQLOutputShape(
+                kind="scalar",
+                type_name=named_type.name,
+                nullable=nullable,
+            ),
+            "",
+        )
+
+    if isinstance(named_type, GraphQLEnumType):
+        return (
+            GraphQLOutputShape(
+                kind="enum",
+                type_name=named_type.name,
+                nullable=nullable,
+            ),
+            "",
+        )
+
+    if isinstance(named_type, GraphQLObjectType):
+        type_name = named_type.name
+        if type_name in seen or depth >= 3:
+            fields = {
+                "__typename": GraphQLOutputShape(
+                    kind="scalar",
+                    type_name="String",
+                    nullable=False,
+                )
+            }
+            return (
+                GraphQLOutputShape(
+                    kind="object",
+                    type_name=type_name,
+                    nullable=nullable,
+                    fields=fields,
+                    federated_entity=federated_schema and _federated_entity_type(named_type),
+                    federation_hint=(
+                        f"Type '{type_name}' is revisited inside a federated schema."
+                        if federated_schema
+                        else None
+                    ),
+                ),
+                "{ __typename }",
+            )
+
+        fields: dict[str, GraphQLOutputShape] = {
+            "__typename": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            )
+        }
+        selections = ["__typename"]
+        for field_name, field in named_type.fields.items():
+            if field_name.startswith("__") or not _selectable_field(field):
+                continue
+            field_shape, field_selection = _graphql_shape(
+                field.type,
+                schema=schema,
+                depth=depth + 1,
+                seen=(*seen, type_name),
+                federated_schema=federated_schema,
+            )
+            fields[field_name] = field_shape
+            if field_selection:
+                selections.append(f"{field_name} {field_selection}")
+            else:
+                selections.append(field_name)
+        return (
+            GraphQLOutputShape(
+                kind="object",
+                type_name=type_name,
+                nullable=nullable,
+                fields=fields,
+                federated_entity=federated_schema and _federated_entity_type(named_type),
+                federation_hint=(
+                    f"Type '{type_name}' may resolve across federated entity boundaries."
+                    if federated_schema and _federated_entity_type(named_type)
+                    else None
+                ),
+            ),
+            "{ " + " ".join(selections) + " }",
+        )
+
+    if isinstance(named_type, GraphQLInterfaceType):
+        possible_types: dict[str, GraphQLOutputShape] = {}
+        fragments: list[str] = ["__typename"]
+        for possible_type in schema.get_possible_types(named_type):
+            possible_shape, possible_selection = _graphql_shape(
+                possible_type,
+                schema=schema,
+                depth=depth + 1,
+                seen=(*seen, named_type.name),
+                federated_schema=federated_schema,
+            )
+            possible_types[possible_type.name] = possible_shape
+            fragments.append(f"... on {possible_type.name} {possible_selection}")
+        return (
+            GraphQLOutputShape(
+                kind="interface",
+                type_name=named_type.name,
+                nullable=nullable,
+                possible_types=possible_types,
+                federation_hint=(
+                    f"Interface '{named_type.name}' spans possible runtime types "
+                    "in a federated schema."
+                    if federated_schema
+                    else None
+                ),
+            ),
+            "{ " + " ".join(fragments) + " }",
+        )
+
+    if isinstance(named_type, GraphQLUnionType):
+        possible_types = {}
+        fragments = ["__typename"]
+        for possible_type in named_type.types:
+            possible_shape, possible_selection = _graphql_shape(
+                possible_type,
+                schema=schema,
+                depth=depth + 1,
+                seen=(*seen, named_type.name),
+                federated_schema=federated_schema,
+            )
+            possible_types[possible_type.name] = possible_shape
+            fragments.append(f"... on {possible_type.name} {possible_selection}")
+        return (
+            GraphQLOutputShape(
+                kind="union",
+                type_name=named_type.name,
+                nullable=nullable,
+                possible_types=possible_types,
+                federation_hint=(
+                    f"Union '{named_type.name}' crosses runtime type boundaries "
+                    "in a federated schema."
+                    if federated_schema
+                    else None
+                ),
+            ),
+            "{ " + " ".join(fragments) + " }",
+        )
+
+    return (
+        GraphQLOutputShape(
+            kind="scalar",
+            type_name=str(named_type),
+            nullable=nullable,
+        ),
+        "",
+    )
 
 
 def _graphql_document(
@@ -91,6 +292,8 @@ def _graphql_document(
     operation_type: str,
     field_name: str,
     field: Any,
+    schema: GraphQLSchema,
+    federated_schema: bool,
 ) -> str:
     variable_definitions: list[str] = []
     argument_bindings: list[str] = []
@@ -101,9 +304,18 @@ def _graphql_document(
     operation_name = field_name[:1].upper() + field_name[1:]
     definitions = f"({', '.join(variable_definitions)})" if variable_definitions else ""
     bindings = f"({', '.join(argument_bindings)})" if argument_bindings else ""
-    selection_set = _selection_set_for_output_type(field.type)
+    _, selection_set = _graphql_shape(
+        field.type,
+        schema=schema,
+        federated_schema=federated_schema,
+    )
     selection = f" {selection_set}" if selection_set else ""
     return f"{operation_type} {operation_name}{definitions} {{ {field_name}{bindings}{selection} }}"
+
+
+def _graphql_schema_is_federated(schema: GraphQLSchema) -> bool:
+    query_fields = schema.query_type.fields if schema.query_type is not None else {}
+    return "_service" in query_fields or "_entities" in query_fields or "_Entity" in schema.type_map
 
 
 def _variables_schema(field: Any) -> dict[str, Any]:
@@ -137,6 +349,7 @@ def _request_body_schema(document: str, variables_schema: dict[str, Any]) -> dic
 
 def _operation_specs(
     *,
+    schema: GraphQLSchema,
     root: GraphQLObjectType | None,
     operation_type: str,
     endpoint: str,
@@ -144,14 +357,29 @@ def _operation_specs(
     if root is None:
         return []
 
+    federated_schema = _graphql_schema_is_federated(schema)
     operations: list[OperationSpec] = []
     for field_name, field in root.fields.items():
         variables_schema = _variables_schema(field)
+        output_shape, _ = _graphql_shape(
+            field.type,
+            schema=schema,
+            federated_schema=federated_schema,
+        )
         document = _graphql_document(
             operation_type=operation_type,
             field_name=field_name,
             field=field,
+            schema=schema,
+            federated_schema=federated_schema,
         )
+        entity_types = sorted(
+            type_name
+            for type_name, shape in output_shape.possible_types.items()
+            if shape.federated_entity
+        )
+        if output_shape.federated_entity:
+            entity_types.append(output_shape.type_name)
         operations.append(
             OperationSpec(
                 operation_id=field_name,
@@ -175,6 +403,10 @@ def _operation_specs(
                 graphql_operation_type=operation_type,
                 graphql_document=document,
                 graphql_variables_schema=variables_schema,
+                graphql_root_field_name=field_name,
+                graphql_output_shape=output_shape,
+                graphql_federated=federated_schema,
+                graphql_entity_types=sorted(set(entity_types)),
             )
         )
 
@@ -188,8 +420,18 @@ def load_graphql_operations_with_warnings(
 ) -> LoadedOperations:
     schema = _load_graphql_schema(path)
     operations = [
-        *_operation_specs(root=schema.query_type, operation_type="query", endpoint=endpoint),
-        *_operation_specs(root=schema.mutation_type, operation_type="mutation", endpoint=endpoint),
+        *_operation_specs(
+            schema=schema,
+            root=schema.query_type,
+            operation_type="query",
+            endpoint=endpoint,
+        ),
+        *_operation_specs(
+            schema=schema,
+            root=schema.mutation_type,
+            operation_type="mutation",
+            endpoint=endpoint,
+        ),
     ]
     return LoadedOperations(source_kind="graphql", operations=operations, warnings=[])
 

--- a/src/knives_out/models.py
+++ b/src/knives_out/models.py
@@ -12,6 +12,7 @@ AuthEventPhase = Literal["acquire", "refresh"]
 SourceKind = Literal["openapi", "graphql", "learned"]
 CaptureSource = Literal["proxy", "har"]
 LearnedBindingTarget = Literal["path", "query", "body"]
+GraphQLOutputKind = Literal["scalar", "enum", "object", "list", "interface", "union"]
 
 
 class CapturedRequest(BaseModel):
@@ -69,6 +70,17 @@ class ResponseSpec(BaseModel):
     schema_def: dict[str, Any] | None = None
 
 
+class GraphQLOutputShape(BaseModel):
+    kind: GraphQLOutputKind
+    type_name: str
+    nullable: bool = True
+    fields: dict[str, GraphQLOutputShape] = Field(default_factory=dict)
+    item_shape: GraphQLOutputShape | None = None
+    possible_types: dict[str, GraphQLOutputShape] = Field(default_factory=dict)
+    federated_entity: bool = False
+    federation_hint: str | None = None
+
+
 class OperationSpec(BaseModel):
     operation_id: str
     method: str
@@ -87,6 +99,10 @@ class OperationSpec(BaseModel):
     graphql_operation_type: Literal["query", "mutation"] | None = None
     graphql_document: str | None = None
     graphql_variables_schema: dict[str, Any] | None = None
+    graphql_root_field_name: str | None = None
+    graphql_output_shape: GraphQLOutputShape | None = None
+    graphql_federated: bool = False
+    graphql_entity_types: list[str] = Field(default_factory=list)
     observed_examples: list[ObservedRequestExample] = Field(default_factory=list)
     learned_confidence: float | None = None
     observation_count: int = 0
@@ -170,6 +186,7 @@ class AttackCase(BaseModel):
     name: str
     kind: str
     operation_id: str
+    protocol: SourceKind = "openapi"
     method: str
     path: str
     tags: list[str] = Field(default_factory=list)
@@ -186,6 +203,10 @@ class AttackCase(BaseModel):
     omit_query_names: list[str] = Field(default_factory=list)
     expected_outcomes: list[str] = Field(default_factory=lambda: ["4xx"])
     response_schemas: dict[str, ResponseSpec] = Field(default_factory=dict)
+    graphql_root_field_name: str | None = None
+    graphql_output_shape: GraphQLOutputShape | None = None
+    graphql_federated: bool = False
+    graphql_entity_types: list[str] = Field(default_factory=list)
 
 
 class ExtractRule(BaseModel):
@@ -218,6 +239,7 @@ class WorkflowAttackCase(BaseModel):
     name: str
     kind: str
     operation_id: str
+    protocol: SourceKind = "openapi"
     method: str
     path: str
     tags: list[str] = Field(default_factory=list)
@@ -291,6 +313,7 @@ class AuthEvent(BaseModel):
 
 
 class ProfileAttackResult(BaseModel):
+    protocol: SourceKind = "openapi"
     profile: str
     level: int = 0
     anonymous: bool = False
@@ -306,6 +329,9 @@ class ProfileAttackResult(BaseModel):
     response_schema_status: str | None = None
     response_schema_valid: bool | None = None
     response_schema_error: str | None = None
+    graphql_response_valid: bool | None = None
+    graphql_response_error: str | None = None
+    graphql_response_hint: str | None = None
     workflow_steps: list[WorkflowStepResult] | None = None
 
 
@@ -315,6 +341,7 @@ class AttackResult(BaseModel):
     operation_id: str
     kind: str
     name: str
+    protocol: SourceKind = "openapi"
     method: str
     path: str | None = None
     tags: list[str] = Field(default_factory=list)
@@ -330,6 +357,9 @@ class AttackResult(BaseModel):
     response_schema_status: str | None = None
     response_schema_valid: bool | None = None
     response_schema_error: str | None = None
+    graphql_response_valid: bool | None = None
+    graphql_response_error: str | None = None
+    graphql_response_hint: str | None = None
     workflow_steps: list[WorkflowStepResult] | None = None
     profile_results: list[ProfileAttackResult] | None = None
 
@@ -359,9 +389,63 @@ class AttackResults(BaseModel):
                 coerced["results"].append(result)
                 continue
             result_coerced = dict(result)
+            result_coerced.setdefault("protocol", "openapi")
             result_coerced.setdefault(
                 "type",
                 "workflow" if result_coerced.get("workflow_steps") else "request",
             )
             coerced["results"].append(result_coerced)
         return coerced
+
+
+class SummaryFinding(BaseModel):
+    attack_id: str
+    name: str
+    protocol: str
+    kind: str
+    issue: str | None = None
+    severity: SeverityLevel
+    confidence: ConfidenceLevel
+    status_code: int | None = None
+    url: str
+    schema_status: str = "-"
+
+
+class AuthSummaryEntry(BaseModel):
+    profile: str
+    name: str
+    strategy: str
+    acquire: int = 0
+    refresh: int = 0
+    failures: int = 0
+    triggers: list[str] = Field(default_factory=list)
+
+
+class ResultsSummary(BaseModel):
+    source: str
+    base_url: str
+    executed_at: datetime
+    baseline_used: bool = False
+    baseline_executed_at: datetime | None = None
+    total_results: int
+    profile_count: int = 0
+    profile_names: list[str] = Field(default_factory=list)
+    active_flagged_count: int = 0
+    suppressed_flagged_count: int = 0
+    new_findings_count: int = 0
+    resolved_findings_count: int = 0
+    persisting_findings_count: int = 0
+    persisting_deltas_count: int = 0
+    auth_failures: int = 0
+    refresh_attempts: int = 0
+    response_schema_mismatches: int = 0
+    graphql_shape_mismatches: int = 0
+    protocol_counts: dict[str, int] = Field(default_factory=dict)
+    issue_counts: dict[str, int] = Field(default_factory=dict)
+    finding_severity_counts: dict[str, int] = Field(default_factory=dict)
+    finding_confidence_counts: dict[str, int] = Field(default_factory=dict)
+    auth_summary: list[AuthSummaryEntry] = Field(default_factory=list)
+    top_findings: list[SummaryFinding] = Field(default_factory=list)
+
+
+GraphQLOutputShape.model_rebuild()

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -32,6 +32,30 @@ def _finding_table_rows(findings: list[ComparedFinding]) -> list[str]:
     return rows
 
 
+def _persisting_delta_findings(findings: list[ComparedFinding]) -> list[ComparedFinding]:
+    return [finding for finding in findings if finding.delta is not None and finding.delta.changed]
+
+
+def _delta_summary(finding: ComparedFinding) -> str:
+    delta = finding.delta
+    if delta is None or not delta.changed:
+        return "unchanged"
+    return ", ".join(
+        f"{change.field} {change.baseline} -> {change.current}" for change in delta.changes
+    )
+
+
+def _persisting_delta_rows(findings: list[ComparedFinding]) -> list[str]:
+    rows: list[str] = []
+    for finding in _persisting_delta_findings(findings):
+        result = finding.result
+        rows.append(
+            f"| {result.name} | {result.kind} | {result.issue or '-'} | "
+            f"{_delta_summary(finding)} | `{result.url}` |"
+        )
+    return rows
+
+
 def _suppressed_table_rows(findings: list[SuppressedFinding]) -> list[str]:
     rows: list[str] = []
     for finding in findings:
@@ -216,6 +240,7 @@ def render_markdown_report(
         lines.append("| None | - | - | - | - | - | - | - |")
 
     if baseline is not None:
+        persisting_deltas = _persisting_delta_findings(comparison.persisting_findings)
         lines.append("")
         lines.append("## Verification summary")
         lines.append("")
@@ -223,6 +248,7 @@ def render_markdown_report(
         lines.append(f"- New findings: **{len(comparison.new_findings)}**")
         lines.append(f"- Resolved findings: **{len(comparison.resolved_findings)}**")
         lines.append(f"- Persisting findings: **{len(comparison.persisting_findings)}**")
+        lines.append(f"- Persisting findings with deltas: **{len(persisting_deltas)}**")
         lines.append(
             f"- Suppressed current findings: **{len(comparison.suppressed_current_findings)}**"
         )
@@ -253,6 +279,15 @@ def render_markdown_report(
         lines.extend(_finding_table_rows(comparison.persisting_findings))
         if not comparison.persisting_findings:
             lines.append("| None | - | - | - | - | - | - | - |")
+
+        lines.append("")
+        lines.append("## Persisting deltas")
+        lines.append("")
+        lines.append("| Attack | Kind | Issue | Changes | URL |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        lines.extend(_persisting_delta_rows(comparison.persisting_findings))
+        if not persisting_deltas:
+            lines.append("| None | - | - | - | - |")
 
     lines.append("")
     lines.append("## Detailed results")
@@ -420,6 +455,19 @@ def _auth_summary_row_html(entry: dict[str, object]) -> str:
         f"<td>{escape(str(entry['refresh']))}</td>"
         f"<td>{escape(str(entry['failures']))}</td>"
         f"<td>{escape(triggers)}</td>"
+        "</tr>"
+    )
+
+
+def _persisting_delta_row_html(finding: ComparedFinding) -> str:
+    result = finding.result
+    return (
+        "<tr>"
+        f"<td>{escape(result.name)}</td>"
+        f"<td>{escape(result.kind)}</td>"
+        f"<td>{escape(result.issue or '-')}</td>"
+        f"<td>{escape(_delta_summary(finding))}</td>"
+        f"<td><code>{escape(result.url)}</code></td>"
         "</tr>"
     )
 
@@ -610,6 +658,11 @@ def render_html_report(
 
     diff_panels = ""
     if baseline is not None:
+        persisting_deltas = _persisting_delta_findings(comparison.persisting_findings)
+        persisting_delta_rows = (
+            "".join(_persisting_delta_row_html(finding) for finding in persisting_deltas)
+            or "<tr><td colspan='5' class='muted'>No persisting deltas detected.</td></tr>"
+        )
         diff_panels = (
             "<section class='panel'>"
             "<h2>Regression summary</h2>"
@@ -618,7 +671,14 @@ def render_html_report(
             f"{_summary_card_html('New findings', str(len(comparison.new_findings)))}"
             f"{_summary_card_html('Resolved findings', str(len(comparison.resolved_findings)))}"
             f"{_summary_card_html('Persisting findings', str(len(comparison.persisting_findings)))}"
+            f"{_summary_card_html('Persisting with deltas', str(len(persisting_deltas)))}"
             "</div></section>"
+            "<section class='panel'>"
+            "<h2>Persisting deltas</h2>"
+            "<table>"
+            "<thead><tr><th>Attack</th><th>Kind</th><th>Issue</th><th>Changes</th><th>URL</th></tr></thead>"
+            f"<tbody>{persisting_delta_rows}</tbody>"
+            "</table></section>"
         )
 
     cards_html = "".join(

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -5,7 +5,14 @@ from collections import Counter
 from html import escape
 from pathlib import Path
 
-from knives_out.models import AttackResults, AuthEvent, ProfileAttackResult
+from knives_out.models import (
+    AttackResults,
+    AuthEvent,
+    AuthSummaryEntry,
+    ProfileAttackResult,
+    ResultsSummary,
+    SummaryFinding,
+)
 from knives_out.suppressions import SuppressedFinding, SuppressionRule
 from knives_out.verification import (
     ComparedFinding,
@@ -18,14 +25,34 @@ def load_attack_results(path: str | Path) -> AttackResults:
     return AttackResults.model_validate_json(raw)
 
 
+def _protocol_label(protocol: str) -> str:
+    if protocol == "openapi":
+        return "rest"
+    return protocol
+
+
+def _schema_summary(result) -> str:
+    if result.protocol == "graphql":
+        if result.graphql_response_valid is False:
+            return "graphql-mismatch"
+        if result.graphql_response_valid is True:
+            return "graphql-ok"
+        return "-"
+    if result.response_schema_valid is False:
+        return "mismatch"
+    if result.response_schema_valid is True:
+        return "ok"
+    return "-"
+
+
 def _finding_table_rows(findings: list[ComparedFinding]) -> list[str]:
     rows: list[str] = []
     for finding in findings:
         result = finding.result
         status = str(result.status_code) if result.status_code is not None else "-"
-        schema = "mismatch" if result.response_schema_valid is False else "-"
+        schema = _schema_summary(result)
         rows.append(
-            f"| {result.name} | {result.kind} | {status} | "
+            f"| {_protocol_label(result.protocol)} | {result.name} | {result.kind} | {status} | "
             f"{result.issue or '-'} | {result.severity} | {result.confidence} | "
             f"{schema} | `{result.url}` |"
         )
@@ -75,12 +102,13 @@ def _profile_table_rows(profile_results: list[ProfileAttackResult]) -> list[str]
         key=lambda result: (result.level, result.profile.casefold()),
     ):
         status = str(profile_result.status_code) if profile_result.status_code is not None else "-"
-        schema = "mismatch" if profile_result.response_schema_valid is False else "-"
+        schema = _schema_summary(profile_result)
         profile_name = profile_result.profile
         if profile_result.anonymous:
             profile_name = f"{profile_name} (anonymous)"
         rows.append(
-            f"| {profile_name} | {profile_result.level} | {status} | "
+            f"| {profile_name} | {_protocol_label(profile_result.protocol)} | "
+            f"{profile_result.level} | {status} | "
             f"{profile_result.issue or 'ok'} | {schema} | `{profile_result.url}` |"
         )
     return rows
@@ -151,6 +179,89 @@ def _workflow_phase(result) -> str:
     return "terminal"
 
 
+def _counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def summarize_results(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    top_limit: int = 10,
+) -> ResultsSummary:
+    if top_limit < 0:
+        raise ValueError("top_limit must be >= 0.")
+
+    comparison = compare_attack_results(results, baseline, suppressions=suppressions)
+    persisting_deltas = _persisting_delta_findings(comparison.persisting_findings)
+
+    auth_summary = [
+        AuthSummaryEntry(
+            profile=str(entry["profile"]),
+            name=str(entry["name"]),
+            strategy=str(entry["strategy"]),
+            acquire=int(entry["acquire"]),
+            refresh=int(entry["refresh"]),
+            failures=int(entry["failures"]),
+            triggers=sorted(str(trigger) for trigger in entry["triggers"]),
+        )
+        for entry in _auth_summary_entries(results.auth_events)
+    ]
+    top_findings = [
+        SummaryFinding(
+            attack_id=result.attack_id,
+            name=result.name,
+            protocol=_protocol_label(result.protocol),
+            kind=result.kind,
+            issue=result.issue,
+            severity=result.severity,
+            confidence=result.confidence,
+            status_code=result.status_code,
+            url=result.url,
+            schema_status=_schema_summary(result),
+        )
+        for result in comparison.current_findings[:top_limit]
+    ]
+
+    return ResultsSummary(
+        source=results.source,
+        base_url=results.base_url,
+        executed_at=results.executed_at,
+        baseline_used=baseline is not None,
+        baseline_executed_at=baseline.executed_at if baseline is not None else None,
+        total_results=len(results.results),
+        profile_count=len(results.profiles),
+        profile_names=list(results.profiles),
+        active_flagged_count=len(comparison.current_findings),
+        suppressed_flagged_count=len(comparison.suppressed_current_findings),
+        new_findings_count=len(comparison.new_findings),
+        resolved_findings_count=len(comparison.resolved_findings),
+        persisting_findings_count=len(comparison.persisting_findings),
+        persisting_deltas_count=len(persisting_deltas),
+        auth_failures=sum(1 for event in results.auth_events if not event.success),
+        refresh_attempts=sum(1 for event in results.auth_events if event.phase == "refresh"),
+        response_schema_mismatches=sum(
+            1 for result in results.results if result.response_schema_valid is False
+        ),
+        graphql_shape_mismatches=sum(
+            1 for result in results.results if result.graphql_response_valid is False
+        ),
+        protocol_counts=_counter_dict(
+            Counter(_protocol_label(result.protocol) for result in results.results)
+        ),
+        issue_counts=_counter_dict(Counter(result.issue or "ok" for result in results.results)),
+        finding_severity_counts=_counter_dict(
+            Counter(result.severity for result in comparison.current_findings)
+        ),
+        finding_confidence_counts=_counter_dict(
+            Counter(result.confidence for result in comparison.current_findings)
+        ),
+        auth_summary=auth_summary,
+        top_findings=top_findings,
+    )
+
+
 def render_markdown_report(
     results: AttackResults,
     *,
@@ -166,7 +277,11 @@ def render_markdown_report(
     response_schema_mismatches = sum(
         1 for result in results.results if result.response_schema_valid is False
     )
+    graphql_shape_mismatches = sum(
+        1 for result in results.results if result.graphql_response_valid is False
+    )
     issue_counter = Counter(result.issue or "ok" for result in results.results)
+    protocol_counter = Counter(_protocol_label(result.protocol) for result in results.results)
 
     lines: list[str] = []
     lines.append("# knives-out report")
@@ -182,6 +297,11 @@ def render_markdown_report(
     lines.append(f"- Suppressed flagged results: **{suppressed_flagged}**")
     lines.append(f"- Auth setup/refresh failures: **{auth_failures}**")
     lines.append(f"- Response schema mismatches: **{response_schema_mismatches}**")
+    lines.append(f"- GraphQL response-shape mismatches: **{graphql_shape_mismatches}**")
+    lines.append(
+        "- Protocol mix: "
+        + ", ".join(f"`{protocol}`={count}" for protocol, count in sorted(protocol_counter.items()))
+    )
     lines.append("")
     lines.append("## Outcome summary")
     lines.append("")
@@ -193,22 +313,24 @@ def render_markdown_report(
     lines.append("")
     lines.append("## Flagged findings")
     lines.append("")
-    lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
-    lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+    lines.append(
+        "| Protocol | Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |"
+    )
+    lines.append("| --- | --- | --- | ---: | --- | --- | --- | --- | --- |")
 
     found_flagged = False
     for result in comparison.current_findings:
         found_flagged = True
         status = str(result.status_code) if result.status_code is not None else "-"
-        schema = "mismatch" if result.response_schema_valid is False else "-"
+        schema = _schema_summary(result)
         lines.append(
-            f"| {result.name} | {result.kind} | {status} | "
+            f"| {_protocol_label(result.protocol)} | {result.name} | {result.kind} | {status} | "
             f"{result.issue or '-'} | {result.severity} | {result.confidence} | "
             f"{schema} | `{result.url}` |"
         )
 
     if not found_flagged:
-        lines.append("| None | - | - | - | - | - | - | - |")
+        lines.append("| None | - | - | - | - | - | - | - | - |")
 
     lines.append("")
     lines.append("## Suppressed findings")
@@ -256,29 +378,35 @@ def render_markdown_report(
         lines.append("")
         lines.append("## New findings")
         lines.append("")
-        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
-        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+        lines.append(
+            "| Protocol | Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |"
+        )
+        lines.append("| --- | --- | --- | ---: | --- | --- | --- | --- | --- |")
         lines.extend(_finding_table_rows(comparison.new_findings))
         if not comparison.new_findings:
-            lines.append("| None | - | - | - | - | - | - | - |")
+            lines.append("| None | - | - | - | - | - | - | - | - |")
 
         lines.append("")
         lines.append("## Resolved findings")
         lines.append("")
-        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
-        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+        lines.append(
+            "| Protocol | Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |"
+        )
+        lines.append("| --- | --- | --- | ---: | --- | --- | --- | --- | --- |")
         lines.extend(_finding_table_rows(comparison.resolved_findings))
         if not comparison.resolved_findings:
-            lines.append("| None | - | - | - | - | - | - | - |")
+            lines.append("| None | - | - | - | - | - | - | - | - |")
 
         lines.append("")
         lines.append("## Persisting findings")
         lines.append("")
-        lines.append("| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |")
-        lines.append("| --- | --- | ---: | --- | --- | --- | --- | --- |")
+        lines.append(
+            "| Protocol | Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |"
+        )
+        lines.append("| --- | --- | --- | ---: | --- | --- | --- | --- | --- |")
         lines.extend(_finding_table_rows(comparison.persisting_findings))
         if not comparison.persisting_findings:
-            lines.append("| None | - | - | - | - | - | - | - |")
+            lines.append("| None | - | - | - | - | - | - | - | - |")
 
         lines.append("")
         lines.append("## Persisting deltas")
@@ -296,6 +424,7 @@ def render_markdown_report(
         lines.append(f"### {result.name}")
         lines.append("")
         lines.append(f"- Type: `{result.type}`")
+        lines.append(f"- Protocol: `{_protocol_label(result.protocol)}`")
         lines.append(f"- Operation: `{result.operation_id}`")
         lines.append(f"- Method: `{result.method}`")
         lines.append(f"- URL: `{result.url}`")
@@ -316,14 +445,20 @@ def render_markdown_report(
             lines.append("- Response schema: `ok`")
         elif result.response_schema_error:
             lines.append(f"- Response schema mismatch: `{result.response_schema_error}`")
+        if result.graphql_response_valid is True:
+            lines.append("- GraphQL response shape: `ok`")
+        elif result.graphql_response_error:
+            lines.append(f"- GraphQL response shape mismatch: `{result.graphql_response_error}`")
+        if result.graphql_response_hint:
+            lines.append(f"- GraphQL federation hint: `{result.graphql_response_hint}`")
         if result.error:
             lines.append(f"- Error: `{result.error}`")
         if result.duration_ms is not None:
             lines.append(f"- Duration: `{result.duration_ms:.2f} ms`")
         if result.profile_results:
             lines.append("")
-            lines.append("| Profile | Level | Status | Issue | Schema | URL |")
-            lines.append("| --- | ---: | ---: | --- | --- | --- |")
+            lines.append("| Profile | Protocol | Level | Status | Issue | Schema | URL |")
+            lines.append("| --- | --- | ---: | ---: | --- | --- | --- |")
             lines.extend(_profile_table_rows(result.profile_results))
         if result.response_excerpt:
             lines.append("")
@@ -395,7 +530,11 @@ def _artifact_links_html(result, *, artifact_root: Path | None) -> str:
 def _issue_badge_class(issue: str | None) -> str:
     if issue in {"anonymous_access", "authorization_inversion", "server_error"}:
         return "critical"
-    if issue in {"unexpected_success", "response_schema_mismatch"}:
+    if issue in {
+        "unexpected_success",
+        "response_schema_mismatch",
+        "graphql_response_shape_mismatch",
+    }:
         return "warning"
     return "neutral"
 
@@ -488,10 +627,11 @@ def _result_card_html(result, *, artifact_root: Path | None) -> str:
             profile_status = (
                 str(profile_result.status_code) if profile_result.status_code is not None else "-"
             )
-            profile_schema = "mismatch" if profile_result.response_schema_valid is False else "-"
+            profile_schema = _schema_summary(profile_result)
             rows.append(
                 "<tr>"
                 f"<td>{escape(profile_name)}</td>"
+                f"<td>{escape(_protocol_label(profile_result.protocol))}</td>"
                 f"<td>{profile_result.level}</td>"
                 f"<td>{escape(profile_status)}</td>"
                 f"<td>{escape(profile_result.issue or 'ok')}</td>"
@@ -501,7 +641,7 @@ def _result_card_html(result, *, artifact_root: Path | None) -> str:
             )
         profile_rows = (
             "<div class='subsection'><h4>Profile outcomes</h4>"
-            "<table><thead><tr><th>Profile</th><th>Level</th><th>Status</th>"
+            "<table><thead><tr><th>Profile</th><th>Protocol</th><th>Level</th><th>Status</th>"
             "<th>Issue</th><th>Schema</th><th>URL</th></tr></thead><tbody>"
             + "".join(rows)
             + "</tbody></table></div>"
@@ -539,10 +679,23 @@ def _result_card_html(result, *, artifact_root: Path | None) -> str:
     error = ""
     if result.error:
         error = f"<p class='callout'>{escape(result.error)}</p>"
+    graphql_details = ""
+    if result.graphql_response_error or result.graphql_response_hint:
+        graphql_details = (
+            "<div class='subsection'><h4>GraphQL validation</h4>"
+            f"<p>{escape(result.graphql_response_error or 'ok')}</p>"
+            + (
+                f"<p class='muted'>{escape(result.graphql_response_hint)}</p>"
+                if result.graphql_response_hint
+                else ""
+            )
+            + "</div>"
+        )
 
     meta_grid = "".join(
         [
             _result_meta_item_html("Type", result.type),
+            _result_meta_item_html("Protocol", _protocol_label(result.protocol)),
             _result_meta_item_html("Operation", result.operation_id),
             _result_meta_item_html("Method", result.method),
             _result_meta_item_html("Status", status),
@@ -562,7 +715,7 @@ def _result_card_html(result, *, artifact_root: Path | None) -> str:
         "</div>"
         f"<p><code>{escape(result.url)}</code></p>"
         f"<div class='subsection'><h4>Artifacts</h4>{artifact_html}</div>"
-        f"{error}{profile_rows}{workflow_rows}{excerpt}"
+        f"{error}{graphql_details}{profile_rows}{workflow_rows}{excerpt}"
         "</article>"
     )
 
@@ -582,6 +735,7 @@ def render_html_report(
         else []
     )
     issue_counter = Counter(result.issue or "ok" for result in results.results)
+    protocol_counter = Counter(_protocol_label(result.protocol) for result in results.results)
     refresh_attempts = sum(1 for event in results.auth_events if event.phase == "refresh")
 
     summary_cards = [
@@ -590,6 +744,10 @@ def render_html_report(
         ("Suppressed", str(len(comparison.suppressed_current_findings))),
         ("Auth failures", str(sum(1 for event in results.auth_events if not event.success))),
         ("Refresh attempts", str(refresh_attempts)),
+        (
+            "Protocols",
+            ", ".join(f"{name}:{count}" for name, count in sorted(protocol_counter.items())),
+        ),
         (
             "Profiles",
             str(len(results.profiles)) if results.profiles else "single",
@@ -606,6 +764,7 @@ def render_html_report(
 
     flagged_rows = "".join(
         "<tr>"
+        f"<td>{escape(_protocol_label(finding.protocol))}</td>"
         f"<td>{escape(finding.name)}</td>"
         f"<td>{escape(finding.kind)}</td>"
         f"<td>{escape(str(finding.status_code) if finding.status_code is not None else '-')}</td>"
@@ -615,7 +774,7 @@ def render_html_report(
         f"<td>{_artifact_links_html(finding, artifact_root=artifact_root_path)}</td>"
         "</tr>"
         for finding in comparison.current_findings
-    ) or ("<tr><td colspan='7' class='muted'>No active flagged findings.</td></tr>")
+    ) or ("<tr><td colspan='8' class='muted'>No active flagged findings.</td></tr>")
 
     suppressed_rows = (
         "".join(
@@ -882,7 +1041,7 @@ def render_html_report(
       <section class="panel">
         <h2>Flagged findings</h2>
         <table>
-          <thead><tr><th>Attack</th><th>Kind</th><th>Status</th><th>Issue</th><th>Severity</th><th>Confidence</th><th>Artifacts</th></tr></thead>
+          <thead><tr><th>Protocol</th><th>Attack</th><th>Kind</th><th>Status</th><th>Issue</th><th>Severity</th><th>Confidence</th><th>Artifacts</th></tr></thead>
           <tbody>{flagged_rows}</tbody>
         </table>
       </section>

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -32,6 +32,7 @@ from knives_out.models import (
     AttackSuite,
     AuthProfile,
     ConfidenceLevel,
+    GraphQLOutputShape,
     ProfileAttackResult,
     ResponseSpec,
     SeverityLevel,
@@ -46,6 +47,7 @@ ISSUE_SCORES: dict[str, tuple[SeverityLevel, ConfidenceLevel]] = {
     "server_error": ("high", "high"),
     "unexpected_success": ("high", "medium"),
     "response_schema_mismatch": ("medium", "high"),
+    "graphql_response_shape_mismatch": ("medium", "high"),
     "anonymous_access": ("high", "high"),
     "authorization_inversion": ("high", "medium"),
 }
@@ -159,6 +161,185 @@ def _response_matches_expected(
         expected.strip().lower() == "graphql_error" and _response_has_graphql_errors(response)
         for expected in expected_outcomes
     )
+
+
+def _graphql_scalar_matches(type_name: str, value: Any) -> bool:
+    if type_name in {"String", "ID"}:
+        return isinstance(value, str)
+    if type_name == "Int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "Float":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if type_name == "Boolean":
+        return isinstance(value, bool)
+    return True
+
+
+def _graphql_federation_hint(
+    attack: AttackCase,
+    shape: GraphQLOutputShape | None = None,
+) -> str | None:
+    if not attack.graphql_federated:
+        return None
+    if shape is not None and shape.federation_hint:
+        return shape.federation_hint
+    if attack.graphql_entity_types:
+        entity_types = ", ".join(sorted(attack.graphql_entity_types))
+        return (
+            "Schema appears federated; mismatches may reflect entity resolution or "
+            f"subgraph field ownership for {entity_types}."
+        )
+    return (
+        "Schema appears federated; mismatches around abstract or nested object selections may "
+        "reflect subgraph composition or entity resolution issues."
+    )
+
+
+def _validate_graphql_output_value(
+    value: Any,
+    shape: GraphQLOutputShape,
+    *,
+    path: str,
+) -> str | None:
+    if value is None:
+        if shape.nullable:
+            return None
+        return f"{path}: expected non-null {shape.type_name}, got null"
+
+    if shape.kind == "scalar":
+        if _graphql_scalar_matches(shape.type_name, value):
+            return None
+        return f"{path}: expected {shape.type_name}, got {_describe_value_type(value)}"
+
+    if shape.kind == "enum":
+        if isinstance(value, str):
+            return None
+        return (
+            f"{path}: expected enum string for {shape.type_name}, "
+            f"got {_describe_value_type(value)}"
+        )
+
+    if shape.kind == "list":
+        if not isinstance(value, list):
+            return f"{path}: expected list, got {_describe_value_type(value)}"
+        if shape.item_shape is None:
+            return None
+        for index, item in enumerate(value):
+            mismatch = _validate_graphql_output_value(
+                item,
+                shape.item_shape,
+                path=f"{path}[{index}]",
+            )
+            if mismatch:
+                return mismatch
+        return None
+
+    if shape.kind == "object":
+        if not isinstance(value, dict):
+            return f"{path}: expected object, got {_describe_value_type(value)}"
+        for field_name, field_shape in shape.fields.items():
+            if field_name not in value:
+                return f"{path}: missing selected field '{field_name}'"
+            mismatch = _validate_graphql_output_value(
+                value[field_name],
+                field_shape,
+                path=f"{path}.{field_name}",
+            )
+            if mismatch:
+                return mismatch
+        return None
+
+    if shape.kind in {"interface", "union"}:
+        if not isinstance(value, dict):
+            return f"{path}: expected object, got {_describe_value_type(value)}"
+        typename = value.get("__typename")
+        if not isinstance(typename, str):
+            return f"{path}.__typename: expected string, got {_describe_value_type(typename)}"
+        runtime_shape = shape.possible_types.get(typename)
+        if runtime_shape is None:
+            return (
+                f"{path}.__typename: expected one of {sorted(shape.possible_types)!r}, got "
+                f"{typename!r}"
+            )
+        return _validate_graphql_output_value(value, runtime_shape, path=path)
+
+    return None
+
+
+def _validate_graphql_response_shape(
+    attack: AttackCase,
+    response: httpx.Response,
+) -> tuple[bool | None, str | None, str | None]:
+    if attack.protocol != "graphql":
+        return None, None, None
+    if attack.graphql_output_shape is None or attack.graphql_root_field_name is None:
+        return None, None, None
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        return (
+            False,
+            f"GraphQL response body is not valid JSON: {exc}",
+            _graphql_federation_hint(attack),
+        )
+
+    if not isinstance(payload, dict):
+        return (
+            False,
+            "GraphQL response must be a JSON object.",
+            _graphql_federation_hint(attack),
+        )
+
+    errors_present = "errors" in payload
+    if errors_present and not isinstance(payload["errors"], list):
+        return (
+            False,
+            "GraphQL response field 'errors' must be a list when present.",
+            _graphql_federation_hint(attack),
+        )
+
+    if "data" not in payload:
+        if errors_present:
+            return None, None, None
+        return (
+            False,
+            "GraphQL response did not include 'data' or 'errors'.",
+            _graphql_federation_hint(attack),
+        )
+
+    data = payload["data"]
+    if data is None:
+        if errors_present:
+            return None, None, None
+        return (
+            False,
+            "GraphQL response included null 'data' without errors.",
+            _graphql_federation_hint(attack),
+        )
+    if not isinstance(data, dict):
+        return (
+            False,
+            f"$.data: expected object, got {_describe_value_type(data)}",
+            _graphql_federation_hint(attack),
+        )
+
+    root_field_name = attack.graphql_root_field_name
+    if root_field_name not in data:
+        return (
+            False,
+            f"$.data: missing selected field '{root_field_name}'",
+            _graphql_federation_hint(attack, attack.graphql_output_shape),
+        )
+
+    mismatch = _validate_graphql_output_value(
+        data[root_field_name],
+        attack.graphql_output_shape,
+        path=f"$.data.{root_field_name}",
+    )
+    if mismatch:
+        return False, mismatch, _graphql_federation_hint(attack, attack.graphql_output_shape)
+    return True, None, None
 
 
 def evaluate_result(
@@ -759,16 +940,28 @@ def _request_result(
     response_schema_status: str | None = None
     response_schema_valid: bool | None = None
     response_schema_error: str | None = None
+    graphql_response_valid: bool | None = None
+    graphql_response_error: str | None = None
+    graphql_response_hint: str | None = None
     if execution.response is not None:
         (
             response_schema_status,
             response_schema_valid,
             response_schema_error,
         ) = _validate_response_schema(attack, execution.response)
+        (
+            graphql_response_valid,
+            graphql_response_error,
+            graphql_response_hint,
+        ) = _validate_graphql_response_shape(attack, execution.response)
     if response_schema_valid is False:
         flagged = True
         if issue in {None, "unexpected_success"}:
             issue = "response_schema_mismatch"
+    if graphql_response_valid is False:
+        flagged = True
+        if issue in {None, "unexpected_success"}:
+            issue = "graphql_response_shape_mismatch"
     severity, confidence = score_result(flagged=flagged, issue=issue)
 
     return AttackResult(
@@ -777,6 +970,7 @@ def _request_result(
         operation_id=attack.operation_id,
         kind=attack.kind,
         name=attack.name,
+        protocol=attack.protocol,
         method=attack.method,
         path=attack.path,
         tags=list(attack.tags),
@@ -794,6 +988,9 @@ def _request_result(
         response_schema_status=response_schema_status,
         response_schema_valid=response_schema_valid,
         response_schema_error=response_schema_error,
+        graphql_response_valid=graphql_response_valid,
+        graphql_response_error=graphql_response_error,
+        graphql_response_hint=graphql_response_hint,
         workflow_steps=workflow_steps,
     )
 
@@ -852,6 +1049,7 @@ def _workflow_failure_result(
         operation_id=workflow.operation_id,
         kind=workflow.kind,
         name=workflow.name,
+        protocol=workflow.protocol,
         method=workflow.method,
         path=workflow.path,
         tags=list(workflow.tags),
@@ -883,6 +1081,7 @@ def _attack_result_sort_key(result: AttackResult) -> tuple[int, int, str, str]:
 
 def _profile_attack_result(profile: AuthProfile, result: AttackResult) -> ProfileAttackResult:
     return ProfileAttackResult(
+        protocol=result.protocol,
         profile=profile.name,
         level=profile.level,
         anonymous=profile.anonymous,
@@ -898,6 +1097,9 @@ def _profile_attack_result(profile: AuthProfile, result: AttackResult) -> Profil
         response_schema_status=result.response_schema_status,
         response_schema_valid=result.response_schema_valid,
         response_schema_error=result.response_schema_error,
+        graphql_response_valid=result.graphql_response_valid,
+        graphql_response_error=result.graphql_response_error,
+        graphql_response_hint=result.graphql_response_hint,
         workflow_steps=result.workflow_steps,
     )
 

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -215,8 +215,7 @@ def _validate_graphql_output_value(
         if isinstance(value, str):
             return None
         return (
-            f"{path}: expected enum string for {shape.type_name}, "
-            f"got {_describe_value_type(value)}"
+            f"{path}: expected enum string for {shape.type_name}, got {_describe_value_type(value)}"
         )
 
     if shape.kind == "list":

--- a/src/knives_out/services.py
+++ b/src/knives_out/services.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from pydantic import ValidationError
+
+from knives_out.attack_packs import load_attack_packs
+from knives_out.auth_config import (
+    BuiltInAuthConfig,
+    auth_config_map,
+    auth_profiles_from_configs,
+    load_auth_configs,
+    select_auth_configs,
+)
+from knives_out.auth_plugins import LoadedAuthPlugin, load_auth_plugins
+from knives_out.filtering import filter_attack_suite, filter_operations
+from knives_out.generator import generate_attack_suite
+from knives_out.learned_discovery import discover_learned_model
+from knives_out.models import (
+    AttackResults,
+    AttackSuite,
+    AuthProfile,
+    LearnedModel,
+    LoadedOperations,
+    OperationSpec,
+    ResultsSummary,
+)
+from knives_out.profiles import (
+    load_auth_profiles,
+    resolve_auth_profile_modules,
+    select_auth_profiles,
+)
+from knives_out.promotion import PromotionError, PromotionResult, promote_attack_suite
+from knives_out.reporting import (
+    load_attack_results,
+    render_html_report,
+    render_markdown_report,
+    summarize_results,
+)
+from knives_out.runner import execute_attack_suite, execute_attack_suite_profiles, load_attack_suite
+from knives_out.spec_loader import load_operations_with_warnings
+from knives_out.suppressions import (
+    DEFAULT_SUPPRESSIONS_PATH,
+    SuppressionRule,
+    SuppressionsFile,
+    load_suppressions,
+    merge_suppressions,
+    triage_rule_for_result,
+    write_suppressions,
+)
+from knives_out.verification import ResultComparison, VerificationResult, compare_attack_results
+from knives_out.verification import evaluate_verification as evaluate_results_verification
+from knives_out.workflow_packs import load_workflow_packs
+
+
+@dataclass(frozen=True)
+class InlineInput:
+    name: str
+    content: str
+
+
+@dataclass(frozen=True)
+class InspectServiceResult:
+    loaded: LoadedOperations
+    operations: list[OperationSpec]
+
+
+@dataclass(frozen=True)
+class GenerateServiceResult:
+    loaded: LoadedOperations
+    suite: AttackSuite
+
+
+@dataclass(frozen=True)
+class RunServiceResult:
+    suite: AttackSuite
+    results: AttackResults
+
+
+@dataclass(frozen=True)
+class ReportServiceResult:
+    rendered: str
+    suppressions_path: Path | None
+    suppressions: list[SuppressionRule]
+
+
+@dataclass(frozen=True)
+class VerifyServiceResult:
+    verification: VerificationResult
+    suppressions_path: Path | None
+    suppressions: list[SuppressionRule]
+
+
+@dataclass(frozen=True)
+class SummaryServiceResult:
+    summary: ResultsSummary
+    suppressions_path: Path | None
+    suppressions: list[SuppressionRule]
+
+
+@dataclass(frozen=True)
+class PromoteServiceResult:
+    promotion: PromotionResult
+    suppressions_path: Path | None
+    suppressions: list[SuppressionRule]
+
+
+@dataclass(frozen=True)
+class TriageServiceResult:
+    comparison: ResultComparison
+    suppressions_file: SuppressionsFile
+    added_count: int
+
+
+def parse_key_value_map(items: list[str] | None, *, separator: str) -> dict[str, Any]:
+    parsed: dict[str, Any] = {}
+    for item in items or []:
+        if separator not in item:
+            raise ValueError(f"Expected '{separator}' in value: {item!r}")
+        key, value = item.split(separator, 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"Missing key in value: {item!r}")
+        parsed[key] = value
+    return parsed
+
+
+def load_attack_results_or_raise(path: Path, *, label: str) -> AttackResults:
+    try:
+        return load_attack_results(path)
+    except (OSError, ValidationError, ValueError) as exc:
+        raise ValueError(f"Could not read {label} results file '{path}': {exc}") from exc
+
+
+def load_attack_suite_or_raise(path: Path) -> AttackSuite:
+    try:
+        return load_attack_suite(path)
+    except (OSError, ValidationError, ValueError) as exc:
+        raise ValueError(f"Could not read attacks file '{path}': {exc}") from exc
+
+
+def load_suppressions_or_default(
+    path: Path | None,
+) -> tuple[Path | None, list[SuppressionRule]]:
+    resolved_path = path
+    if resolved_path is None and DEFAULT_SUPPRESSIONS_PATH.exists():
+        resolved_path = DEFAULT_SUPPRESSIONS_PATH
+    if resolved_path is None:
+        return None, []
+
+    try:
+        suppressions_file = load_suppressions(resolved_path)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Could not read suppressions file '{resolved_path}': {exc}") from exc
+    return resolved_path, suppressions_file.suppressions
+
+
+def _inline_path(stack: ExitStack, inline_input: InlineInput) -> Path:
+    temp_dir = Path(stack.enter_context(TemporaryDirectory()))
+    path = temp_dir / Path(inline_input.name).name
+    path.write_text(inline_input.content, encoding="utf-8")
+    return path
+
+
+def _load_operations_from_inline(
+    source: InlineInput,
+    *,
+    graphql_endpoint: str,
+) -> LoadedOperations:
+    with ExitStack() as stack:
+        path = _inline_path(stack, source)
+        return load_operations_with_warnings(path, graphql_endpoint=graphql_endpoint)
+
+
+def _load_suppressions_from_text(text: str | None) -> list[SuppressionRule]:
+    if text is None:
+        return []
+    with ExitStack() as stack:
+        path = _inline_path(stack, InlineInput(name=".knives-out-ignore.yml", content=text))
+        return load_suppressions(path).suppressions
+
+
+def _load_auth_profiles_from_path(
+    path: Path | None,
+    *,
+    include_names: list[str] | None = None,
+) -> list[AuthProfile]:
+    if path is None:
+        if include_names:
+            raise ValueError("--profile requires --profile-file.")
+        return []
+
+    try:
+        profiles_file = load_auth_profiles(path)
+        selected_profiles = select_auth_profiles(profiles_file, include_names=include_names)
+        return resolve_auth_profile_modules(selected_profiles, relative_to=path)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Could not read auth profile file '{path}': {exc}") from exc
+
+
+def _load_auth_profiles_from_text(
+    text: str | None,
+    *,
+    include_names: list[str] | None = None,
+) -> list[AuthProfile]:
+    if text is None:
+        if include_names:
+            raise ValueError("profile_names require profile_file_yaml.")
+        return []
+    with ExitStack() as stack:
+        path = _inline_path(stack, InlineInput(name="profiles.yml", content=text))
+        profiles = _load_auth_profiles_from_path(path, include_names=include_names)
+    for profile in profiles:
+        if profile.auth_plugin_modules:
+            raise ValueError(
+                "Inline profile YAML cannot use auth_plugin_modules; use auth_plugin names instead."
+            )
+    return profiles
+
+
+def _load_auth_configs_from_path(
+    path: Path | None,
+    *,
+    include_names: list[str] | None = None,
+) -> list[BuiltInAuthConfig]:
+    if path is None:
+        if include_names:
+            raise ValueError("--auth-profile requires --auth-config.")
+        return []
+
+    try:
+        auth_file = load_auth_configs(path)
+        selected_configs = select_auth_configs(auth_file, include_names=include_names)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Could not read auth config file '{path}': {exc}") from exc
+
+    if not selected_configs:
+        raise ValueError(f"Auth config file '{path}' did not define any auth entries.")
+    return selected_configs
+
+
+def _load_auth_configs_from_text(
+    text: str | None,
+    *,
+    include_names: list[str] | None = None,
+) -> list[BuiltInAuthConfig]:
+    if text is None:
+        if include_names:
+            raise ValueError("auth_profile_names require auth_config_yaml.")
+        return []
+    with ExitStack() as stack:
+        path = _inline_path(stack, InlineInput(name="auth-config.yml", content=text))
+        return _load_auth_configs_from_path(path, include_names=include_names)
+
+
+def inspect_source_path(
+    spec: Path,
+    *,
+    graphql_endpoint: str = "/graphql",
+    tag: list[str] | None = None,
+    exclude_tag: list[str] | None = None,
+    path: list[str] | None = None,
+    exclude_path: list[str] | None = None,
+) -> InspectServiceResult:
+    loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
+    operations = filter_operations(
+        loaded.operations,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
+    )
+    return InspectServiceResult(loaded=loaded, operations=operations)
+
+
+def inspect_source_inline(
+    source: InlineInput,
+    *,
+    graphql_endpoint: str = "/graphql",
+    tag: list[str] | None = None,
+    exclude_tag: list[str] | None = None,
+    path: list[str] | None = None,
+    exclude_path: list[str] | None = None,
+) -> InspectServiceResult:
+    loaded = _load_operations_from_inline(source, graphql_endpoint=graphql_endpoint)
+    operations = filter_operations(
+        loaded.operations,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
+    )
+    return InspectServiceResult(loaded=loaded, operations=operations)
+
+
+def discover_model_paths(inputs: list[Path]) -> LearnedModel:
+    return discover_learned_model(inputs)
+
+
+def discover_model_inline(inputs: list[InlineInput]) -> LearnedModel:
+    with ExitStack() as stack:
+        paths = [_inline_path(stack, current) for current in inputs]
+        return discover_learned_model(paths)
+
+
+def generate_suite_from_path(
+    spec: Path,
+    *,
+    graphql_endpoint: str = "/graphql",
+    operation: list[str] | None = None,
+    exclude_operation: list[str] | None = None,
+    method: list[str] | None = None,
+    exclude_method: list[str] | None = None,
+    kind: list[str] | None = None,
+    exclude_kind: list[str] | None = None,
+    tag: list[str] | None = None,
+    exclude_tag: list[str] | None = None,
+    path: list[str] | None = None,
+    exclude_path: list[str] | None = None,
+    pack_names: list[str] | None = None,
+    pack_module_paths: list[Path] | None = None,
+    auto_workflows: bool = False,
+    workflow_pack_names: list[str] | None = None,
+    workflow_pack_module_paths: list[Path] | None = None,
+) -> GenerateServiceResult:
+    loaded = load_operations_with_warnings(spec, graphql_endpoint=graphql_endpoint)
+    attack_packs = load_attack_packs(
+        entry_point_names=pack_names,
+        module_paths=pack_module_paths,
+    )
+    workflow_packs = load_workflow_packs(
+        entry_point_names=workflow_pack_names,
+        module_paths=workflow_pack_module_paths,
+    )
+    suite = generate_attack_suite(
+        loaded.operations,
+        source=str(spec),
+        extra_packs=attack_packs,
+        auto_workflows=auto_workflows,
+        workflow_packs=workflow_packs,
+        learned_model=loaded.learned_model,
+    )
+    suite = filter_attack_suite(
+        suite,
+        include_operations=operation,
+        exclude_operations=exclude_operation,
+        include_methods=method,
+        exclude_methods=exclude_method,
+        include_kinds=kind,
+        exclude_kinds=exclude_kind,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
+    )
+    return GenerateServiceResult(loaded=loaded, suite=suite)
+
+
+def generate_suite_from_inline(
+    source: InlineInput,
+    *,
+    graphql_endpoint: str = "/graphql",
+    operation: list[str] | None = None,
+    exclude_operation: list[str] | None = None,
+    method: list[str] | None = None,
+    exclude_method: list[str] | None = None,
+    kind: list[str] | None = None,
+    exclude_kind: list[str] | None = None,
+    tag: list[str] | None = None,
+    exclude_tag: list[str] | None = None,
+    path: list[str] | None = None,
+    exclude_path: list[str] | None = None,
+    pack_names: list[str] | None = None,
+    auto_workflows: bool = False,
+    workflow_pack_names: list[str] | None = None,
+) -> GenerateServiceResult:
+    with ExitStack() as stack:
+        path_input = _inline_path(stack, source)
+        return generate_suite_from_path(
+            path_input,
+            graphql_endpoint=graphql_endpoint,
+            operation=operation,
+            exclude_operation=exclude_operation,
+            method=method,
+            exclude_method=exclude_method,
+            kind=kind,
+            exclude_kind=exclude_kind,
+            tag=tag,
+            exclude_tag=exclude_tag,
+            path=path,
+            exclude_path=exclude_path,
+            pack_names=pack_names,
+            auto_workflows=auto_workflows,
+            workflow_pack_names=workflow_pack_names,
+        )
+
+
+def run_suite(
+    suite: AttackSuite,
+    *,
+    base_url: str,
+    default_headers: dict[str, str] | None = None,
+    default_query: dict[str, Any] | None = None,
+    timeout_seconds: float = 10.0,
+    artifact_dir: Path | None = None,
+    auth_plugin_names: list[str] | None = None,
+    auth_plugin_module_paths: list[Path] | None = None,
+    auth_config_path: Path | None = None,
+    auth_profile_names: list[str] | None = None,
+    profile_file_path: Path | None = None,
+    profile_names: list[str] | None = None,
+    operation: list[str] | None = None,
+    exclude_operation: list[str] | None = None,
+    method: list[str] | None = None,
+    exclude_method: list[str] | None = None,
+    kind: list[str] | None = None,
+    exclude_kind: list[str] | None = None,
+    tag: list[str] | None = None,
+    exclude_tag: list[str] | None = None,
+    path: list[str] | None = None,
+    exclude_path: list[str] | None = None,
+) -> RunServiceResult:
+    filtered_suite = filter_attack_suite(
+        suite,
+        include_operations=operation,
+        exclude_operations=exclude_operation,
+        include_methods=method,
+        exclude_methods=exclude_method,
+        include_kinds=kind,
+        exclude_kinds=exclude_kind,
+        include_paths=path,
+        exclude_paths=exclude_path,
+        include_tags=tag,
+        exclude_tags=exclude_tag,
+    )
+    default_headers = dict(default_headers or {})
+    default_query = dict(default_query or {})
+    auth_profiles = _load_auth_profiles_from_path(profile_file_path, include_names=profile_names)
+    built_in_auth_configs = _load_auth_configs_from_path(
+        auth_config_path,
+        include_names=auth_profile_names,
+    )
+    built_in_auth_by_name = auth_config_map(built_in_auth_configs)
+    global_auth_plugin_modules = [
+        str(current.resolve()) for current in auth_plugin_module_paths or []
+    ]
+
+    if auth_profiles or built_in_auth_configs:
+        if not auth_profiles:
+            auth_profiles = auth_profiles_from_configs(built_in_auth_configs)
+        auth_profiles = [
+            auth_profile.model_copy(
+                update={
+                    "auth_plugins": [*(auth_plugin_names or []), *auth_profile.auth_plugins],
+                    "auth_plugin_modules": [
+                        *global_auth_plugin_modules,
+                        *auth_profile.auth_plugin_modules,
+                    ],
+                }
+            )
+            for auth_profile in auth_profiles
+        ]
+        auth_plugins: list[LoadedAuthPlugin] | None = None
+    else:
+        auth_plugins = load_auth_plugins(
+            entry_point_names=auth_plugin_names,
+            module_paths=auth_plugin_module_paths,
+        )
+
+    if auth_profiles:
+        results = execute_attack_suite_profiles(
+            filtered_suite,
+            base_url=base_url,
+            profiles=auth_profiles,
+            default_headers=default_headers,
+            default_query=default_query,
+            timeout_seconds=timeout_seconds,
+            artifact_dir=artifact_dir,
+            built_in_auth_configs=built_in_auth_by_name,
+        )
+    else:
+        results = execute_attack_suite(
+            filtered_suite,
+            base_url=base_url,
+            default_headers=default_headers,
+            default_query=default_query,
+            timeout_seconds=timeout_seconds,
+            artifact_dir=artifact_dir,
+            auth_plugins=auth_plugins,
+            built_in_auth_configs=built_in_auth_configs,
+        )
+    return RunServiceResult(suite=filtered_suite, results=results)
+
+
+def run_suite_from_inline(
+    suite: AttackSuite,
+    *,
+    base_url: str,
+    default_headers: dict[str, str] | None = None,
+    default_query: dict[str, Any] | None = None,
+    timeout_seconds: float = 10.0,
+    artifact_dir: Path | None = None,
+    auth_plugin_names: list[str] | None = None,
+    auth_config_yaml: str | None = None,
+    auth_profile_names: list[str] | None = None,
+    profile_file_yaml: str | None = None,
+    profile_names: list[str] | None = None,
+    operation: list[str] | None = None,
+    exclude_operation: list[str] | None = None,
+    method: list[str] | None = None,
+    exclude_method: list[str] | None = None,
+    kind: list[str] | None = None,
+    exclude_kind: list[str] | None = None,
+    tag: list[str] | None = None,
+    exclude_tag: list[str] | None = None,
+    path: list[str] | None = None,
+    exclude_path: list[str] | None = None,
+) -> RunServiceResult:
+    with ExitStack() as stack:
+        auth_config_path = (
+            _inline_path(stack, InlineInput(name="auth-config.yml", content=auth_config_yaml))
+            if auth_config_yaml is not None
+            else None
+        )
+        profile_file_path = (
+            _inline_path(stack, InlineInput(name="profiles.yml", content=profile_file_yaml))
+            if profile_file_yaml is not None
+            else None
+        )
+        return run_suite(
+            suite,
+            base_url=base_url,
+            default_headers=default_headers,
+            default_query=default_query,
+            timeout_seconds=timeout_seconds,
+            artifact_dir=artifact_dir,
+            auth_plugin_names=auth_plugin_names,
+            auth_config_path=auth_config_path,
+            auth_profile_names=auth_profile_names,
+            profile_file_path=profile_file_path,
+            profile_names=profile_names,
+            operation=operation,
+            exclude_operation=exclude_operation,
+            method=method,
+            exclude_method=exclude_method,
+            kind=kind,
+            exclude_kind=exclude_kind,
+            tag=tag,
+            exclude_tag=exclude_tag,
+            path=path,
+            exclude_path=exclude_path,
+        )
+
+
+def render_report(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    format: str = "markdown",
+    artifact_root: Path | None = None,
+) -> str:
+    if format == "html":
+        return render_html_report(
+            results,
+            baseline=baseline,
+            suppressions=suppressions,
+            artifact_root=artifact_root,
+        )
+    return render_markdown_report(results, baseline=baseline, suppressions=suppressions)
+
+
+def render_report_from_paths(
+    results_path: Path,
+    *,
+    baseline_path: Path | None = None,
+    suppressions_path: Path | None = None,
+    format: str = "markdown",
+    artifact_root: Path | None = None,
+) -> ReportServiceResult:
+    attack_results = load_attack_results_or_raise(results_path, label="current")
+    baseline_results = (
+        load_attack_results_or_raise(baseline_path, label="baseline")
+        if baseline_path is not None
+        else None
+    )
+    resolved_suppressions_path, suppression_rules = load_suppressions_or_default(suppressions_path)
+    rendered = render_report(
+        attack_results,
+        baseline=baseline_results,
+        suppressions=suppression_rules,
+        format=format,
+        artifact_root=artifact_root,
+    )
+    return ReportServiceResult(
+        rendered=rendered,
+        suppressions_path=resolved_suppressions_path,
+        suppressions=suppression_rules,
+    )
+
+
+def render_report_from_models(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions_yaml: str | None = None,
+    format: str = "markdown",
+    artifact_root: Path | None = None,
+) -> str:
+    suppression_rules = _load_suppressions_from_text(suppressions_yaml)
+    return render_report(
+        results,
+        baseline=baseline,
+        suppressions=suppression_rules,
+        format=format,
+        artifact_root=artifact_root,
+    )
+
+
+def summarize_report_results(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    top_limit: int = 10,
+) -> ResultsSummary:
+    return summarize_results(
+        results,
+        baseline=baseline,
+        suppressions=suppressions,
+        top_limit=top_limit,
+    )
+
+
+def summarize_results_from_paths(
+    results_path: Path,
+    *,
+    baseline_path: Path | None = None,
+    suppressions_path: Path | None = None,
+    top_limit: int = 10,
+) -> SummaryServiceResult:
+    attack_results = load_attack_results_or_raise(results_path, label="current")
+    baseline_results = (
+        load_attack_results_or_raise(baseline_path, label="baseline")
+        if baseline_path is not None
+        else None
+    )
+    resolved_suppressions_path, suppression_rules = load_suppressions_or_default(suppressions_path)
+    summary = summarize_report_results(
+        attack_results,
+        baseline=baseline_results,
+        suppressions=suppression_rules,
+        top_limit=top_limit,
+    )
+    return SummaryServiceResult(
+        summary=summary,
+        suppressions_path=resolved_suppressions_path,
+        suppressions=suppression_rules,
+    )
+
+
+def summarize_results_from_models(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions_yaml: str | None = None,
+    top_limit: int = 10,
+) -> ResultsSummary:
+    suppression_rules = _load_suppressions_from_text(suppressions_yaml)
+    return summarize_report_results(
+        results,
+        baseline=baseline,
+        suppressions=suppression_rules,
+        top_limit=top_limit,
+    )
+
+
+def verify_results(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    min_severity: str = "high",
+    min_confidence: str = "medium",
+) -> VerificationResult:
+    return evaluate_results_verification(
+        results,
+        baseline=baseline,
+        min_severity=min_severity,
+        min_confidence=min_confidence,
+        suppressions=suppressions,
+    )
+
+
+def verify_results_from_paths(
+    results_path: Path,
+    *,
+    baseline_path: Path | None = None,
+    suppressions_path: Path | None = None,
+    min_severity: str = "high",
+    min_confidence: str = "medium",
+) -> VerifyServiceResult:
+    attack_results = load_attack_results_or_raise(results_path, label="current")
+    baseline_results = (
+        load_attack_results_or_raise(baseline_path, label="baseline")
+        if baseline_path is not None
+        else None
+    )
+    resolved_suppressions_path, suppression_rules = load_suppressions_or_default(suppressions_path)
+    verification = verify_results(
+        attack_results,
+        baseline=baseline_results,
+        suppressions=suppression_rules,
+        min_severity=min_severity,
+        min_confidence=min_confidence,
+    )
+    return VerifyServiceResult(
+        verification=verification,
+        suppressions_path=resolved_suppressions_path,
+        suppressions=suppression_rules,
+    )
+
+
+def verify_results_from_models(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions_yaml: str | None = None,
+    min_severity: str = "high",
+    min_confidence: str = "medium",
+) -> VerificationResult:
+    return verify_results(
+        results,
+        baseline=baseline,
+        suppressions=_load_suppressions_from_text(suppressions_yaml),
+        min_severity=min_severity,
+        min_confidence=min_confidence,
+    )
+
+
+def promote_results(
+    current: AttackResults,
+    attacks: AttackSuite,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    min_severity: str = "high",
+    min_confidence: str = "medium",
+) -> PromotionResult:
+    try:
+        return promote_attack_suite(
+            current,
+            attacks,
+            baseline=baseline,
+            min_severity=min_severity,
+            min_confidence=min_confidence,
+            suppressions=suppressions,
+        )
+    except PromotionError:
+        raise
+
+
+def promote_results_from_paths(
+    results_path: Path,
+    attacks_path: Path,
+    *,
+    baseline_path: Path | None = None,
+    suppressions_path: Path | None = None,
+    min_severity: str = "high",
+    min_confidence: str = "medium",
+) -> PromoteServiceResult:
+    current_results = load_attack_results_or_raise(results_path, label="current")
+    baseline_results = (
+        load_attack_results_or_raise(baseline_path, label="baseline")
+        if baseline_path is not None
+        else None
+    )
+    attack_suite = load_attack_suite_or_raise(attacks_path)
+    resolved_suppressions_path, suppression_rules = load_suppressions_or_default(suppressions_path)
+    promotion = promote_results(
+        current_results,
+        attack_suite,
+        baseline=baseline_results,
+        suppressions=suppression_rules,
+        min_severity=min_severity,
+        min_confidence=min_confidence,
+    )
+    return PromoteServiceResult(
+        promotion=promotion,
+        suppressions_path=resolved_suppressions_path,
+        suppressions=suppression_rules,
+    )
+
+
+def promote_results_from_models(
+    current: AttackResults,
+    attacks: AttackSuite,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions_yaml: str | None = None,
+    min_severity: str = "high",
+    min_confidence: str = "medium",
+) -> PromotionResult:
+    return promote_results(
+        current,
+        attacks,
+        baseline=baseline,
+        suppressions=_load_suppressions_from_text(suppressions_yaml),
+        min_severity=min_severity,
+        min_confidence=min_confidence,
+    )
+
+
+def triage_results(
+    current_results: AttackResults,
+    *,
+    existing_rules: list[SuppressionRule],
+) -> TriageServiceResult:
+    comparison = compare_attack_results(current_results, suppressions=existing_rules)
+    generated_rules = [triage_rule_for_result(result) for result in comparison.current_findings]
+    merged_rules = merge_suppressions(existing_rules, generated_rules)
+    suppressions_file = SuppressionsFile(suppressions=merged_rules)
+    added_count = len(merged_rules) - len(existing_rules)
+    return TriageServiceResult(
+        comparison=comparison,
+        suppressions_file=suppressions_file,
+        added_count=added_count,
+    )
+
+
+def triage_results_from_path(
+    results_path: Path,
+    *,
+    out_path: Path,
+) -> TriageServiceResult:
+    current_results = load_attack_results_or_raise(results_path, label="current")
+    existing_file = SuppressionsFile()
+    if out_path.exists():
+        try:
+            existing_file = load_suppressions(out_path)
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"Could not read suppressions file '{out_path}': {exc}") from exc
+
+    triage = triage_results(current_results, existing_rules=existing_file.suppressions)
+    write_suppressions(out_path, triage.suppressions_file)
+    return triage
+
+
+def triage_results_from_model(
+    current_results: AttackResults,
+    *,
+    existing_suppressions_yaml: str | None = None,
+) -> tuple[SuppressionsFile, int]:
+    existing_rules = _load_suppressions_from_text(existing_suppressions_yaml)
+    triage = triage_results(current_results, existing_rules=existing_rules)
+    return triage.suppressions_file, triage.added_count

--- a/src/knives_out/verification.py
+++ b/src/knives_out/verification.py
@@ -63,10 +63,7 @@ class ComparedFinding:
         delta = self.delta
         if delta is None:
             return []
-        return [
-            f"{change.field} {change.baseline} -> {change.current}"
-            for change in delta.changes
-        ]
+        return [f"{change.field} {change.baseline} -> {change.current}" for change in delta.changes]
 
     @property
     def has_delta(self) -> bool:

--- a/src/knives_out/verification.py
+++ b/src/knives_out/verification.py
@@ -9,6 +9,7 @@ from knives_out.suppressions import SuppressedFinding, SuppressionRule
 SeverityThreshold = Literal["low", "medium", "high", "critical"]
 ConfidenceThreshold = Literal["low", "medium", "high"]
 FindingChange = Literal["new", "resolved", "persisting"]
+FindingDeltaFieldName = Literal["status", "severity", "confidence", "schema"]
 
 SEVERITY_ORDER = {
     "none": 0,
@@ -50,6 +51,28 @@ class ComparedFinding:
         if issue is None:
             raise ValueError("ComparedFinding requires a flagged result with an issue.")
         return issue
+
+    @property
+    def delta(self) -> FindingDelta | None:
+        if self.current is None or self.baseline is None:
+            return None
+        return finding_delta(self.current, self.baseline)
+
+
+@dataclass(frozen=True)
+class FindingDeltaChange:
+    field: FindingDeltaFieldName
+    baseline: str
+    current: str
+
+
+@dataclass(frozen=True)
+class FindingDelta:
+    changes: list[FindingDeltaChange]
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.changes)
 
 
 @dataclass(frozen=True)
@@ -96,6 +119,40 @@ def compared_finding_sort_key(finding: ComparedFinding) -> tuple[int, int, str, 
 
 def suppressed_finding_sort_key(finding: SuppressedFinding) -> tuple[int, int, str, str]:
     return attack_result_sort_key(finding.result)
+
+
+def _status_value(result: AttackResult) -> str:
+    return str(result.status_code) if result.status_code is not None else "-"
+
+
+def _schema_value(result: AttackResult) -> str:
+    if result.response_schema_valid is True:
+        return "ok"
+    if result.response_schema_valid is False:
+        return "mismatch"
+    if result.response_schema_status:
+        return result.response_schema_status
+    return "-"
+
+
+def finding_delta(current: AttackResult, baseline: AttackResult) -> FindingDelta:
+    changes: list[FindingDeltaChange] = []
+    values = [
+        ("status", _status_value(baseline), _status_value(current)),
+        ("severity", baseline.severity, current.severity),
+        ("confidence", baseline.confidence, current.confidence),
+        ("schema", _schema_value(baseline), _schema_value(current)),
+    ]
+    for field, baseline_value, current_value in values:
+        if baseline_value != current_value:
+            changes.append(
+                FindingDeltaChange(
+                    field=field,
+                    baseline=baseline_value,
+                    current=current_value,
+                )
+            )
+    return FindingDelta(changes=changes)
 
 
 def _matching_suppression(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import time
 from textwrap import dedent
 
@@ -7,6 +8,8 @@ import httpx
 from fastapi.testclient import TestClient
 
 from knives_out.api import create_app
+from knives_out.api_models import JobRecord
+from knives_out.api_store import JobStore
 from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite
 
 OPENAPI_SPEC = dedent(
@@ -205,6 +208,25 @@ def test_run_job_status_endpoints_404_for_missing_job(tmp_path) -> None:
 
     response = client.get("/v1/jobs/missing/artifacts")
     assert response.status_code == 404
+
+
+def test_job_store_retries_transient_empty_job_records(tmp_path) -> None:
+    store = JobStore(tmp_path)
+    record = JobRecord(base_url="https://example.com", attack_count=1)
+    store.job_dir(record.id).mkdir(parents=True, exist_ok=True)
+    store.record_path(record.id).write_text("", encoding="utf-8")
+
+    def _repair_record() -> None:
+        time.sleep(0.01)
+        store.update_job(record)
+
+    repair_thread = threading.Thread(target=_repair_record)
+    repair_thread.start()
+    loaded = store.load_job(record.id)
+    repair_thread.join()
+
+    assert loaded.id == record.id
+    assert loaded.base_url == "https://example.com"
 
 
 def test_report_verify_promote_and_triage_endpoints(tmp_path) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import time
+from textwrap import dedent
+
+import httpx
+from fastapi.testclient import TestClient
+
+from knives_out.api import create_app
+from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite
+
+OPENAPI_SPEC = dedent(
+    """
+    openapi: 3.0.3
+    info:
+      title: Demo API
+      version: "1.0"
+    paths:
+      /pets:
+        get:
+          operationId: listPets
+          parameters:
+            - in: query
+              name: limit
+              required: true
+              schema:
+                type: integer
+                minimum: 1
+          responses:
+            "200":
+              description: ok
+    """
+)
+
+GRAPHQL_SCHEMA = dedent(
+    """
+    type Query {
+      book(id: ID!): Book
+    }
+
+    type Mutation {
+      updateBook(id: ID!, title: String!): Book
+    }
+
+    type Book {
+      id: ID!
+      title: String!
+    }
+    """
+)
+
+
+class _StubClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+
+    def __enter__(self) -> _StubClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def request(self, *_: object, **__: object) -> httpx.Response:
+        return self._response
+
+
+def _install_stub_response(monkeypatch, response: httpx.Response) -> None:
+    monkeypatch.setattr(
+        "knives_out.runner.httpx.Client",
+        lambda **_: _StubClient(response),
+    )
+
+
+def _attack_suite() -> AttackSuite:
+    return AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_api",
+                name="Missing auth",
+                kind="missing_auth",
+                operation_id="getSecret",
+                method="GET",
+                path="/secrets",
+                description="Missing auth attack",
+            )
+        ],
+    )
+
+
+def _flagged_results() -> AttackResults:
+    return AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_api",
+                operation_id="getSecret",
+                kind="missing_auth",
+                name="Server failure",
+                method="GET",
+                path="/secrets",
+                url="https://example.com/secrets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ],
+    )
+
+
+def test_inspect_endpoint_supports_inline_graphql_schema(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.post(
+        "/v1/inspect",
+        json={
+            "source": {
+                "name": "library.graphql",
+                "content": GRAPHQL_SCHEMA,
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source_kind"] == "graphql"
+    assert {operation["operation_id"] for operation in payload["operations"]} == {
+        "book",
+        "updateBook",
+    }
+    assert payload["learned_workflow_count"] == 0
+
+
+def test_generate_endpoint_supports_inline_openapi_source(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.post(
+        "/v1/generate",
+        json={
+            "source": {
+                "name": "demo.yaml",
+                "content": OPENAPI_SPEC,
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source_kind"] == "openapi"
+    assert payload["suite"]["attacks"]
+    assert {attack["operation_id"] for attack in payload["suite"]["attacks"]} == {"listPets"}
+
+
+def test_run_job_lifecycle_and_artifacts(tmp_path, monkeypatch) -> None:
+    _install_stub_response(monkeypatch, httpx.Response(422, text="missing auth"))
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.post(
+        "/v1/runs",
+        json={
+            "suite": _attack_suite().model_dump(mode="json"),
+            "base_url": "https://example.com",
+            "store_artifacts": True,
+        },
+    )
+
+    assert response.status_code == 200
+    job_id = response.json()["id"]
+
+    status_payload = None
+    for _ in range(50):
+        status_response = client.get(f"/v1/jobs/{job_id}")
+        assert status_response.status_code == 200
+        status_payload = status_response.json()
+        if status_payload["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    assert status_payload is not None
+    assert status_payload["status"] == "completed"
+    assert status_payload["result_available"] is True
+    assert status_payload["artifact_names"] == ["atk_api.json"]
+
+    result_response = client.get(f"/v1/jobs/{job_id}/result")
+    assert result_response.status_code == 200
+    assert result_response.json()["results"][0]["attack_id"] == "atk_api"
+
+    artifact_list_response = client.get(f"/v1/jobs/{job_id}/artifacts")
+    assert artifact_list_response.status_code == 200
+    assert artifact_list_response.json()["artifacts"] == ["atk_api.json"]
+
+    artifact_response = client.get(f"/v1/jobs/{job_id}/artifacts/atk_api.json")
+    assert artifact_response.status_code == 200
+    assert artifact_response.json()["attack"]["id"] == "atk_api"
+
+
+def test_run_job_status_endpoints_404_for_missing_job(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.get("/v1/jobs/missing")
+    assert response.status_code == 404
+
+    response = client.get("/v1/jobs/missing/artifacts")
+    assert response.status_code == 404
+
+
+def test_report_verify_promote_and_triage_endpoints(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+    results = _flagged_results()
+    suite = _attack_suite()
+
+    summary_response = client.post(
+        "/v1/summary",
+        json={"results": results.model_dump(mode="json"), "top_limit": 5},
+    )
+    assert summary_response.status_code == 200
+    assert summary_response.json()["active_flagged_count"] == 1
+    assert summary_response.json()["top_findings"][0]["attack_id"] == "atk_api"
+
+    verify_response = client.post(
+        "/v1/verify",
+        json={"results": results.model_dump(mode="json")},
+    )
+    assert verify_response.status_code == 200
+    assert verify_response.json()["passed"] is False
+    assert verify_response.json()["current_findings_count"] == 1
+
+    report_response = client.post(
+        "/v1/report",
+        json={
+            "results": results.model_dump(mode="json"),
+            "format": "markdown",
+        },
+    )
+    assert report_response.status_code == 200
+    assert "Server failure" in report_response.json()["content"]
+
+    triage_response = client.post(
+        "/v1/triage",
+        json={"results": results.model_dump(mode="json")},
+    )
+    assert triage_response.status_code == 200
+    assert triage_response.json()["added_count"] == 1
+    assert triage_response.json()["suppressions"]["suppressions"][0]["attack_id"] == "atk_api"
+
+    promote_response = client.post(
+        "/v1/promote",
+        json={
+            "results": results.model_dump(mode="json"),
+            "attacks": suite.model_dump(mode="json"),
+        },
+    )
+    assert promote_response.status_code == 200
+    assert promote_response.json()["promoted_attack_ids"] == ["atk_api"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
+import json
 import re
 from pathlib import Path
 from textwrap import dedent
 
+from fastapi import FastAPI
 from typer.testing import CliRunner
 
 from knives_out.auth_plugins import PluginRuntimeError
@@ -48,7 +50,7 @@ def test_inspect_command_runs() -> None:
 
 def test_inspect_command_shows_preflight_warnings(monkeypatch) -> None:
     monkeypatch.setattr(
-        "knives_out.cli.load_operations_with_warnings",
+        "knives_out.services.load_operations_with_warnings",
         lambda spec, **_: LoadedOperations(
             operations=[],
             warnings=[
@@ -73,7 +75,7 @@ def test_inspect_command_shows_preflight_warnings(monkeypatch) -> None:
 
 def test_inspect_command_filters_operations_by_tag(monkeypatch) -> None:
     monkeypatch.setattr(
-        "knives_out.cli.load_operations_with_warnings",
+        "knives_out.services.load_operations_with_warnings",
         lambda spec, **_: LoadedOperations(
             operations=[
                 {
@@ -310,6 +312,80 @@ def test_report_command_shows_persisting_deltas(tmp_path: Path) -> None:
     assert "schema ok -> mismatch" in report
 
 
+def test_summary_command_writes_json_summary(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    summary_path = tmp_path / "summary.json"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_server",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "summary",
+            str(results_path),
+            "--out",
+            str(summary_path),
+            "--top",
+            "5",
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["active_flagged_count"] == 1
+    assert summary["issue_counts"]["server_error"] == 1
+    assert summary["top_findings"][0]["attack_id"] == "atk_server"
+
+
+def test_summary_command_prints_json_to_stdout(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_graphql",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="GraphQL mismatch",
+                protocol="graphql",
+                method="POST",
+                path="/graphql",
+                url="https://example.com/graphql",
+                status_code=200,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="medium",
+                confidence="high",
+                graphql_response_valid=False,
+            )
+        ),
+    )
+
+    result = runner.invoke(app, ["summary", str(results_path), "--top", "1"])
+
+    assert result.exit_code == 0
+    summary = json.loads(result.stdout)
+    assert summary["protocol_counts"]["graphql"] == 1
+    assert summary["graphql_shape_mismatches"] == 1
+    assert summary["top_findings"][0]["schema_status"] == "graphql-mismatch"
+
+
 def test_report_command_supports_html_and_artifact_links(tmp_path: Path) -> None:
     results_path = tmp_path / "results.json"
     report_path = tmp_path / "report.html"
@@ -455,7 +531,7 @@ def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
         captured["auth_plugins"] = auth_plugins
         return AttackResults(source=suite.source, base_url=base_url, results=[])
 
-    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+    monkeypatch.setattr("knives_out.services.execute_attack_suite", _fake_execute_attack_suite)
 
     result = runner.invoke(
         app,
@@ -618,7 +694,8 @@ def test_verify_command_shows_persisting_delta_summary(tmp_path: Path) -> None:
     assert "Persisting with deltas: 1" in normalized
     assert "Persisting findings with deltas" in result.stdout
     assert "status 403 -> 500" in normalized
-    assert "severity high -> critical" in normalized
+    assert "critical" in normalized
+    assert "confidence high ->" in normalized
 
 
 def test_verify_command_fails_with_baseline_when_new_qualifying_findings_appear(
@@ -653,7 +730,9 @@ def test_verify_command_fails_with_baseline_when_new_qualifying_findings_appear(
 
     assert result.exit_code == 1
     assert "New: 1" in result.stdout
-    assert "New server failure" in result.stdout
+    normalized = _normalized_output(result.stdout)
+    assert "New server" in normalized
+    assert "failure" in normalized
     assert "Verification failed." in result.stdout
 
 
@@ -1128,11 +1207,11 @@ def test_generate_command_filters_attacks(tmp_path: Path, monkeypatch) -> None:
     out_path = tmp_path / "attacks.json"
 
     monkeypatch.setattr(
-        "knives_out.cli.load_operations_with_warnings",
+        "knives_out.services.load_operations_with_warnings",
         lambda spec, **_: LoadedOperations(operations=[], warnings=[]),
     )
     monkeypatch.setattr(
-        "knives_out.cli.generate_attack_suite",
+        "knives_out.services.generate_attack_suite",
         lambda operations, source, **_: AttackSuite(
             source=source,
             attacks=[
@@ -1181,11 +1260,11 @@ def test_generate_command_filters_attacks_by_tag(tmp_path: Path, monkeypatch) ->
     out_path = tmp_path / "attacks.json"
 
     monkeypatch.setattr(
-        "knives_out.cli.load_operations_with_warnings",
+        "knives_out.services.load_operations_with_warnings",
         lambda spec, **_: LoadedOperations(operations=[], warnings=[]),
     )
     monkeypatch.setattr(
-        "knives_out.cli.generate_attack_suite",
+        "knives_out.services.generate_attack_suite",
         lambda operations, source, **_: AttackSuite(
             source=source,
             attacks=[
@@ -1234,7 +1313,7 @@ def test_generate_command_echoes_preflight_warnings(tmp_path: Path, monkeypatch)
     out_path = tmp_path / "attacks.json"
 
     monkeypatch.setattr(
-        "knives_out.cli.load_operations_with_warnings",
+        "knives_out.services.load_operations_with_warnings",
         lambda spec, **_: LoadedOperations(
             operations=[],
             warnings=[
@@ -1252,7 +1331,7 @@ def test_generate_command_echoes_preflight_warnings(tmp_path: Path, monkeypatch)
         ),
     )
     monkeypatch.setattr(
-        "knives_out.cli.generate_attack_suite",
+        "knives_out.services.generate_attack_suite",
         lambda operations, source, **_: AttackSuite(
             source=source,
             attacks=[],
@@ -1321,7 +1400,7 @@ def test_run_command_filters_attacks_before_execution(tmp_path: Path, monkeypatc
         captured["auth_plugins"] = auth_plugins
         return AttackResults(source=suite.source, base_url=base_url, results=[])
 
-    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+    monkeypatch.setattr("knives_out.services.execute_attack_suite", _fake_execute_attack_suite)
 
     result = runner.invoke(
         app,
@@ -1407,7 +1486,7 @@ def test_run_command_filters_attacks_by_path_before_execution(tmp_path: Path, mo
         captured["attack_ids"] = [attack.id for attack in suite.attacks]
         return AttackResults(source=suite.source, base_url="https://example.com", results=[])
 
-    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+    monkeypatch.setattr("knives_out.services.execute_attack_suite", _fake_execute_attack_suite)
 
     result = runner.invoke(
         app,
@@ -1482,7 +1561,7 @@ def test_run_command_loads_local_auth_plugin(tmp_path: Path, monkeypatch) -> Non
         captured["auth_plugin_names"] = [plugin.name for plugin in auth_plugins]
         return AttackResults(source=suite.source, base_url=base_url, results=[])
 
-    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+    monkeypatch.setattr("knives_out.services.execute_attack_suite", _fake_execute_attack_suite)
 
     result = runner.invoke(
         app,
@@ -1573,7 +1652,7 @@ def test_run_command_executes_selected_auth_profiles(tmp_path: Path, monkeypatch
         )
 
     monkeypatch.setattr(
-        "knives_out.cli.execute_attack_suite_profiles",
+        "knives_out.services.execute_attack_suite_profiles",
         _fake_execute_attack_suite_profiles,
     )
 
@@ -1652,7 +1731,7 @@ def test_run_command_combines_profile_file_with_built_in_auth_config(
         )
 
     monkeypatch.setattr(
-        "knives_out.cli.execute_attack_suite_profiles",
+        "knives_out.services.execute_attack_suite_profiles",
         _fake_execute_attack_suite_profiles,
     )
 
@@ -1724,7 +1803,7 @@ def test_run_command_supports_built_in_auth_config_profiles(tmp_path: Path, monk
         )
 
     monkeypatch.setattr(
-        "knives_out.cli.execute_attack_suite_profiles",
+        "knives_out.services.execute_attack_suite_profiles",
         _fake_execute_attack_suite_profiles,
     )
 
@@ -1833,7 +1912,7 @@ def test_run_command_reports_auth_plugin_runtime_error(tmp_path: Path, monkeypat
         )
         raise PluginRuntimeError("boom")
 
-    monkeypatch.setattr("knives_out.cli.execute_attack_suite", _fake_execute_attack_suite)
+    monkeypatch.setattr("knives_out.services.execute_attack_suite", _fake_execute_attack_suite)
 
     result = runner.invoke(
         app,
@@ -1970,3 +2049,30 @@ def test_generate_command_loads_local_workflow_pack(tmp_path: Path) -> None:
     assert result.exit_code == 0
     suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
     assert any(attack.type == "workflow" for attack in suite.attacks)
+
+
+def test_serve_command_starts_local_api(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(app_instance: object, *, host: str, port: int) -> None:
+        captured["app"] = app_instance
+        captured["host"] = host
+        captured["port"] = port
+
+    monkeypatch.setattr("knives_out.cli.uvicorn.run", _fake_run)
+
+    result = runner.invoke(
+        app,
+        [
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8787",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert isinstance(captured["app"], FastAPI)
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 8787

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,71 @@ def test_report_command_supports_baseline(tmp_path: Path) -> None:
     assert "## Persisting findings" in report
 
 
+def test_report_command_shows_persisting_deltas(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    report_path = tmp_path / "report.md"
+
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="high",
+                confidence="medium",
+                response_schema_valid=False,
+            )
+        ),
+    )
+    _write_results(
+        baseline_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+                response_schema_valid=True,
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            str(current_path),
+            "--baseline",
+            str(baseline_path),
+            "--out",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "## Persisting deltas" in report
+    assert "status 200 -> 500" in report
+    assert "severity medium -> high" in report
+    assert "confidence high -> medium" in report
+    assert "schema ok -> mismatch" in report
+
+
 def test_report_command_supports_html_and_artifact_links(tmp_path: Path) -> None:
     results_path = tmp_path / "results.json"
     report_path = tmp_path / "report.html"
@@ -290,6 +355,71 @@ def test_report_command_supports_html_and_artifact_links(tmp_path: Path) -> None
     assert "<!DOCTYPE html>" in report
     assert "<h2>Artifact index</h2>" in report
     assert "atk_html.json" in report
+
+
+def test_report_command_supports_html_persisting_deltas(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    report_path = tmp_path / "report.html"
+
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="high",
+                confidence="medium",
+                response_schema_valid=False,
+            )
+        ),
+    )
+    _write_results(
+        baseline_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="Persisting mismatch",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+                response_schema_valid=True,
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            str(current_path),
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "html",
+            "--out",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "<h2>Persisting deltas</h2>" in report
+    assert "Persisting with deltas" in report
+    assert "status 200 -&gt; 500" in report
 
 
 def test_run_command_passes_artifact_dir(tmp_path: Path, monkeypatch) -> None:
@@ -434,6 +564,61 @@ def test_verify_command_passes_with_baseline_when_findings_only_persist(tmp_path
     normalized = _normalized_output(result.stdout)
     assert "Persisting: 1" in normalized
     assert "Verification passed." in normalized
+
+
+def test_verify_command_shows_persisting_delta_summary(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Shared failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="critical",
+                confidence="medium",
+                response_schema_valid=False,
+            )
+        ),
+    )
+    _write_results(
+        baseline_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Shared failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=403,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+                response_schema_valid=True,
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["verify", str(current_path), "--baseline", str(baseline_path)],
+    )
+
+    assert result.exit_code == 0
+    normalized = _normalized_output(result.stdout)
+    assert "Persisting with deltas: 1" in normalized
+    assert "Persisting findings with deltas" in result.stdout
+    assert "status 403 -> 500" in normalized
+    assert "severity high -> critical" in normalized
 
 
 def test_verify_command_fails_with_baseline_when_new_qualifying_findings_appear(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -27,7 +27,16 @@ def test_readme_includes_ci_guidance() -> None:
     assert "status, severity, confidence, or schema outcome drifted" in readme
     assert "knives-out promote results.json" in readme
     assert "knives-out triage results.json" in readme
+    assert "knives-out summary results.json --out summary.json" in readme
+    assert "summary.json" in readme
     assert ".knives-out-ignore.yml" in readme
+    assert "## Local API" in readme
+    assert "knives-out serve --host 127.0.0.1 --port 8787" in readme
+    assert "KNIVES_OUT_API_DATA_DIR" in readme
+    assert "POST /v1/inspect" in readme
+    assert "POST /v1/summary" in readme
+    assert "POST /v1/runs" in readme
+    assert "GET /v1/jobs/{id}/artifacts" in readme
     assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in readme
     assert "anonymous_access" in readme
     assert "--auto-workflows" in readme
@@ -117,6 +126,13 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "--baseline previous-results.json" in ci_doc
     assert "status, severity, confidence, or schema outcome changed" in ci_doc
     assert "Persisting deltas" in ci_doc
+    assert "Optional: local HTTP API" in ci_doc
+    assert "knives-out serve --host 127.0.0.1 --port 8787" in ci_doc
+    assert "POST /v1/inspect" in ci_doc
+    assert "POST /v1/summary" in ci_doc
+    assert "POST /v1/runs" in ci_doc
+    assert "KNIVES_OUT_API_DATA_DIR" in ci_doc
+    assert "knives-out summary results.json --out summary.json" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
     assert "--tag orders" in ci_doc
     assert "--path /draft-orders/{draftId}" in ci_doc
@@ -179,14 +195,16 @@ def test_roadmap_and_architecture_describe_next_milestones() -> None:
     assert "client_credentials" in roadmap
     assert "v0.10: Shadow Twin learned-model capture and discovery" in roadmap
     assert "learned-model artifacts" in roadmap
-    assert "## v0.11 — deeper GraphQL coverage" in roadmap
-    assert "subscription coverage" in roadmap
     assert "LLM application and tool-misuse testing" in roadmap
 
     assert "capture.py" in architecture
+    assert "api.py" in architecture
+    assert "api_models.py" in architecture
+    assert "api_store.py" in architecture
     assert "learned_discovery.py" in architecture
     assert "learned_loader.py" in architecture
     assert "graphql_loader.py" in architecture
+    assert "services.py" in architecture
     assert "spec_loader.py" in architecture
     assert "auth_config.py" in architecture
     assert "builtin_auth.py" in architecture
@@ -197,4 +215,13 @@ def test_roadmap_and_architecture_describe_next_milestones() -> None:
     assert "built-in auth acquisition/refresh" in architecture
     assert "Shadow Twin inference around state machines" in architecture
     assert "GraphQL response-shape validation, federation awareness" in architecture
+    assert "CLI and the HTTP API now sit on top of `services.py`" in architecture
+    assert "FastAPI surface" in architecture
     assert "redirect-driven OAuth auth-code flows" in architecture
+
+    assert "v0.11: deeper GraphQL coverage" in roadmap
+    assert "response-shape validation, federation-aware diagnostics" in roadmap
+    assert "## v0.12 — local-first HTTP API" in roadmap
+    assert "FastAPI server that mirrors the current CLI surface" in roadmap
+    assert "background run jobs with polling and artifact retrieval" in roadmap
+    assert "## v0.13 — richer CI and triage ergonomics" in roadmap

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -24,6 +24,7 @@ def test_readme_includes_ci_guidance() -> None:
     assert "KNIVES_OUT_BASE_URL" in readme
     assert "`knives-out run` currently exits with status `0`" in readme
     assert "knives-out verify results.json" in readme
+    assert "status, severity, confidence, or schema outcome drifted" in readme
     assert "knives-out promote results.json" in readme
     assert "knives-out triage results.json" in readme
     assert ".knives-out-ignore.yml" in readme
@@ -114,6 +115,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "knives-out triage results.json --out .knives-out-ignore.yml" in ci_doc
     assert ".knives-out-ignore.yml" in ci_doc
     assert "--baseline previous-results.json" in ci_doc
+    assert "status, severity, confidence, or schema outcome changed" in ci_doc
+    assert "Persisting deltas" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
     assert "--tag orders" in ci_doc
     assert "--path /draft-orders/{draftId}" in ci_doc

--- a/tests/test_graphql_generator.py
+++ b/tests/test_graphql_generator.py
@@ -29,6 +29,10 @@ def test_generate_graphql_attack_suite_emits_variable_mutations() -> None:
         attack for attack in create_book_attacks if attack.kind == "wrong_type_variable"
     )
     assert wrong_type_attack.path == "/graphql"
+    assert wrong_type_attack.protocol == "graphql"
     assert wrong_type_attack.expected_outcomes == ["graphql_error", "4xx"]
     assert wrong_type_attack.body_json["query"].startswith("mutation CreateBook")
+    assert wrong_type_attack.graphql_root_field_name == "createBook"
+    assert wrong_type_attack.graphql_output_shape is not None
+    assert "__typename" in wrong_type_attack.graphql_output_shape.fields
     assert "variables" in wrong_type_attack.body_json

--- a/tests/test_graphql_loader.py
+++ b/tests/test_graphql_loader.py
@@ -13,16 +13,21 @@ from knives_out.spec_loader import is_graphql_schema_path, load_operations_with_
 def _graphql_schema_text() -> str:
     return dedent(
         """
+        interface Node {
+          id: ID!
+        }
+
         type Query {
           book(id: ID!): Book
           books(limit: Int, genre: Genre): [Book!]!
+          node(id: ID!): Node
         }
 
         type Mutation {
           createBook(input: CreateBookInput!): Book!
         }
 
-        type Book {
+        type Book implements Node {
           id: ID!
           title: String!
           genre: Genre!
@@ -51,6 +56,7 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
     assert [operation.operation_id for operation in operations] == [
         "book",
         "books",
+        "node",
         "createBook",
     ]
 
@@ -60,7 +66,14 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
     assert book.method == "POST"
     assert book.path == "/api/graphql"
     assert book.tags == ["graphql", "query"]
-    assert book.graphql_document == "query Book($id: ID!) { book(id: $id) { __typename } }"
+    assert (
+        book.graphql_document
+        == "query Book($id: ID!) { book(id: $id) { __typename id title genre } }"
+    )
+    assert book.graphql_root_field_name == "book"
+    assert book.graphql_output_shape is not None
+    assert book.graphql_output_shape.kind == "object"
+    assert sorted(book.graphql_output_shape.fields) == ["__typename", "genre", "id", "title"]
     assert book.graphql_variables_schema == {
         "type": "object",
         "properties": {"id": {"type": "string"}},
@@ -84,6 +97,13 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
         },
         "required": ["input"],
     }
+    assert create_book.graphql_output_shape is not None
+    assert create_book.graphql_output_shape.fields["title"].type_name == "String"
+
+    node = next(operation for operation in operations if operation.operation_id == "node")
+    assert node.graphql_output_shape is not None
+    assert node.graphql_output_shape.kind == "interface"
+    assert "Book" in node.graphql_output_shape.possible_types
 
 
 def test_spec_loader_detects_graphql_introspection_json(tmp_path) -> None:
@@ -101,5 +121,36 @@ def test_spec_loader_detects_graphql_introspection_json(tmp_path) -> None:
     assert {operation.operation_id for operation in loaded.operations} == {
         "book",
         "books",
+        "node",
         "createBook",
     }
+
+
+def test_load_graphql_operations_detects_federation_hints(tmp_path) -> None:
+    schema_path = tmp_path / "federated.graphql"
+    schema_path.write_text(
+        dedent(
+            """
+            directive @key(fields: String!) repeatable on OBJECT | INTERFACE
+
+            type Query {
+              _service: String
+              book(id: ID!): Book
+            }
+
+            type Book @key(fields: "id") {
+              id: ID!
+              title: String!
+            }
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    operations = load_graphql_operations(schema_path)
+    book = next(operation for operation in operations if operation.operation_id == "book")
+
+    assert book.graphql_federated is True
+    assert book.graphql_output_shape is not None
+    assert book.graphql_output_shape.federated_entity is True
+    assert book.graphql_entity_types == ["Book"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -239,11 +239,7 @@ def _graphql_attack_case(
         path="/graphql",
         description="Wrong type for GraphQL variable.",
         body_json={
-            "query": (
-                "query Book($id: ID!) { "
-                "book(id: $id) { __typename id title rating } "
-                "}"
-            ),
+            "query": ("query Book($id: ID!) { book(id: $id) { __typename id title rating } }"),
             "variables": {"id": 123},
         },
         expected_outcomes=["graphql_error", "4xx"],

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,12 +14,13 @@ from knives_out.models import (
     AttackSuite,
     AuthProfile,
     ExtractRule,
+    GraphQLOutputShape,
     ProfileAttackResult,
     WorkflowAttackCase,
     WorkflowStep,
     WorkflowStepResult,
 )
-from knives_out.reporting import render_html_report, render_markdown_report
+from knives_out.reporting import render_html_report, render_markdown_report, summarize_results
 from knives_out.runner import execute_attack_suite, execute_attack_suite_profiles
 from knives_out.suppressions import SuppressionRule
 
@@ -189,6 +190,67 @@ def _workflow_attack(
             description="Terminal attack",
             path_params={"petId": terminal_path_param},
         ),
+    )
+
+
+def _graphql_shape_book(*, nullable: bool = True) -> GraphQLOutputShape:
+    return GraphQLOutputShape(
+        kind="object",
+        type_name="Book",
+        nullable=nullable,
+        fields={
+            "__typename": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "id": GraphQLOutputShape(
+                kind="scalar",
+                type_name="ID",
+                nullable=False,
+            ),
+            "title": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "rating": GraphQLOutputShape(
+                kind="scalar",
+                type_name="Int",
+                nullable=True,
+            ),
+        },
+    )
+
+
+def _graphql_attack_case(
+    *,
+    output_shape: GraphQLOutputShape | None = None,
+    federated: bool = False,
+    entity_types: list[str] | None = None,
+) -> AttackCase:
+    return AttackCase(
+        id="atk_graphql",
+        name="Wrong-type GraphQL variable",
+        kind="wrong_type_variable",
+        operation_id="book",
+        protocol="graphql",
+        method="POST",
+        path="/graphql",
+        description="Wrong type for GraphQL variable.",
+        body_json={
+            "query": (
+                "query Book($id: ID!) { "
+                "book(id: $id) { __typename id title rating } "
+                "}"
+            ),
+            "variables": {"id": 123},
+        },
+        expected_outcomes=["graphql_error", "4xx"],
+        graphql_root_field_name="book",
+        graphql_output_shape=output_shape or _graphql_shape_book(),
+        graphql_federated=federated,
+        graphql_entity_types=list(entity_types or []),
     )
 
 
@@ -394,13 +456,50 @@ def test_render_markdown_report_sorts_flagged_findings_by_score() -> None:
     report = render_markdown_report(results)
 
     assert "Response schema mismatches" in report
-    assert "| Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |" in report
+    assert (
+        "| Protocol | Attack | Kind | Status | Issue | Severity | Confidence | Schema | URL |"
+        in report
+    )
     assert "response_schema_mismatch" in report
     assert "mismatch" in report
     assert "$.id: expected integer, got string" in report
     assert report.index("| Server failure |") < report.index("| Unexpected success |")
     assert report.index("| Unexpected success |") < report.index("| Schema mismatch |")
     assert report.index("| Schema mismatch |") < report.index("| Transport error |")
+
+
+def test_render_markdown_report_shows_graphql_protocol_details() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_graphql",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="GraphQL mismatch",
+                protocol="graphql",
+                method="POST",
+                url="https://example.com/graphql",
+                status_code=200,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="medium",
+                confidence="high",
+                graphql_response_valid=False,
+                graphql_response_error="$.data.book.title: expected String, got integer",
+                graphql_response_hint="Schema appears federated.",
+            )
+        ],
+    )
+
+    report = render_markdown_report(results)
+
+    assert "GraphQL response-shape mismatches" in report
+    assert "`graphql`=1" in report
+    assert "graphql_response_shape_mismatch" in report
+    assert "graphql-mismatch" in report
+    assert "GraphQL federation hint" in report
 
 
 def test_render_markdown_report_with_baseline_shows_regression_sections() -> None:
@@ -849,7 +948,7 @@ def test_render_markdown_report_shows_profile_outcomes() -> None:
 
     assert "- Profiles: **3**" in report
     assert "anonymous (anonymous)" in report
-    assert "| user | 10 | 403 | ok | - | `https://example.com/secrets` |" in report
+    assert "| user | rest | 10 | 403 | ok | - | `https://example.com/secrets` |" in report
 
 
 def test_execute_attack_suite_removes_only_declared_auth_header(monkeypatch) -> None:
@@ -1296,22 +1395,7 @@ def test_execute_attack_suite_treats_graphql_errors_as_expected_failures(monkeyp
     results = execute_attack_suite(
         AttackSuite(
             source="unit",
-            attacks=[
-                AttackCase(
-                    id="atk_graphql_error",
-                    name="Wrong-type GraphQL variable",
-                    kind="wrong_type_variable",
-                    operation_id="book",
-                    method="POST",
-                    path="/graphql",
-                    description="Wrong type for GraphQL variable.",
-                    body_json={
-                        "query": "query Book($id: ID!) { book(id: $id) { __typename } }",
-                        "variables": {"id": 123},
-                    },
-                    expected_outcomes=["graphql_error", "4xx"],
-                )
-            ],
+            attacks=[_graphql_attack_case()],
         ),
         base_url="https://example.com",
     )
@@ -1320,33 +1404,31 @@ def test_execute_attack_suite_treats_graphql_errors_as_expected_failures(monkeyp
     assert result.flagged is False
     assert result.issue is None
     assert result.status_code == 200
+    assert result.graphql_response_valid is None
 
 
 def test_execute_attack_suite_flags_graphql_success_without_errors(monkeypatch) -> None:
     _install_stub_response(
         monkeypatch,
-        httpx.Response(200, json={"data": {"book": {"__typename": "Book"}}}),
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "book": {
+                        "__typename": "Book",
+                        "id": "1",
+                        "title": "Dune",
+                        "rating": 5,
+                    }
+                }
+            },
+        ),
     )
 
     results = execute_attack_suite(
         AttackSuite(
             source="unit",
-            attacks=[
-                AttackCase(
-                    id="atk_graphql_success",
-                    name="Wrong-type GraphQL variable",
-                    kind="wrong_type_variable",
-                    operation_id="book",
-                    method="POST",
-                    path="/graphql",
-                    description="Wrong type for GraphQL variable.",
-                    body_json={
-                        "query": "query Book($id: ID!) { book(id: $id) { __typename } }",
-                        "variables": {"id": 123},
-                    },
-                    expected_outcomes=["graphql_error", "4xx"],
-                )
-            ],
+            attacks=[_graphql_attack_case()],
         ),
         base_url="https://example.com",
     )
@@ -1354,6 +1436,167 @@ def test_execute_attack_suite_flags_graphql_success_without_errors(monkeypatch) 
     result = results.results[0]
     assert result.flagged is True
     assert result.issue == "unexpected_success"
+    assert result.graphql_response_valid is True
+
+
+def test_execute_attack_suite_flags_missing_graphql_selected_field(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={"data": {"book": {"__typename": "Book", "id": "1", "rating": 5}}},
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_graphql_attack_case()]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_valid is False
+    assert result.graphql_response_error == "$.data.book: missing selected field 'title'"
+
+
+def test_execute_attack_suite_flags_wrong_graphql_scalar_type(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "book": {
+                        "__typename": "Book",
+                        "id": "1",
+                        "title": "Dune",
+                        "rating": "five",
+                    }
+                }
+            },
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_graphql_attack_case()]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_error == "$.data.book.rating: expected Int, got string"
+
+
+def test_execute_attack_suite_allows_partial_graphql_data_when_shape_is_valid(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "book": {"__typename": "Book", "id": "1", "title": "Dune", "rating": None}
+                },
+                "errors": [{"message": "rating resolver failed"}],
+            },
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_graphql_attack_case()]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert result.issue is None
+    assert result.graphql_response_valid is True
+
+
+def test_execute_attack_suite_flags_partial_graphql_data_when_shape_is_invalid(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {"book": {"__typename": "Book", "id": "1", "rating": None}},
+                "errors": [{"message": "title resolver failed"}],
+            },
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[_graphql_attack_case()]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert "missing selected field 'title'" in (result.graphql_response_error or "")
+
+
+def test_execute_attack_suite_adds_graphql_federation_hint(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(200, json={"data": {"book": {"__typename": "Book", "id": "1"}}}),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[_graphql_attack_case(federated=True, entity_types=["Book"])],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.graphql_response_valid is False
+    assert result.graphql_response_hint is not None
+    assert "federated" in result.graphql_response_hint.lower()
+
+
+def test_execute_attack_suite_validates_graphql_union_typename(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={"data": {"node": {"__typename": "Magazine", "id": "1", "title": "Issue 1"}}},
+        ),
+    )
+
+    union_shape = GraphQLOutputShape(
+        kind="interface",
+        type_name="Node",
+        nullable=True,
+        possible_types={"Book": _graphql_shape_book()},
+    )
+    attack = _graphql_attack_case(output_shape=union_shape)
+    attack = attack.model_copy(
+        update={
+            "operation_id": "node",
+            "graphql_root_field_name": "node",
+            "body_json": {
+                "query": (
+                    "query Node($id: ID!) { "
+                    "node(id: $id) { __typename ... on Book { id title rating } } "
+                    "}"
+                ),
+                "variables": {"id": "1"},
+            },
+        }
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[attack]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert "expected one of ['Book']" in (result.graphql_response_error or "")
 
 
 def test_render_markdown_report_shows_workflow_sections() -> None:
@@ -1493,3 +1736,92 @@ def test_render_html_report_shows_auth_summary() -> None:
     assert "<td>1</td>" in report
     assert "Refresh attempts" in report
     assert "401, suite" in report
+
+
+def test_summarize_results_builds_machine_readable_regression_summary() -> None:
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        auth_events=[
+            {
+                "profile": "user",
+                "name": "user",
+                "strategy": "static_bearer",
+                "phase": "acquire",
+                "success": True,
+            },
+            {
+                "profile": "user",
+                "name": "user",
+                "strategy": "static_bearer",
+                "phase": "refresh",
+                "success": False,
+                "trigger": "401",
+            },
+        ],
+        results=[
+            AttackResult(
+                attack_id="atk_new",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="GraphQL mismatch",
+                protocol="graphql",
+                method="POST",
+                path="/graphql",
+                url="https://example.com/graphql",
+                status_code=200,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="medium",
+                confidence="high",
+                graphql_response_valid=False,
+            ),
+        ],
+    )
+    baseline = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="GraphQL mismatch",
+                protocol="graphql",
+                method="POST",
+                path="/graphql",
+                url="https://example.com/graphql",
+                status_code=500,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="medium",
+                confidence="high",
+                graphql_response_valid=False,
+            )
+        ],
+    )
+
+    summary = summarize_results(current, baseline=baseline, top_limit=1)
+
+    assert summary.baseline_used is True
+    assert summary.new_findings_count == 1
+    assert summary.persisting_findings_count == 1
+    assert summary.persisting_deltas_count == 1
+    assert summary.auth_failures == 1
+    assert summary.refresh_attempts == 1
+    assert summary.protocol_counts == {"graphql": 1, "rest": 1}
+    assert summary.finding_severity_counts == {"high": 1, "medium": 1}
+    assert summary.top_findings[0].attack_id == "atk_new"

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -96,6 +96,53 @@ def test_compare_attack_results_treats_issue_changes_as_resolved_and_new() -> No
     assert comparison.persisting_findings == []
 
 
+def test_compare_attack_results_tracks_persisting_deltas() -> None:
+    current = _results(
+        AttackResult(
+            attack_id="atk_shared",
+            operation_id="createPet",
+            kind="wrong_type_param",
+            name="Shared finding",
+            method="POST",
+            url="https://example.com/pets/atk_shared",
+            status_code=500,
+            flagged=True,
+            issue="server_error",
+            severity="critical",
+            confidence="medium",
+            response_schema_valid=False,
+        )
+    )
+    baseline = _results(
+        AttackResult(
+            attack_id="atk_shared",
+            operation_id="createPet",
+            kind="wrong_type_param",
+            name="Shared finding",
+            method="POST",
+            url="https://example.com/pets/atk_shared",
+            status_code=403,
+            flagged=True,
+            issue="server_error",
+            severity="high",
+            confidence="high",
+            response_schema_valid=True,
+        )
+    )
+
+    comparison = compare_attack_results(current, baseline)
+
+    assert len(comparison.persisting_findings) == 1
+    delta = comparison.persisting_findings[0].delta
+    assert delta is not None
+    assert [(change.field, change.baseline, change.current) for change in delta.changes] == [
+        ("status", "403", "500"),
+        ("severity", "high", "critical"),
+        ("confidence", "high", "medium"),
+        ("schema", "ok", "mismatch"),
+    ]
+
+
 def test_evaluate_verification_without_baseline_filters_by_thresholds() -> None:
     current = _results(
         _finding("atk_high", issue="server_error", severity="high", confidence="high"),


### PR DESCRIPTION
## Summary

- add a local-first FastAPI surface for inspect, generate, discover, report, summary, verify, promote, triage, and background run jobs
- refactor the CLI onto a shared service layer so the CLI and API stay behaviorally aligned
- add a machine-readable `knives-out summary` command and `/v1/summary` endpoint for CI, dashboards, and follow-on automation
- document the new API and summary flows across the README, CI guide, architecture notes, and roadmap
- cover the new surfaces with API, CLI, reporting, GraphQL, and docs tests

## Why

`knives-out` had grown into a useful pipeline, but it was still effectively shell-only. This change opens that pipeline up for local tools and automation without shelling out, and it adds a structured summary artifact so downstream systems do not need to parse Markdown or HTML just to understand the run.

## Validation

- `.venv/bin/ruff check src tests`
- `.venv/bin/pytest`

Closes #48
