### PR TITLE
[codex] Finish attack-kind filtering docs and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Generate attacks:
 ```bash
 knives-out generate examples/openapi/petstore.yaml --out attacks.json
 knives-out generate examples/openapi/storefront.yaml --tag orders --out attacks.json
+knives-out generate examples/openapi/petstore.yaml --kind missing_auth --out auth-attacks.json
+knives-out generate examples/openapi/petstore.yaml --exclude-kind malformed_json_body --out quieter-attacks.json
 knives-out generate examples/graphql/library.graphql --out graphql-attacks.json
 ```
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -249,9 +249,10 @@ spec is incomplete or missing workflow detail.
   run: knives-out generate learned-model.json --out attacks.json
 ```
 
-## Optional: tag and path filtering
+## Optional: tag, path, and kind filtering
 
-The same exact-match filters work in `inspect`, `generate`, and `run`:
+The same exact-match filters work in `inspect`, `generate`, and `run`, and `generate` also
+supports repeatable attack-kind filters for narrowing or muting specific attack categories:
 
 ```yaml
 - name: Generate only order-related attacks
@@ -270,6 +271,22 @@ The same exact-match filters work in `inspect`, `generate`, and `run`:
       --tag orders \
       --path /draft-orders/{draftId} \
       --out results.json
+```
+
+```yaml
+- name: Generate only auth-focused attacks
+  run: |
+    knives-out generate "$SPEC_PATH" \
+      --kind missing_auth \
+      --out attacks.json
+```
+
+```yaml
+- name: Exclude noisy malformed-body attacks
+  run: |
+    knives-out generate "$SPEC_PATH" \
+      --exclude-kind malformed_json_body \
+      --out attacks.json
 ```
 
 ## Optional: auth/session plugins

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,49 @@ def test_generate_command_writes_attack_suite(tmp_path: Path) -> None:
     assert all(attack.type == "request" for attack in suite.attacks)
 
 
+def test_generate_command_filters_attacks_by_kind(tmp_path: Path) -> None:
+    out_path = tmp_path / "auth-attacks.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(EXAMPLE_SPEC),
+            "--kind",
+            "missing_auth",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert len(suite.attacks) == 1
+    assert {attack.kind for attack in suite.attacks} == {"missing_auth"}
+    assert [attack.operation_id for attack in suite.attacks] == ["createPet"]
+
+
+def test_generate_command_excludes_attacks_by_kind(tmp_path: Path) -> None:
+    out_path = tmp_path / "filtered-attacks.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(EXAMPLE_SPEC),
+            "--exclude-kind",
+            "missing_auth",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    suite = AttackSuite.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert suite.attacks
+    assert all(attack.kind != "missing_auth" for attack in suite.attacks)
+
+
 def test_generate_command_supports_graphql_schema(tmp_path: Path) -> None:
     out_path = tmp_path / "graphql-attacks.json"
     result = runner.invoke(app, ["generate", str(GRAPHQL_EXAMPLE_SPEC), "--out", str(out_path)])

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -42,6 +42,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert "--auto-workflows" in readme
     assert "--tag orders" in readme
     assert "--path /draft-orders/{draftId}" in readme
+    assert "--kind missing_auth" in readme
+    assert "--exclude-kind malformed_json_body" in readme
     assert "--format json" in readme
     assert "knives-out report results.json --format html" in readme
     assert "--artifact-root artifacts" in readme
@@ -141,6 +143,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "Generate attacks with built-in workflows" in ci_doc
     assert "--tag orders" in ci_doc
     assert "--path /draft-orders/{draftId}" in ci_doc
+    assert "--kind missing_auth" in ci_doc
+    assert "--exclude-kind malformed_json_body" in ci_doc
     assert "Promote qualifying findings" in ci_doc
     assert "pytest --cov=src/knives_out --cov-report=term-missing" in ci_doc
     assert "coverage-badge.json" in ci_doc


### PR DESCRIPTION
## Summary
- add CLI regression tests covering `knives-out generate --kind` and `--exclude-kind`
- document attack-kind filtering in the README quick-start examples
- extend the CI guide with focused kind-filtering examples

## Why
Issue #49 was already mostly implemented in the generator and filtering layer, but it was still missing CLI-level regression coverage and user-facing documentation. This finishes the feature so it is discoverable and protected against regressions.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/knives-out-pycache .venv/bin/python -m ruff check README.md docs/ci.md tests/test_cli.py tests/test_docs.py tests/test_filtering.py`
- `PYTHONPYCACHEPREFIX=/tmp/knives-out-pycache .venv/bin/python -m pytest tests/test_cli.py tests/test_docs.py tests/test_filtering.py -q`

Closes #49
