### PR TITLE
[codex] Add API job retention controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,13 @@ Longer execution runs use a job resource instead:
 
 - `POST /v1/runs`
 - `GET /v1/jobs/{id}`
+- `DELETE /v1/jobs/{id}`
+- `POST /v1/jobs/prune`
 - `GET /v1/jobs/{id}/result`
 - `GET /v1/jobs/{id}/artifacts`
+
+Cleanup stays explicit and local-only: the delete and prune endpoints only remove completed or failed jobs,
+and active jobs must finish before they can be deleted.
 
 The API accepts uploaded source content and JSON artifacts in the request body. It does not expose
 arbitrary server-side file reads. FastAPI also publishes the schema at `/openapi.json` and the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -213,6 +213,8 @@ server on loopback:
 The API mirrors the same JSON artifacts through `POST /v1/inspect`, `POST /v1/generate`,
 `POST /v1/discover`, `POST /v1/report`, `POST /v1/summary`, `POST /v1/verify`, `POST /v1/promote`,
 `POST /v1/triage`, and background `POST /v1/runs` jobs with `GET /v1/jobs/{id}` polling.
+When local tools need cleanup, use `DELETE /v1/jobs/{id}` for a specific completed or failed run or
+`POST /v1/jobs/prune` to remove older completed/failed jobs in batch.
 Use `KNIVES_OUT_API_DATA_DIR` when you want the job store somewhere other than `.knives-out-api/`.
 
 ## Optional: machine-readable summary export

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -11,6 +11,7 @@ from fastapi.responses import FileResponse
 from knives_out.api_models import (
     ApiJobStatus,
     ArtifactListResponse,
+    DeleteJobResponse,
     DeltaChangeResponse,
     DiscoverRequest,
     DiscoverResponse,
@@ -20,9 +21,12 @@ from knives_out.api_models import (
     InspectRequest,
     InspectResponse,
     JobRecord,
+    JobRetentionEntry,
     JobStatusResponse,
     PromoteRequest,
     PromoteResponse,
+    PruneJobsRequest,
+    PruneJobsResponse,
     ReportRequest,
     ReportResponse,
     RunRequest,
@@ -33,7 +37,12 @@ from knives_out.api_models import (
     VerifyRequest,
     VerifyResponse,
 )
-from knives_out.api_store import JobNotFoundError, JobStore
+from knives_out.api_store import (
+    ActiveJobDeletionError,
+    DeletedJob,
+    JobNotFoundError,
+    JobStore,
+)
 from knives_out.models import AttackResults
 from knives_out.services import (
     InlineInput,
@@ -47,6 +56,8 @@ from knives_out.services import (
     triage_results_from_model,
     verify_results_from_models,
 )
+
+PRUNEABLE_JOB_STATUSES = frozenset({ApiJobStatus.completed, ApiJobStatus.failed})
 
 
 def _finding_summary(finding) -> FindingSummaryResponse:
@@ -105,6 +116,34 @@ def _default_data_dir() -> Path:
     if configured:
         return Path(configured)
     return Path.cwd() / ".knives-out-api"
+
+
+def _retention_entry(deleted: DeletedJob) -> JobRetentionEntry:
+    record = deleted.record
+    return JobRetentionEntry(
+        id=record.id,
+        status=record.status,
+        created_at=record.created_at,
+        completed_at=record.completed_at,
+        base_url=record.base_url,
+        attack_count=record.attack_count,
+        error=record.error,
+        result_available=deleted.result_available,
+        artifact_names=deleted.artifact_names,
+    )
+
+
+def _validate_prune_statuses(statuses: list[ApiJobStatus]) -> None:
+    invalid = [status.value for status in statuses if status not in PRUNEABLE_JOB_STATUSES]
+    if invalid:
+        joined = ", ".join(sorted(invalid))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Only completed and failed jobs can be pruned. "
+                f"Received unsupported statuses: {joined}."
+            ),
+        )
 
 
 def _run_job_worker(job_store: JobStore, job_id: str, request: RunRequest) -> None:
@@ -293,6 +332,68 @@ def create_app(*, data_dir: Path | None = None) -> FastAPI:
             return job_store.job_status_response(job_id)
         except JobNotFoundError as exc:
             raise HTTPException(status_code=404, detail="Job not found.") from exc
+
+    @app.delete("/v1/jobs/{job_id}", response_model=DeleteJobResponse)
+    def delete_job(job_id: str) -> DeleteJobResponse:
+        job_store: JobStore = app.state.job_store
+        try:
+            deleted = job_store.delete_job(job_id)
+        except JobNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Job not found.") from exc
+        except ActiveJobDeletionError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="Active jobs cannot be deleted; wait for completion or failure first.",
+            ) from exc
+        return DeleteJobResponse(deleted=_retention_entry(deleted))
+
+    @app.post("/v1/jobs/prune", response_model=PruneJobsResponse)
+    def prune_jobs(request: PruneJobsRequest) -> PruneJobsResponse:
+        _validate_prune_statuses(request.statuses)
+        job_store: JobStore = app.state.job_store
+
+        matched_records = []
+        for record in job_store.list_job_records():
+            if record.status not in request.statuses:
+                continue
+            if request.completed_before is not None:
+                if record.completed_at is None or record.completed_at > request.completed_before:
+                    continue
+            matched_records.append(record)
+            if len(matched_records) >= request.limit:
+                break
+
+        if request.dry_run:
+            jobs = [
+                JobRetentionEntry(
+                    id=record.id,
+                    status=record.status,
+                    created_at=record.created_at,
+                    completed_at=record.completed_at,
+                    base_url=record.base_url,
+                    attack_count=record.attack_count,
+                    error=record.error,
+                    result_available=job_store.result_exists(record.id),
+                    artifact_names=job_store.list_artifacts(record.id),
+                )
+                for record in matched_records
+            ]
+            return PruneJobsResponse(
+                dry_run=True,
+                matched_count=len(jobs),
+                deleted_count=0,
+                jobs=jobs,
+            )
+
+        deleted_jobs = [
+            _retention_entry(job_store.delete_job(record.id)) for record in matched_records
+        ]
+        return PruneJobsResponse(
+            dry_run=False,
+            matched_count=len(matched_records),
+            deleted_count=len(deleted_jobs),
+            jobs=deleted_jobs,
+        )
 
     @app.get("/v1/jobs/{job_id}/result", response_model=AttackResults)
     def get_job_result(job_id: str) -> AttackResults:

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -228,3 +228,35 @@ class JobStatusResponse(BaseModel):
 class ArtifactListResponse(BaseModel):
     job_id: str
     artifacts: list[str] = Field(default_factory=list)
+
+
+class JobRetentionEntry(BaseModel):
+    id: str
+    status: ApiJobStatus
+    created_at: datetime
+    completed_at: datetime | None = None
+    base_url: str
+    attack_count: int
+    error: str | None = None
+    result_available: bool = False
+    artifact_names: list[str] = Field(default_factory=list)
+
+
+class DeleteJobResponse(BaseModel):
+    deleted: JobRetentionEntry
+
+
+class PruneJobsRequest(BaseModel):
+    statuses: list[ApiJobStatus] = Field(
+        default_factory=lambda: [ApiJobStatus.completed, ApiJobStatus.failed]
+    )
+    completed_before: datetime | None = None
+    limit: int = Field(default=100, ge=1, le=500)
+    dry_run: bool = False
+
+
+class PruneJobsResponse(BaseModel):
+    dry_run: bool = False
+    matched_count: int = 0
+    deleted_count: int = 0
+    jobs: list[JobRetentionEntry] = Field(default_factory=list)

--- a/src/knives_out/api_store.py
+++ b/src/knives_out/api_store.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+from shutil import rmtree
 from time import monotonic, sleep
 from uuid import uuid4
 
 from pydantic import ValidationError
 
-from knives_out.api_models import ArtifactListResponse, JobRecord, JobStatusResponse
+from knives_out.api_models import ApiJobStatus, ArtifactListResponse, JobRecord, JobStatusResponse
 from knives_out.models import AttackResults
 
 
 class JobNotFoundError(FileNotFoundError):
     pass
+
+
+class ActiveJobDeletionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DeletedJob:
+    record: JobRecord
+    result_available: bool
+    artifact_names: list[str]
 
 
 class JobStore:
@@ -100,6 +113,18 @@ class JobStore:
     def result_exists(self, job_id: str) -> bool:
         return self.result_path(job_id).exists()
 
+    def list_job_records(self) -> list[JobRecord]:
+        records: list[JobRecord] = []
+        for path in self.jobs_dir.iterdir():
+            if not path.is_dir():
+                continue
+            record_path = path / "job.json"
+            if not record_path.exists():
+                continue
+            records.append(self.load_job(path.name))
+        records.sort(key=lambda record: record.created_at, reverse=True)
+        return records
+
     def list_artifacts(self, job_id: str) -> list[str]:
         artifact_dir = self.artifact_dir(job_id)
         if not artifact_dir.exists():
@@ -121,6 +146,26 @@ class JobStore:
         if not candidate.exists() or not candidate.is_file():
             raise FileNotFoundError(name)
         return candidate
+
+    def _job_dir_path_for_delete(self, job_id: str) -> Path:
+        jobs_root = self.jobs_dir.resolve()
+        candidate = (self.jobs_dir / job_id).resolve()
+        if candidate.parent != jobs_root or not candidate.exists() or not candidate.is_dir():
+            raise JobNotFoundError(job_id)
+        return candidate
+
+    def delete_job(self, job_id: str) -> DeletedJob:
+        record = self.load_job(job_id)
+        if record.status in {ApiJobStatus.pending, ApiJobStatus.running}:
+            raise ActiveJobDeletionError(job_id)
+
+        deleted = DeletedJob(
+            record=record,
+            result_available=self.result_exists(job_id),
+            artifact_names=self.list_artifacts(job_id),
+        )
+        rmtree(self._job_dir_path_for_delete(job_id))
+        return deleted
 
     def job_status_response(self, job_id: str) -> JobStatusResponse:
         record = self.load_job(job_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -449,8 +449,7 @@ def test_prune_jobs_rejects_active_status_filters(tmp_path) -> None:
 
     assert response.status_code == 400
     assert response.json()["detail"] == (
-        "Only completed and failed jobs can be pruned. "
-        "Received unsupported statuses: running."
+        "Only completed and failed jobs can be pruned. Received unsupported statuses: running."
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 import time
+from datetime import UTC, datetime, timedelta
 from textwrap import dedent
 
 import httpx
@@ -9,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from knives_out.api import create_app
-from knives_out.api_models import JobRecord
+from knives_out.api_models import ApiJobStatus, JobRecord
 from knives_out.api_store import JobStore
 from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite, LearnedModel
 
@@ -136,6 +137,37 @@ def _baseline_results() -> AttackResults:
             )
         ],
     )
+
+
+def _stored_job(
+    store: JobStore,
+    *,
+    status: ApiJobStatus,
+    created_at: datetime,
+    completed_at: datetime | None = None,
+    base_url: str = "https://example.com",
+    attack_count: int = 1,
+    error: str | None = None,
+    with_result: bool = False,
+    with_artifact: bool = False,
+) -> JobRecord:
+    record = store.create_job(
+        JobRecord(base_url=base_url, attack_count=attack_count).model_copy(
+            update={
+                "status": status,
+                "created_at": created_at,
+                "started_at": created_at,
+                "completed_at": completed_at,
+                "error": error,
+            }
+        )
+    )
+    if with_result:
+        store.write_result(record.id, _flagged_results().model_copy(update={"base_url": base_url}))
+    if with_artifact:
+        artifact_path = store.artifact_dir(record.id) / "atk_api.json"
+        artifact_path.write_text('{"attack":{"id":"atk_api"}}', encoding="utf-8")
+    return record
 
 
 def test_create_app_uses_env_data_dir_and_healthz_endpoint(tmp_path, monkeypatch) -> None:
@@ -291,6 +323,137 @@ def test_run_job_failure_is_reported(tmp_path, monkeypatch) -> None:
     assert result_response.status_code == 404
 
 
+def test_delete_job_removes_completed_job_and_related_artifacts(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    completed_at = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+    record = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=completed_at - timedelta(minutes=1),
+        completed_at=completed_at,
+        with_result=True,
+        with_artifact=True,
+    )
+
+    response = client.delete(f"/v1/jobs/{record.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deleted"]["id"] == record.id
+    assert payload["deleted"]["status"] == "completed"
+    assert payload["deleted"]["result_available"] is True
+    assert payload["deleted"]["artifact_names"] == ["atk_api.json"]
+    assert not store.job_dir(record.id).exists()
+
+    assert client.get(f"/v1/jobs/{record.id}").status_code == 404
+    assert client.get(f"/v1/jobs/{record.id}/result").status_code == 404
+    assert client.get(f"/v1/jobs/{record.id}/artifacts").status_code == 404
+
+
+def test_delete_job_rejects_active_jobs(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    record = _stored_job(
+        store,
+        status=ApiJobStatus.running,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+    )
+
+    response = client.delete(f"/v1/jobs/{record.id}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "Active jobs cannot be deleted; wait for completion or failure first."
+    )
+    assert store.job_dir(record.id).exists()
+
+
+def test_prune_jobs_supports_dry_run_and_completed_before_filter(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    cutoff = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+    old_completed = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=cutoff - timedelta(hours=2),
+        completed_at=cutoff - timedelta(hours=1),
+        with_result=True,
+    )
+    old_failed = _stored_job(
+        store,
+        status=ApiJobStatus.failed,
+        created_at=cutoff - timedelta(hours=3),
+        completed_at=cutoff - timedelta(hours=2),
+        error="boom",
+        with_artifact=True,
+    )
+    _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=cutoff - timedelta(minutes=10),
+        completed_at=cutoff + timedelta(minutes=5),
+        with_result=True,
+    )
+    _stored_job(
+        store,
+        status=ApiJobStatus.running,
+        created_at=cutoff - timedelta(minutes=2),
+    )
+
+    dry_run = client.post(
+        "/v1/jobs/prune",
+        json={
+            "statuses": ["completed", "failed"],
+            "completed_before": cutoff.isoformat(),
+            "limit": 10,
+            "dry_run": True,
+        },
+    )
+
+    assert dry_run.status_code == 200
+    dry_payload = dry_run.json()
+    assert dry_payload["dry_run"] is True
+    assert dry_payload["matched_count"] == 2
+    assert dry_payload["deleted_count"] == 0
+    assert [job["id"] for job in dry_payload["jobs"]] == [old_completed.id, old_failed.id]
+    assert store.job_dir(old_completed.id).exists()
+    assert store.job_dir(old_failed.id).exists()
+
+    response = client.post(
+        "/v1/jobs/prune",
+        json={
+            "statuses": ["completed", "failed"],
+            "completed_before": cutoff.isoformat(),
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["dry_run"] is False
+    assert payload["matched_count"] == 2
+    assert payload["deleted_count"] == 2
+    assert [job["id"] for job in payload["jobs"]] == [old_completed.id, old_failed.id]
+    assert not store.job_dir(old_completed.id).exists()
+    assert not store.job_dir(old_failed.id).exists()
+
+
+def test_prune_jobs_rejects_active_status_filters(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.post("/v1/jobs/prune", json={"statuses": ["running"]})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Only completed and failed jobs can be pruned. "
+        "Received unsupported statuses: running."
+    )
+
+
 def test_job_store_lists_nested_artifacts_and_rejects_path_traversal(tmp_path) -> None:
     store = JobStore(tmp_path)
     record = store.create_job(JobRecord(base_url="https://example.com", attack_count=1))
@@ -309,6 +472,13 @@ def test_job_store_lists_nested_artifacts_and_rejects_path_traversal(tmp_path) -
 
     with pytest.raises(FileNotFoundError):
         store.artifact_path_for_name(record.id, "missing.json")
+
+
+def test_job_store_delete_rejects_path_traversal(tmp_path) -> None:
+    store = JobStore(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        store.delete_job("../job.json")
 
 
 def test_discover_endpoint_supports_inline_inputs(tmp_path, monkeypatch) -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -36,7 +36,10 @@ def test_readme_includes_ci_guidance() -> None:
     assert "POST /v1/inspect" in readme
     assert "POST /v1/summary" in readme
     assert "POST /v1/runs" in readme
+    assert "DELETE /v1/jobs/{id}" in readme
+    assert "POST /v1/jobs/prune" in readme
     assert "GET /v1/jobs/{id}/artifacts" in readme
+    assert "completed or failed jobs" in readme
     assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in readme
     assert "anonymous_access" in readme
     assert "--auto-workflows" in readme
@@ -136,6 +139,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "POST /v1/inspect" in ci_doc
     assert "POST /v1/summary" in ci_doc
     assert "POST /v1/runs" in ci_doc
+    assert "DELETE /v1/jobs/{id}" in ci_doc
+    assert "POST /v1/jobs/prune" in ci_doc
     assert "KNIVES_OUT_API_DATA_DIR" in ci_doc
     assert "knives-out summary results.json --out summary.json" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc


### PR DESCRIPTION
## Summary
- add explicit local API cleanup endpoints for deleting one completed/failed job or pruning batches of old completed/failed jobs
- harden the filesystem job store so cleanup rejects active jobs and path traversal attempts
- document the retention flow and cover it with API and docs tests

## Validation
- `.venv/bin/python -m pytest tests/test_api.py tests/test_docs.py`
- `.venv/bin/ruff check src/knives_out/api.py src/knives_out/api_models.py src/knives_out/api_store.py tests/test_api.py tests/test_docs.py`

Closes #67
