### PR TITLE
[codex] Add guided web workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,15 @@ __pycache__/
 .mypy_cache/
 .venv/
 venv/
+node_modules/
 .knives-out-api/
 dist/
 build/
+coverage/
 .coverage
 htmlcov/
+*.tsbuildinfo
+frontend/vite.config.js
+frontend/vite.config.d.ts
 .DS_Store
 *.log

--- a/README.md
+++ b/README.md
@@ -212,6 +212,45 @@ Generate a review-ready suppressions file for known findings:
 knives-out triage results.json --out .knives-out-ignore.yml
 ```
 
+## Web workbench
+
+`knives-out` also includes a local-first web workbench for saved projects, guided attack
+generation, background runs, and native review panels.
+
+For normal local use, build the frontend once and let the API serve it under `/app/`:
+
+```bash
+cd frontend
+npm install
+npm run build
+cd ..
+
+knives-out serve --host 127.0.0.1 --port 8787
+```
+
+Then open [http://127.0.0.1:8787/app/](http://127.0.0.1:8787/app/).
+
+By default the API looks for built frontend assets in `frontend/dist/`. Set
+`KNIVES_OUT_FRONTEND_DIR` if you want to serve a different build output directory.
+
+For frontend development, run the API and Vite side by side:
+
+```bash
+# terminal 1
+knives-out serve --host 127.0.0.1 --port 8787
+
+# terminal 2
+cd frontend
+npm install
+npm run dev -- --host 127.0.0.1
+```
+
+Then open [http://127.0.0.1:4173/app/](http://127.0.0.1:4173/app/). The Vite dev server proxies
+`/v1` and `/healthz` to the API on `127.0.0.1:8787`.
+
+The workbench is intentionally local-only and single-user in v1. Saved project drafts, jobs, and
+artifacts all live under `.knives-out-api/` unless you override `KNIVES_OUT_API_DATA_DIR`.
+
 ## Local API
 
 `knives-out` can also run as a local-first HTTP API instead of only as a CLI.
@@ -251,6 +290,15 @@ run has finished writing `result.json`, so local tools can triage recent runs wi
 the full result body first.
 Cleanup stays explicit and local-only: the delete and prune endpoints only remove completed or failed jobs,
 and active jobs must finish before they can be deleted.
+
+The web workbench also uses project resources for saved drafts and project-scoped run history:
+
+- `GET /v1/projects`
+- `POST /v1/projects`
+- `GET /v1/projects/{id}`
+- `PATCH /v1/projects/{id}`
+- `DELETE /v1/projects/{id}`
+- `GET /v1/projects/{id}/jobs`
 
 The API accepts uploaded source content and JSON artifacts in the request body. It does not expose
 arbitrary server-side file reads. FastAPI also publishes the schema at `/openapi.json` and the

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>knives-out workbench</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,3310 @@
+{
+  "name": "knives-out-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "knives-out-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
+        "@tanstack/react-query": "^5.90.2",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.9.4"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^24.7.2",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
+        "@vitejs/plugin-react": "^5.0.4",
+        "jsdom": "^27.0.1",
+        "typescript": "^5.9.3",
+        "vite": "^7.1.9",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "knives-out-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
+    "@tanstack/react-query": "^5.90.2",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.9.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^24.7.2",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.0.4",
+    "jsdom": "^27.0.1",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.9",
+    "vitest": "^3.2.4"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Route, Routes } from "react-router-dom";
+import HomePage from "./pages/HomePage";
+import ProjectWorkbenchPage from "./pages/ProjectWorkbenchPage";
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/projects/:projectId" element={<ProjectWorkbenchPage />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,219 @@
+import type {
+  ApiReportFormat,
+  AttackResults,
+  AttackSuite,
+  DiscoverResponse,
+  GenerateResponse,
+  InspectResponse,
+  JobStatusResponse,
+  ProjectJobsResponse,
+  ProjectListResponse,
+  ProjectRecord,
+  ProjectReviewDraft,
+  PromoteResponse,
+  ReportResponse,
+  ResultsSummary,
+  SourcePayload,
+  TriageResponse,
+  VerifyResponse,
+} from "./types";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    headers: {
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}.`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export function listProjects() {
+  return request<ProjectListResponse>("/v1/projects");
+}
+
+export function createProject(name: string) {
+  return request<ProjectRecord>("/v1/projects", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
+export function getProject(projectId: string) {
+  return request<ProjectRecord>(`/v1/projects/${projectId}`);
+}
+
+export function updateProject(projectId: string, project: Partial<ProjectRecord>) {
+  return request<ProjectRecord>(`/v1/projects/${projectId}`, {
+    method: "PATCH",
+    body: JSON.stringify(project),
+  });
+}
+
+export function deleteProject(projectId: string) {
+  return request<{ deleted: boolean }>(`/v1/projects/${projectId}`, {
+    method: "DELETE",
+  });
+}
+
+export function listProjectJobs(projectId: string) {
+  return request<ProjectJobsResponse>(`/v1/projects/${projectId}/jobs`);
+}
+
+export function inspectSource(payload: {
+  source: SourcePayload;
+  graphql_endpoint: string;
+  tag: string[];
+  exclude_tag: string[];
+  path: string[];
+  exclude_path: string[];
+}) {
+  return request<InspectResponse>("/v1/inspect", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function discoverModel(inputs: SourcePayload[]) {
+  return request<DiscoverResponse>("/v1/discover", {
+    method: "POST",
+    body: JSON.stringify({ inputs }),
+  });
+}
+
+export function generateSuite(payload: {
+  source: SourcePayload;
+  graphql_endpoint: string;
+  operation: string[];
+  exclude_operation: string[];
+  method: string[];
+  exclude_method: string[];
+  kind: string[];
+  exclude_kind: string[];
+  tag: string[];
+  exclude_tag: string[];
+  path: string[];
+  exclude_path: string[];
+  pack_names: string[];
+  auto_workflows: boolean;
+  workflow_pack_names: string[];
+}) {
+  return request<GenerateResponse>("/v1/generate", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function createRun(payload: {
+  project_id: string;
+  suite: AttackSuite;
+  base_url: string;
+  headers: Record<string, string>;
+  query: Record<string, unknown>;
+  timeout: number;
+  store_artifacts: boolean;
+  auth_plugin_names: string[];
+  auth_config_yaml?: string | null;
+  auth_profile_names: string[];
+  profile_file_yaml?: string | null;
+  profile_names: string[];
+  operation: string[];
+  exclude_operation: string[];
+  method: string[];
+  exclude_method: string[];
+  kind: string[];
+  exclude_kind: string[];
+  tag: string[];
+  exclude_tag: string[];
+  path: string[];
+  exclude_path: string[];
+}) {
+  return request<JobStatusResponse>("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getJobResult(jobId: string) {
+  return request<AttackResults>(`/v1/jobs/${jobId}/result`);
+}
+
+export function summarizeResults(results: AttackResults, review: ProjectReviewDraft) {
+  return request<ResultsSummary>("/v1/summary", {
+    method: "POST",
+    body: JSON.stringify({
+      results,
+      baseline: review.baseline ?? null,
+      suppressions_yaml: review.suppressions_yaml ?? null,
+      top_limit: 50,
+    }),
+  });
+}
+
+export function verifyResults(results: AttackResults, review: ProjectReviewDraft) {
+  return request<VerifyResponse>("/v1/verify", {
+    method: "POST",
+    body: JSON.stringify({
+      results,
+      baseline: review.baseline ?? null,
+      suppressions_yaml: review.suppressions_yaml ?? null,
+      min_severity: review.min_severity,
+      min_confidence: review.min_confidence,
+    }),
+  });
+}
+
+export function renderReport(
+  results: AttackResults,
+  review: ProjectReviewDraft,
+  format: ApiReportFormat,
+) {
+  return request<ReportResponse>("/v1/report", {
+    method: "POST",
+    body: JSON.stringify({
+      results,
+      baseline: review.baseline ?? null,
+      suppressions_yaml: review.suppressions_yaml ?? null,
+      format,
+    }),
+  });
+}
+
+export function triageResults(results: AttackResults, review: ProjectReviewDraft) {
+  return request<TriageResponse>("/v1/triage", {
+    method: "POST",
+    body: JSON.stringify({
+      results,
+      existing_suppressions_yaml: review.suppressions_yaml ?? null,
+    }),
+  });
+}
+
+export function promoteResults(
+  results: AttackResults,
+  suite: AttackSuite,
+  review: ProjectReviewDraft,
+) {
+  return request<PromoteResponse>("/v1/promote", {
+    method: "POST",
+    body: JSON.stringify({
+      results,
+      attacks: suite,
+      baseline: review.baseline ?? null,
+      suppressions_yaml: review.suppressions_yaml ?? null,
+      min_severity: review.min_severity,
+      min_confidence: review.min_confidence,
+    }),
+  });
+}

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,0 +1,48 @@
+import Editor from "@monaco-editor/react";
+
+interface CodeEditorProps {
+  label: string;
+  language: string;
+  value: string;
+  onChange: (value: string) => void;
+  height?: number;
+  hint?: string;
+  error?: string | null;
+}
+
+export default function CodeEditor({
+  label,
+  language,
+  value,
+  onChange,
+  height = 240,
+  hint,
+  error,
+}: CodeEditorProps) {
+  return (
+    <label className="editor-field">
+      <span className="field-label">{label}</span>
+      {hint ? <span className="field-hint">{hint}</span> : null}
+      <div className={`editor-shell${error ? " editor-shell-error" : ""}`}>
+        <Editor
+          height={height}
+          defaultLanguage={language}
+          language={language}
+          value={value}
+          onChange={(nextValue) => onChange(nextValue ?? "")}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 13,
+            lineNumbersMinChars: 3,
+            scrollBeyondLastLine: false,
+            wordWrap: "on",
+            tabSize: 2,
+            padding: { top: 14, bottom: 14 },
+          }}
+          theme="vs-dark"
+        />
+      </div>
+      {error ? <span className="field-error">{error}</span> : null}
+    </label>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import "./styles.css";
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter basename="/app">
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import HomePage from "./HomePage";
+
+function renderHomePage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          projects: [
+            {
+              id: "project-1",
+              name: "Storefront triage",
+              source_mode: "openapi",
+              active_step: "review",
+              created_at: "2026-04-13T20:00:00Z",
+              updated_at: "2026-04-13T20:05:00Z",
+              source_name: "storefront.yaml",
+              job_count: 2,
+              last_run_job_id: "job-1",
+              last_run_status: "completed",
+              last_run_at: "2026-04-13T20:06:00Z",
+              active_flagged_count: 3,
+            },
+          ],
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders saved projects", async () => {
+    renderHomePage();
+
+    expect(await screen.findByText("Storefront triage")).toBeInTheDocument();
+    expect(screen.getByText("storefront.yaml")).toBeInTheDocument();
+    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getByText("Open")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,136 @@
+import { startTransition, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router-dom";
+import { createProject, deleteProject, listProjects } from "../api";
+
+export default function HomePage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [newProjectName, setNewProjectName] = useState("Security workbench");
+
+  const projectListQuery = useQuery({
+    queryKey: ["projects"],
+    queryFn: listProjects,
+  });
+
+  const createProjectMutation = useMutation({
+    mutationFn: createProject,
+    onSuccess: async (project) => {
+      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+      startTransition(() => {
+        navigate(`/projects/${project.id}`);
+      });
+    },
+  });
+
+  const deleteProjectMutation = useMutation({
+    mutationFn: deleteProject,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+
+  return (
+    <main className="shell">
+      <section className="hero-panel">
+        <div className="hero-copy">
+          <p className="eyebrow">Guided IDE</p>
+          <h1>Adversarial API testing, with a sharper workbench.</h1>
+          <p className="hero-body">
+            Inspect specs, generate attacks, run suites, and triage findings without leaving the
+            flow. Everything stays local-first and project-scoped.
+          </p>
+        </div>
+        <form
+          className="hero-create"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!newProjectName.trim()) {
+              return;
+            }
+            createProjectMutation.mutate(newProjectName.trim());
+          }}
+        >
+          <label className="field">
+            <span className="field-label">New project</span>
+            <input
+              className="text-input text-input-large"
+              value={newProjectName}
+              onChange={(event) => setNewProjectName(event.target.value)}
+              placeholder="Name the workbench"
+            />
+          </label>
+          <button className="primary-button" type="submit" disabled={createProjectMutation.isPending}>
+            {createProjectMutation.isPending ? "Creating…" : "Open workbench"}
+          </button>
+        </form>
+      </section>
+
+      <section className="panel">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Recent projects</p>
+            <h2>Pick up where you left off</h2>
+          </div>
+          <div className="meta-pill">
+            {projectListQuery.data?.projects.length ?? 0}
+            <span>saved</span>
+          </div>
+        </div>
+
+        {projectListQuery.isLoading ? <p className="empty-copy">Loading projects…</p> : null}
+
+        {!projectListQuery.isLoading && !projectListQuery.data?.projects.length ? (
+          <div className="empty-state">
+            <p>No saved projects yet.</p>
+            <p>Start with an OpenAPI or GraphQL source and the workbench will hold the drafts.</p>
+          </div>
+        ) : null}
+
+        <div className="project-grid">
+          {projectListQuery.data?.projects.map((project) => (
+            <article className="project-card" key={project.id}>
+              <div className="project-card-top">
+                <p className="project-mode">{project.source_mode.replace('_', ' ')}</p>
+                <div className={`status-chip status-${project.last_run_status ?? "idle"}`}>
+                  {project.last_run_status ?? "draft"}
+                </div>
+              </div>
+              <Link className="project-card-link" to={`/projects/${project.id}`}>
+                <h3>{project.name}</h3>
+                <p>{project.source_name ?? "No source loaded yet"}</p>
+              </Link>
+              <dl className="project-metrics">
+                <div>
+                  <dt>Step</dt>
+                  <dd>{project.active_step}</dd>
+                </div>
+                <div>
+                  <dt>Jobs</dt>
+                  <dd>{project.job_count}</dd>
+                </div>
+                <div>
+                  <dt>Findings</dt>
+                  <dd>{project.active_flagged_count ?? "—"}</dd>
+                </div>
+              </dl>
+              <div className="project-card-actions">
+                <Link className="secondary-button" to={`/projects/${project.id}`}>
+                  Open
+                </Link>
+                <button
+                  className="ghost-button"
+                  type="button"
+                  onClick={() => deleteProjectMutation.mutate(project.id)}
+                  disabled={deleteProjectMutation.isPending}
+                >
+                  Delete
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -1,0 +1,231 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectWorkbenchPage from "./ProjectWorkbenchPage";
+
+const projectPayload = {
+  id: "project-1",
+  name: "Workbench demo",
+  source_mode: "openapi",
+  active_step: "review",
+  created_at: "2026-04-13T20:00:00Z",
+  updated_at: "2026-04-13T20:05:00Z",
+  graphql_endpoint: "/graphql",
+  source: {
+    name: "demo.yaml",
+    content: "openapi: 3.0.3",
+  },
+  discover_inputs: [],
+  inspect_draft: {
+    tag: [],
+    exclude_tag: [],
+    path: [],
+    exclude_path: [],
+  },
+  generate_draft: {
+    operation: [],
+    exclude_operation: [],
+    method: [],
+    exclude_method: [],
+    kind: [],
+    exclude_kind: [],
+    tag: [],
+    exclude_tag: [],
+    path: [],
+    exclude_path: [],
+    pack_names: [],
+    auto_workflows: false,
+    workflow_pack_names: [],
+  },
+  run_draft: {
+    base_url: "",
+    headers: {},
+    query: {},
+    timeout: 10,
+    store_artifacts: true,
+    auth_plugin_names: [],
+    auth_config_yaml: null,
+    auth_profile_names: [],
+    profile_file_yaml: null,
+    profile_names: [],
+    operation: [],
+    exclude_operation: [],
+    method: [],
+    exclude_method: [],
+    kind: [],
+    exclude_kind: [],
+    tag: [],
+    exclude_tag: [],
+    path: [],
+    exclude_path: [],
+  },
+  review_draft: {
+    baseline: null,
+    suppressions_yaml: null,
+    min_severity: "high",
+    min_confidence: "medium",
+  },
+  artifacts: {
+    latest_summary: {
+      source: "unit",
+      base_url: "https://example.com",
+      executed_at: "2026-04-13T20:06:00Z",
+      baseline_used: false,
+      baseline_executed_at: null,
+      total_results: 2,
+      profile_count: 0,
+      profile_names: [],
+      active_flagged_count: 2,
+      suppressed_flagged_count: 0,
+      new_findings_count: 2,
+      resolved_findings_count: 0,
+      persisting_findings_count: 0,
+      persisting_deltas_count: 0,
+      auth_failures: 0,
+      refresh_attempts: 0,
+      response_schema_mismatches: 0,
+      graphql_shape_mismatches: 0,
+      protocol_counts: { rest: 2 },
+      issue_counts: { server_error: 1, response_schema_mismatch: 1 },
+      finding_severity_counts: { high: 1, medium: 1 },
+      finding_confidence_counts: { high: 2 },
+      auth_summary: [],
+      top_findings: [],
+    },
+    latest_verification: {
+      passed: false,
+      baseline_used: false,
+      min_severity: "high",
+      min_confidence: "medium",
+      current_findings_count: 2,
+      new_findings_count: 2,
+      resolved_findings_count: 0,
+      persisting_findings_count: 0,
+      suppressed_current_findings_count: 0,
+      current_findings: [
+        {
+          change: "current",
+          attack_id: "atk-login",
+          name: "Login failure",
+          protocol: "rest",
+          kind: "missing_auth",
+          method: "POST",
+          path: "/login",
+          tags: ["auth"],
+          issue: "server_error",
+          severity: "high",
+          confidence: "high",
+          status_code: 500,
+          url: "https://example.com/login",
+          delta_changes: [],
+        },
+        {
+          change: "current",
+          attack_id: "atk-order",
+          name: "Order mismatch",
+          protocol: "rest",
+          kind: "wrong_type_param",
+          method: "GET",
+          path: "/orders",
+          tags: ["orders"],
+          issue: "response_schema_mismatch",
+          severity: "medium",
+          confidence: "high",
+          status_code: 200,
+          url: "https://example.com/orders",
+          delta_changes: [],
+        },
+      ],
+      failing_findings: [],
+      new_findings: [],
+      resolved_findings: [],
+      persisting_findings: [],
+    },
+    latest_results: {
+      source: "unit",
+      base_url: "https://example.com",
+      executed_at: "2026-04-13T20:06:00Z",
+      profiles: [],
+      auth_events: [],
+      results: [],
+    },
+    latest_markdown_report: "# report",
+    latest_html_report: "<!doctype html>",
+    last_run_job_id: "job-1",
+  },
+};
+
+function renderWorkbench() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/projects/project-1"]}>
+        <Routes>
+          <Route path="/projects/:projectId" element={<ProjectWorkbenchPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ProjectWorkbenchPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/v1/projects/project-1")) {
+          return Response.json(projectPayload);
+        }
+        if (url.endsWith("/v1/projects/project-1/jobs")) {
+          return Response.json({ project_id: "project-1", jobs: [] });
+        }
+        throw new Error(`Unhandled fetch for ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the fixed step rail and disables runs without a generated suite", async () => {
+    renderWorkbench();
+
+    expect(await screen.findByText("Workbench demo")).toBeInTheDocument();
+    const stepRail = screen.getByRole("navigation", { name: "Workbench steps" });
+    for (const stepName of ["source", "inspect", "generate", "run", "review"]) {
+      expect(within(stepRail).getByRole("button", { name: new RegExp(stepName, "i") })).toBeInTheDocument();
+    }
+    expect(screen.getByRole("button", { name: "Run suite" })).toBeDisabled();
+  });
+
+  it("filters findings inside the native review workbench", async () => {
+    renderWorkbench();
+
+    await screen.findByText("Workbench demo");
+    fireEvent.click(screen.getByRole("tab", { name: "Findings" }));
+
+    const table = screen
+      .getAllByRole("table")
+      .find((candidate) => within(candidate).queryByText("Login failure"));
+    if (!table) {
+      throw new Error("Expected the findings table to render.");
+    }
+    expect(within(table).getByText("Login failure")).toBeInTheDocument();
+    expect(within(table).getByText("Order mismatch")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("search by attack, kind, issue, path"), {
+      target: { value: "login" },
+    });
+
+    expect(within(table).getByText("Login failure")).toBeInTheDocument();
+    expect(within(table).queryByText("Order mismatch")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -1,0 +1,1599 @@
+import { useDeferredValue, useEffect, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import CodeEditor from "../components/CodeEditor";
+import {
+  createRun,
+  discoverModel,
+  generateSuite,
+  getJobResult,
+  getProject,
+  inspectSource,
+  listProjectJobs,
+  promoteResults,
+  renderReport,
+  summarizeResults,
+  triageResults,
+  updateProject,
+  verifyResults,
+} from "../api";
+import type {
+  ApiJobStatus,
+  AttackResults,
+  AttackSuite,
+  JobStatusResponse,
+  ProjectRecord,
+  ProjectReviewDraft,
+  ProjectSourceMode,
+  ProjectStep,
+  SourcePayload,
+} from "../types";
+
+type ReviewTab =
+  | "summary"
+  | "findings"
+  | "deltas"
+  | "auth"
+  | "artifacts"
+  | "suppressions"
+  | "promote";
+
+const STEP_ORDER: ProjectStep[] = ["source", "inspect", "generate", "run", "review"];
+
+function defaultSourceForMode(mode: ProjectSourceMode): SourcePayload | null {
+  if (mode === "openapi") {
+    return { name: "openapi.yaml", content: "" };
+  }
+  if (mode === "graphql") {
+    return { name: "schema.graphql", content: "" };
+  }
+  if (mode === "learned") {
+    return { name: "learned-model.json", content: "" };
+  }
+  return null;
+}
+
+function normalizeList(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function formatList(values: string[]): string {
+  return values.join(", ");
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function buildProjectPatch(project: ProjectRecord) {
+  return {
+    name: project.name,
+    source_mode: project.source_mode,
+    active_step: project.active_step,
+    graphql_endpoint: project.graphql_endpoint,
+    source: project.source,
+    discover_inputs: project.discover_inputs,
+    inspect_draft: project.inspect_draft,
+    generate_draft: project.generate_draft,
+    run_draft: project.run_draft,
+    review_draft: project.review_draft,
+    artifacts: project.artifacts,
+  };
+}
+
+function statusTone(status: ApiJobStatus | "idle") {
+  if (status === "completed") {
+    return "status-completed";
+  }
+  if (status === "failed") {
+    return "status-failed";
+  }
+  if (status === "running") {
+    return "status-running";
+  }
+  if (status === "pending") {
+    return "status-pending";
+  }
+  return "status-idle";
+}
+
+function ReviewTable({
+  headings,
+  rows,
+  emptyCopy,
+}: {
+  headings: string[];
+  rows: Array<Array<string | number | null | undefined>>;
+  emptyCopy: string;
+}) {
+  return (
+    <div className="table-shell">
+      <table className="data-table">
+        <thead>
+          <tr>
+            {headings.map((heading) => (
+              <th key={heading}>{heading}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length ? (
+            rows.map((row, index) => (
+              <tr key={`${row[0] ?? "row"}-${index}`}>
+                {row.map((value, cellIndex) => (
+                  <td key={`${index}-${cellIndex}`}>{value ?? "—"}</td>
+                ))}
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={headings.length} className="table-empty">
+                {emptyCopy}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ListField({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string[];
+  placeholder: string;
+  onChange: (value: string[]) => void;
+}) {
+  return (
+    <label className="field">
+      <span className="field-label">{label}</span>
+      <input
+        className="text-input"
+        value={formatList(value)}
+        onChange={(event) => onChange(normalizeList(event.target.value))}
+        placeholder={placeholder}
+      />
+    </label>
+  );
+}
+
+function StepRail({
+  activeStep,
+  onChange,
+}: {
+  activeStep: ProjectStep;
+  onChange: (step: ProjectStep) => void;
+}) {
+  return (
+    <nav className="step-rail" aria-label="Workbench steps">
+      {STEP_ORDER.map((step, index) => (
+        <button
+          className={`step-rail-button${step === activeStep ? " step-rail-button-active" : ""}`}
+          key={step}
+          onClick={() => onChange(step)}
+          type="button"
+        >
+          <span className="step-rail-index">0{index + 1}</span>
+          <span className="step-rail-name">{step}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+export default function ProjectWorkbenchPage() {
+  const { projectId } = useParams();
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState<ProjectRecord | null>(null);
+  const [hasPendingSave, setHasPendingSave] = useState(false);
+  const [sourceText, setSourceText] = useState("");
+  const [headersText, setHeadersText] = useState("{}");
+  const [queryText, setQueryText] = useState("{}");
+  const [baselineText, setBaselineText] = useState("");
+  const [authConfigText, setAuthConfigText] = useState("");
+  const [profileFileText, setProfileFileText] = useState("");
+  const [suppressionsText, setSuppressionsText] = useState("");
+  const [headersError, setHeadersError] = useState<string | null>(null);
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [baselineError, setBaselineError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [activityMessage, setActivityMessage] = useState<string | null>(null);
+  const [reviewTab, setReviewTab] = useState<ReviewTab>("summary");
+  const [reviewFilter, setReviewFilter] = useState("");
+  const [trackedJobId, setTrackedJobId] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const syncedJobIdRef = useRef<string | null>(null);
+  const deferredReviewFilter = useDeferredValue(reviewFilter.trim().toLowerCase());
+
+  const projectQuery = useQuery({
+    queryKey: ["project", projectId],
+    queryFn: () => getProject(projectId!),
+    enabled: Boolean(projectId),
+  });
+
+  const projectJobsQuery = useQuery({
+    queryKey: ["projectJobs", projectId],
+    queryFn: () => listProjectJobs(projectId!),
+    enabled: Boolean(projectId),
+    refetchInterval: trackedJobId ? 1500 : false,
+  });
+
+  const saveProjectMutation = useMutation({
+    mutationFn: (project: ProjectRecord) => updateProject(project.id, buildProjectPatch(project)),
+    onSuccess: (project) => {
+      queryClient.setQueryData(["project", project.id], project);
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      setDraft(project);
+      hydrateTextBuffers(project);
+      setHasPendingSave(false);
+    },
+  });
+
+  function hydrateTextBuffers(project: ProjectRecord) {
+    setSourceText(project.source?.content ?? "");
+    setHeadersText(formatJson(project.run_draft.headers));
+    setQueryText(formatJson(project.run_draft.query));
+    setBaselineText(project.review_draft.baseline ? formatJson(project.review_draft.baseline) : "");
+    setAuthConfigText(project.run_draft.auth_config_yaml ?? "");
+    setProfileFileText(project.run_draft.profile_file_yaml ?? "");
+    setSuppressionsText(project.review_draft.suppressions_yaml ?? "");
+    setHeadersError(null);
+    setQueryError(null);
+    setBaselineError(null);
+  }
+
+  function applyDraftUpdate(updater: (current: ProjectRecord) => ProjectRecord) {
+    setDraft((current) => {
+      if (!current) {
+        return current;
+      }
+      return updater(current);
+    });
+    setHasPendingSave(true);
+  }
+
+  function getLoadedProject(): ProjectRecord {
+    if (!draft) {
+      throw new Error("Project is not loaded yet.");
+    }
+    return draft;
+  }
+
+  useEffect(() => {
+    if (!projectQuery.data) {
+      return;
+    }
+    if (hasPendingSave || saveProjectMutation.isPending) {
+      return;
+    }
+    setDraft(projectQuery.data);
+    hydrateTextBuffers(projectQuery.data);
+  }, [projectQuery.data, hasPendingSave, saveProjectMutation.isPending]);
+
+  useEffect(() => {
+    if (!draft || !hasPendingSave) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      saveProjectMutation.mutate(draft);
+    }, 650);
+    return () => window.clearTimeout(timer);
+  }, [draft, hasPendingSave, saveProjectMutation]);
+
+  useEffect(() => {
+    const job = projectJobsQuery.data?.jobs.find((candidate) => candidate.id === trackedJobId);
+    if (!draft || !job || job.id === syncedJobIdRef.current) {
+      return;
+    }
+
+    if (job.status === "failed") {
+      syncedJobIdRef.current = job.id;
+      setTrackedJobId(null);
+      setActivityMessage("Run failed. Check the run history panel for details.");
+      return;
+    }
+
+    if (job.status !== "completed" || !job.result_available) {
+      return;
+    }
+
+    syncedJobIdRef.current = job.id;
+    setBusyAction("refresh-review");
+    void (async () => {
+      try {
+        const results = await getJobResult(job.id);
+        const reviewDraft: ProjectReviewDraft = draft.review_draft;
+        const [summary, verification, markdownReport, htmlReport] = await Promise.all([
+          summarizeResults(results, reviewDraft),
+          verifyResults(results, reviewDraft),
+          renderReport(results, reviewDraft, "markdown"),
+          renderReport(results, reviewDraft, "html"),
+        ]);
+        applyDraftUpdate((current) => ({
+          ...current,
+          active_step: "review",
+          artifacts: {
+            ...current.artifacts,
+            last_run_job_id: job.id,
+            latest_results: results,
+            latest_summary: summary,
+            latest_verification: verification,
+            latest_markdown_report: markdownReport.content,
+            latest_html_report: htmlReport.content,
+          },
+        }));
+        setActivityMessage("Run finished and the review workspace is up to date.");
+        setActionError(null);
+      } catch (error) {
+        setActionError(error instanceof Error ? error.message : "Could not refresh review data.");
+      } finally {
+        setBusyAction(null);
+        setTrackedJobId(null);
+      }
+    })();
+  }, [draft, projectJobsQuery.data, trackedJobId]);
+
+  if (!projectId) {
+    return (
+      <main className="shell">
+        <section className="panel">
+          <p className="empty-copy">Missing project id.</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (projectQuery.isLoading || !draft) {
+    return (
+      <main className="shell">
+        <section className="panel">
+          <p className="empty-copy">Loading workbench…</p>
+        </section>
+      </main>
+    );
+  }
+
+  const currentJobs = projectJobsQuery.data?.jobs ?? [];
+  const latestJob = currentJobs[0];
+  const activeFindings =
+    draft.artifacts.latest_verification?.current_findings.filter((finding) => {
+      if (!deferredReviewFilter) {
+        return true;
+      }
+      const haystack = [
+        finding.attack_id,
+        finding.name,
+        finding.kind,
+        finding.issue ?? "",
+        finding.method,
+        finding.path ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(deferredReviewFilter);
+    }) ?? [];
+
+  async function handleSourceUpload(files: FileList | null) {
+    if (!files?.length) {
+      return;
+    }
+    const file = files[0];
+    const content = await file.text();
+    setSourceText(content);
+    applyDraftUpdate((current) => ({
+      ...current,
+      source: { name: file.name, content },
+    }));
+  }
+
+  async function handleCaptureUpload(files: FileList | null) {
+    if (!files?.length) {
+      return;
+    }
+    const uploaded = await Promise.all(
+      Array.from(files).map(async (file) => ({
+        name: file.name,
+        content: await file.text(),
+      })),
+    );
+    applyDraftUpdate((current) => ({
+      ...current,
+      discover_inputs: uploaded,
+    }));
+  }
+
+  async function handleInspect() {
+    const project = getLoadedProject();
+    if (!project.source) {
+      setActionError("Add a source document before inspecting.");
+      return;
+    }
+    setBusyAction("inspect");
+    setActionError(null);
+    try {
+      const inspected = await inspectSource({
+        source: project.source,
+        graphql_endpoint: project.graphql_endpoint,
+        ...project.inspect_draft,
+      });
+      applyDraftUpdate((current) => ({
+        ...current,
+        active_step: "inspect",
+        artifacts: {
+          ...current.artifacts,
+          inspect_result: inspected,
+        },
+      }));
+      setActivityMessage(`Inspected ${inspected.operations.length} operation(s).`);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Inspect failed.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleDiscover() {
+    const project = getLoadedProject();
+    if (!project.discover_inputs.length) {
+      setActionError("Upload at least one capture NDJSON or HAR file first.");
+      return;
+    }
+    setBusyAction("discover");
+    setActionError(null);
+    try {
+      const discovered = await discoverModel(project.discover_inputs);
+      const content = formatJson(discovered.learned_model);
+      setSourceText(content);
+      applyDraftUpdate((current) => ({
+        ...current,
+        source_mode: "learned",
+        active_step: "inspect",
+        source: { name: "learned-model.json", content },
+        artifacts: {
+          ...current.artifacts,
+          learned_model: discovered.learned_model,
+        },
+      }));
+      setActivityMessage(
+        `Discovered ${discovered.learned_model.operations.length} learned operation(s).`,
+      );
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Discover failed.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleGenerate() {
+    const project = getLoadedProject();
+    if (!project.source) {
+      setActionError("Add a source before generating attacks.");
+      return;
+    }
+    setBusyAction("generate");
+    setActionError(null);
+    try {
+      const generated = await generateSuite({
+        source: project.source,
+        graphql_endpoint: project.graphql_endpoint,
+        ...project.generate_draft,
+      });
+      applyDraftUpdate((current) => ({
+        ...current,
+        active_step: "run",
+        artifacts: {
+          ...current.artifacts,
+          generated_suite: generated.suite,
+        },
+      }));
+      setActivityMessage(`Generated ${generated.suite.attacks.length} attack(s).`);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Generate failed.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleRun() {
+    const project = getLoadedProject();
+    if (!project.artifacts.generated_suite) {
+      setActionError("Generate an attack suite before running.");
+      return;
+    }
+    if (!project.run_draft.base_url.trim()) {
+      setActionError("Add a base URL before starting a run.");
+      return;
+    }
+    if (headersError || queryError) {
+      setActionError("Fix JSON errors in the run settings before starting a run.");
+      return;
+    }
+    setBusyAction("run");
+    setActionError(null);
+    try {
+      const job = await createRun({
+        project_id: project.id,
+        suite: project.artifacts.generated_suite,
+        ...project.run_draft,
+      });
+      syncedJobIdRef.current = null;
+      setTrackedJobId(job.id);
+      applyDraftUpdate((current) => ({
+        ...current,
+        active_step: "review",
+        artifacts: {
+          ...current.artifacts,
+          last_run_job_id: job.id,
+        },
+      }));
+      projectJobsQuery.refetch();
+      setActivityMessage("Run started. The review step will refresh when it completes.");
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Run could not be started.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleRefreshReview() {
+    const project = getLoadedProject();
+    if (!project.artifacts.latest_results) {
+      setActionError("Run a suite first so there is data to analyze.");
+      return;
+    }
+    if (baselineError) {
+      setActionError("Fix baseline JSON before refreshing the review workspace.");
+      return;
+    }
+    setBusyAction("refresh-review");
+    setActionError(null);
+    try {
+      const [summary, verification, markdownReport, htmlReport] = await Promise.all([
+        summarizeResults(project.artifacts.latest_results, project.review_draft),
+        verifyResults(project.artifacts.latest_results, project.review_draft),
+        renderReport(project.artifacts.latest_results, project.review_draft, "markdown"),
+        renderReport(project.artifacts.latest_results, project.review_draft, "html"),
+      ]);
+      applyDraftUpdate((current) => ({
+        ...current,
+        artifacts: {
+          ...current.artifacts,
+          latest_summary: summary,
+          latest_verification: verification,
+          latest_markdown_report: markdownReport.content,
+          latest_html_report: htmlReport.content,
+        },
+      }));
+      setActivityMessage("Review panels refreshed.");
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not refresh review panels.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleGenerateSuppressions() {
+    const project = getLoadedProject();
+    if (!project.artifacts.latest_results) {
+      setActionError("Run a suite first so suppressions can be generated.");
+      return;
+    }
+    setBusyAction("suppressions");
+    setActionError(null);
+    try {
+      const triaged = await triageResults(project.artifacts.latest_results, project.review_draft);
+      setSuppressionsText(triaged.rendered_yaml);
+      applyDraftUpdate((current) => ({
+        ...current,
+        review_draft: {
+          ...current.review_draft,
+          suppressions_yaml: triaged.rendered_yaml,
+        },
+        artifacts: {
+          ...current.artifacts,
+          latest_suppressions: triaged.suppressions,
+        },
+      }));
+      setActivityMessage(`Generated ${triaged.added_count} suppression rule(s).`);
+      setReviewTab("suppressions");
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not generate suppressions.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handlePromote() {
+    const project = getLoadedProject();
+    if (!project.artifacts.latest_results || !project.artifacts.generated_suite) {
+      setActionError("Both run results and the generated suite are required for promotion.");
+      return;
+    }
+    setBusyAction("promote");
+    setActionError(null);
+    try {
+      const promoted = await promoteResults(
+        project.artifacts.latest_results,
+        project.artifacts.generated_suite,
+        project.review_draft,
+      );
+      applyDraftUpdate((current) => ({
+        ...current,
+        artifacts: {
+          ...current.artifacts,
+          latest_promoted_suite: promoted.promoted_suite,
+        },
+      }));
+      setActivityMessage(`Promoted ${promoted.promoted_attack_ids.length} attack(s).`);
+      setReviewTab("promote");
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Promotion failed.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  return (
+    <main className="workbench-shell">
+      <header className="workbench-header">
+        <div>
+          <p className="eyebrow">Local companion app</p>
+          <h1>{draft.name}</h1>
+          <p className="hero-body">
+            Saved {hasPendingSave || saveProjectMutation.isPending ? "drafting changes…" : "locally"}.
+            {activityMessage ? ` ${activityMessage}` : ""}
+          </p>
+        </div>
+        <div className="header-actions">
+          <Link className="ghost-button" to="/">
+            Back to projects
+          </Link>
+          <div className={`status-chip ${statusTone(latestJob?.status ?? "idle")}`}>
+            {latestJob?.status ?? "draft"}
+          </div>
+        </div>
+      </header>
+
+      {actionError ? <div className="error-banner">{actionError}</div> : null}
+
+      <div className="workbench-layout">
+        <StepRail
+          activeStep={draft.active_step}
+          onChange={(step) =>
+            applyDraftUpdate((current) => ({
+              ...current,
+              active_step: step,
+            }))
+          }
+        />
+
+        <section className="workbench-main">
+          <div className="panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Source</p>
+                <h2>Choose how this project begins</h2>
+              </div>
+              <div className="mode-switch">
+                {(
+                  ["openapi", "graphql", "learned", "capture_upload"] as ProjectSourceMode[]
+                ).map((mode) => (
+                  <button
+                    className={`mode-button${draft.source_mode === mode ? " mode-button-active" : ""}`}
+                    key={mode}
+                    onClick={() => {
+                      const nextSource = defaultSourceForMode(mode);
+                      setSourceText(nextSource?.content ?? "");
+                      applyDraftUpdate((current) => ({
+                        ...current,
+                        source_mode: mode,
+                        active_step: "source",
+                        source:
+                          mode === "capture_upload"
+                            ? null
+                            : {
+                                name: nextSource?.name ?? current.source?.name ?? "",
+                                content:
+                                  mode === current.source_mode
+                                    ? current.source?.content ?? ""
+                                    : nextSource?.content ?? "",
+                              },
+                      }));
+                    }}
+                    type="button"
+                  >
+                    {mode.replace("_", " ")}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {draft.source_mode === "capture_upload" ? (
+              <div className="stack">
+                <label className="upload-box">
+                  <span className="field-label">Capture inputs</span>
+                  <span className="field-hint">Upload one or more `capture.ndjson` or HAR files.</span>
+                  <input
+                    multiple
+                    onChange={(event) => void handleCaptureUpload(event.target.files)}
+                    type="file"
+                  />
+                </label>
+                <ul className="compact-list">
+                  {draft.discover_inputs.length ? (
+                    draft.discover_inputs.map((input) => (
+                      <li key={input.name}>
+                        <strong>{input.name}</strong>
+                        <span>{input.content.length} chars loaded</span>
+                      </li>
+                    ))
+                  ) : (
+                    <li>No capture files loaded yet.</li>
+                  )}
+                </ul>
+                <div className="action-row">
+                  <button
+                    className="primary-button"
+                    disabled={busyAction === "discover" || !draft.discover_inputs.length}
+                    onClick={() => void handleDiscover()}
+                    type="button"
+                  >
+                    {busyAction === "discover" ? "Discovering…" : "Discover learned model"}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="stack">
+                <div className="field-grid field-grid-2">
+                  <label className="field">
+                    <span className="field-label">Source name</span>
+                    <input
+                      className="text-input"
+                      value={draft.source?.name ?? ""}
+                      onChange={(event) =>
+                        applyDraftUpdate((current) => ({
+                          ...current,
+                          source: {
+                            name: event.target.value,
+                            content: current.source?.content ?? sourceText,
+                          },
+                        }))
+                      }
+                    />
+                  </label>
+                  <label className="field">
+                    <span className="field-label">GraphQL endpoint</span>
+                    <input
+                      className="text-input"
+                      value={draft.graphql_endpoint}
+                      onChange={(event) =>
+                        applyDraftUpdate((current) => ({
+                          ...current,
+                          graphql_endpoint: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+                </div>
+
+                <label className="upload-box">
+                  <span className="field-label">Upload source</span>
+                  <span className="field-hint">Load a local file into the project editor.</span>
+                  <input onChange={(event) => void handleSourceUpload(event.target.files)} type="file" />
+                </label>
+
+                <CodeEditor
+                  error={null}
+                  height={300}
+                  hint="This editor is the saved source of truth for inspect and generate."
+                  label="Source document"
+                  language={
+                    draft.source_mode === "graphql"
+                      ? "graphql"
+                      : draft.source_mode === "learned"
+                        ? "json"
+                        : "yaml"
+                  }
+                  onChange={(value) => {
+                    setSourceText(value);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      source: {
+                        name:
+                          current.source?.name ??
+                          defaultSourceForMode(current.source_mode)?.name ??
+                          "source.txt",
+                        content: value,
+                      },
+                    }));
+                  }}
+                  value={sourceText}
+                />
+
+                <div className="action-row">
+                  <button
+                    className="primary-button"
+                    disabled={busyAction === "inspect" || !draft.source?.content.trim()}
+                    onClick={() => void handleInspect()}
+                    type="button"
+                  >
+                    {busyAction === "inspect" ? "Inspecting…" : "Inspect source"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Inspect</p>
+                <h2>Preflight the operation surface</h2>
+              </div>
+              <div className="meta-pill">
+                {draft.artifacts.inspect_result?.operations.length ?? 0}
+                <span>ops</span>
+              </div>
+            </div>
+            <div className="field-grid field-grid-4">
+              <ListField
+                label="Include tags"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    inspect_draft: { ...current.inspect_draft, tag: value },
+                  }))
+                }
+                placeholder="orders, pets"
+                value={draft.inspect_draft.tag}
+              />
+              <ListField
+                label="Exclude tags"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    inspect_draft: { ...current.inspect_draft, exclude_tag: value },
+                  }))
+                }
+                placeholder="internal"
+                value={draft.inspect_draft.exclude_tag}
+              />
+              <ListField
+                label="Include paths"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    inspect_draft: { ...current.inspect_draft, path: value },
+                  }))
+                }
+                placeholder="/draft-orders/{draftId}"
+                value={draft.inspect_draft.path}
+              />
+              <ListField
+                label="Exclude paths"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    inspect_draft: { ...current.inspect_draft, exclude_path: value },
+                  }))
+                }
+                placeholder="/internal"
+                value={draft.inspect_draft.exclude_path}
+              />
+            </div>
+            <ReviewTable
+              emptyCopy="Run inspect to see discovered operations."
+              headings={["Operation", "Method", "Path", "Protocol", "Tags", "Auth"]}
+              rows={(draft.artifacts.inspect_result?.operations ?? []).map((operation) => [
+                operation.operation_id,
+                operation.method,
+                operation.path,
+                operation.protocol,
+                operation.tags.join(", ") || "—",
+                operation.auth_required ? "yes" : "no",
+              ])}
+            />
+          </div>
+
+          <div className="panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Generate</p>
+                <h2>Shape the attack suite</h2>
+              </div>
+              <div className="meta-pill">
+                {draft.artifacts.generated_suite?.attacks.length ?? 0}
+                <span>attacks</span>
+              </div>
+            </div>
+            <div className="field-grid field-grid-4">
+              <ListField
+                label="Include operations"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, operation: value },
+                  }))
+                }
+                placeholder="listPets"
+                value={draft.generate_draft.operation}
+              />
+              <ListField
+                label="Methods"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, method: value },
+                  }))
+                }
+                placeholder="GET, POST"
+                value={draft.generate_draft.method}
+              />
+              <ListField
+                label="Kinds"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, kind: value },
+                  }))
+                }
+                placeholder="missing_auth"
+                value={draft.generate_draft.kind}
+              />
+              <ListField
+                label="Pack names"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, pack_names: value },
+                  }))
+                }
+                placeholder="unexpected-header"
+                value={draft.generate_draft.pack_names}
+              />
+            </div>
+            <div className="field-grid field-grid-3">
+              <ListField
+                label="Tags"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, tag: value },
+                  }))
+                }
+                placeholder="orders"
+                value={draft.generate_draft.tag}
+              />
+              <ListField
+                label="Paths"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, path: value },
+                  }))
+                }
+                placeholder="/draft-orders/{draftId}"
+                value={draft.generate_draft.path}
+              />
+              <ListField
+                label="Workflow packs"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: { ...current.generate_draft, workflow_pack_names: value },
+                  }))
+                }
+                placeholder="listed-id-lookup"
+                value={draft.generate_draft.workflow_pack_names}
+              />
+            </div>
+            <label className="checkbox-row">
+              <input
+                checked={draft.generate_draft.auto_workflows}
+                onChange={(event) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    generate_draft: {
+                      ...current.generate_draft,
+                      auto_workflows: event.target.checked,
+                    },
+                  }))
+                }
+                type="checkbox"
+              />
+              <span>Enable auto-generated workflows</span>
+            </label>
+            <div className="action-row">
+              <button
+                className="primary-button"
+                disabled={busyAction === "generate" || !draft.source?.content.trim()}
+                onClick={() => void handleGenerate()}
+                type="button"
+              >
+                {busyAction === "generate" ? "Generating…" : "Generate suite"}
+              </button>
+            </div>
+          </div>
+
+          <div className="panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Run</p>
+                <h2>Execute against a live target</h2>
+              </div>
+              <div className="meta-pill">
+                {draft.artifacts.generated_suite?.attacks.length ?? 0}
+                <span>ready</span>
+              </div>
+            </div>
+            <div className="field-grid field-grid-3">
+              <label className="field">
+                <span className="field-label">Base URL</span>
+                <input
+                  className="text-input"
+                  placeholder="https://api.example.com"
+                  value={draft.run_draft.base_url}
+                  onChange={(event) =>
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: { ...current.run_draft, base_url: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+              <label className="field">
+                <span className="field-label">Timeout (seconds)</span>
+                <input
+                  className="text-input"
+                  type="number"
+                  value={draft.run_draft.timeout}
+                  onChange={(event) =>
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: {
+                        ...current.run_draft,
+                        timeout: Number(event.target.value || 0),
+                      },
+                    }))
+                  }
+                />
+              </label>
+              <label className="checkbox-row checkbox-row-inline">
+                <input
+                  checked={draft.run_draft.store_artifacts}
+                  onChange={(event) =>
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: {
+                        ...current.run_draft,
+                        store_artifacts: event.target.checked,
+                      },
+                    }))
+                  }
+                  type="checkbox"
+                />
+                <span>Store request/response artifacts</span>
+              </label>
+            </div>
+            <div className="field-grid field-grid-2">
+              <CodeEditor
+                error={headersError}
+                height={220}
+                hint='JSON object, for example `{ "Authorization": "Bearer token" }`.'
+                label="Default headers"
+                language="json"
+                onChange={(value) => {
+                  setHeadersText(value);
+                  if (!value.trim()) {
+                    setHeadersError(null);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: { ...current.run_draft, headers: {} },
+                    }));
+                    return;
+                  }
+                  try {
+                    const parsed = JSON.parse(value) as Record<string, string>;
+                    setHeadersError(null);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: { ...current.run_draft, headers: parsed },
+                    }));
+                  } catch (error) {
+                    setHeadersError(error instanceof Error ? error.message : "Invalid JSON.");
+                  }
+                }}
+                value={headersText}
+              />
+              <CodeEditor
+                error={queryError}
+                height={220}
+                hint='JSON object, for example `{ "api_key": "secret" }`.'
+                label="Default query"
+                language="json"
+                onChange={(value) => {
+                  setQueryText(value);
+                  if (!value.trim()) {
+                    setQueryError(null);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: { ...current.run_draft, query: {} },
+                    }));
+                    return;
+                  }
+                  try {
+                    const parsed = JSON.parse(value) as Record<string, unknown>;
+                    setQueryError(null);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      run_draft: { ...current.run_draft, query: parsed },
+                    }));
+                  } catch (error) {
+                    setQueryError(error instanceof Error ? error.message : "Invalid JSON.");
+                  }
+                }}
+                value={queryText}
+              />
+            </div>
+            <div className="field-grid field-grid-2">
+              <CodeEditor
+                error={null}
+                height={220}
+                hint="Optional YAML for built-in auth configs."
+                label="Auth config YAML"
+                language="yaml"
+                onChange={(value) => {
+                  setAuthConfigText(value);
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    run_draft: { ...current.run_draft, auth_config_yaml: value || null },
+                  }));
+                }}
+                value={authConfigText}
+              />
+              <CodeEditor
+                error={null}
+                height={220}
+                hint="Optional YAML for multi-profile runs."
+                label="Profile file YAML"
+                language="yaml"
+                onChange={(value) => {
+                  setProfileFileText(value);
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    run_draft: { ...current.run_draft, profile_file_yaml: value || null },
+                  }));
+                }}
+                value={profileFileText}
+              />
+            </div>
+            <div className="field-grid field-grid-3">
+              <ListField
+                label="Auth plugins"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    run_draft: { ...current.run_draft, auth_plugin_names: value },
+                  }))
+                }
+                placeholder="env-bearer"
+                value={draft.run_draft.auth_plugin_names}
+              />
+              <ListField
+                label="Auth profile names"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    run_draft: { ...current.run_draft, auth_profile_names: value },
+                  }))
+                }
+                placeholder="user, admin"
+                value={draft.run_draft.auth_profile_names}
+              />
+              <ListField
+                label="Profile names"
+                onChange={(value) =>
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    run_draft: { ...current.run_draft, profile_names: value },
+                  }))
+                }
+                placeholder="anonymous, admin"
+                value={draft.run_draft.profile_names}
+              />
+            </div>
+            <div className="action-row">
+              <button
+                className="primary-button"
+                disabled={busyAction === "run" || !draft.artifacts.generated_suite}
+                onClick={() => void handleRun()}
+                type="button"
+              >
+                {busyAction === "run" ? "Starting…" : "Run suite"}
+              </button>
+            </div>
+          </div>
+
+          <div className="panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Review</p>
+                <h2>Native triage and regression workspace</h2>
+              </div>
+              <div className="action-row">
+                <button
+                  className="secondary-button"
+                  disabled={busyAction === "refresh-review" || !draft.artifacts.latest_results}
+                  onClick={() => void handleRefreshReview()}
+                  type="button"
+                >
+                  {busyAction === "refresh-review" ? "Refreshing…" : "Refresh analysis"}
+                </button>
+                <button
+                  className="secondary-button"
+                  disabled={busyAction === "suppressions" || !draft.artifacts.latest_results}
+                  onClick={() => void handleGenerateSuppressions()}
+                  type="button"
+                >
+                  {busyAction === "suppressions" ? "Generating…" : "Seed suppressions"}
+                </button>
+                <button
+                  className="secondary-button"
+                  disabled={busyAction === "promote" || !draft.artifacts.latest_results}
+                  onClick={() => void handlePromote()}
+                  type="button"
+                >
+                  {busyAction === "promote" ? "Promoting…" : "Promote findings"}
+                </button>
+              </div>
+            </div>
+            <div className="field-grid field-grid-3">
+              <label className="field">
+                <span className="field-label">Minimum severity</span>
+                <select
+                  className="text-input"
+                  value={draft.review_draft.min_severity}
+                  onChange={(event) =>
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      review_draft: {
+                        ...current.review_draft,
+                        min_severity: event.target.value,
+                      },
+                    }))
+                  }
+                >
+                  {["low", "medium", "high", "critical"].map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="field">
+                <span className="field-label">Minimum confidence</span>
+                <select
+                  className="text-input"
+                  value={draft.review_draft.min_confidence}
+                  onChange={(event) =>
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      review_draft: {
+                        ...current.review_draft,
+                        min_confidence: event.target.value,
+                      },
+                    }))
+                  }
+                >
+                  {["low", "medium", "high"].map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="field">
+                <span className="field-label">Findings filter</span>
+                <input
+                  className="text-input"
+                  value={reviewFilter}
+                  onChange={(event) => setReviewFilter(event.target.value)}
+                  placeholder="search by attack, kind, issue, path"
+                />
+              </label>
+            </div>
+            <CodeEditor
+              error={baselineError}
+              height={220}
+              hint="Optional baseline results JSON for regression-aware review."
+              label="Baseline results JSON"
+              language="json"
+              onChange={(value) => {
+                setBaselineText(value);
+                if (!value.trim()) {
+                  setBaselineError(null);
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    review_draft: { ...current.review_draft, baseline: null },
+                  }));
+                  return;
+                }
+                try {
+                  const parsed = JSON.parse(value) as AttackResults;
+                  setBaselineError(null);
+                  applyDraftUpdate((current) => ({
+                    ...current,
+                    review_draft: { ...current.review_draft, baseline: parsed },
+                  }));
+                } catch (error) {
+                  setBaselineError(error instanceof Error ? error.message : "Invalid JSON.");
+                }
+              }}
+              value={baselineText}
+            />
+
+            <div className="tab-row" role="tablist" aria-label="Review panels">
+              {(
+                [
+                  ["summary", "Summary"],
+                  ["findings", "Findings"],
+                  ["deltas", "Deltas"],
+                  ["auth", "Auth"],
+                  ["artifacts", "Artifacts"],
+                  ["suppressions", "Suppressions"],
+                  ["promote", "Promote"],
+                ] as Array<[ReviewTab, string]>
+              ).map(([tab, label]) => (
+                <button
+                  className={`tab-button${reviewTab === tab ? " tab-button-active" : ""}`}
+                  key={tab}
+                  onClick={() => setReviewTab(tab)}
+                  role="tab"
+                  type="button"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {reviewTab === "summary" ? (
+              <div className="stack">
+                <div className="summary-card-grid">
+                  <div className="summary-card">
+                    <span>Total results</span>
+                    <strong>{draft.artifacts.latest_summary?.total_results ?? 0}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>Active flagged</span>
+                    <strong>{draft.artifacts.latest_summary?.active_flagged_count ?? 0}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>New</span>
+                    <strong>{draft.artifacts.latest_summary?.new_findings_count ?? 0}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>Persisting deltas</span>
+                    <strong>{draft.artifacts.latest_summary?.persisting_deltas_count ?? 0}</strong>
+                  </div>
+                </div>
+                <ReviewTable
+                  emptyCopy="Run a suite and refresh analysis to populate the summary."
+                  headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "URL"]}
+                  rows={(draft.artifacts.latest_summary?.top_findings ?? []).map((finding) => [
+                    finding.name,
+                    finding.kind,
+                    finding.issue ?? "—",
+                    finding.severity,
+                    finding.confidence,
+                    finding.url,
+                  ])}
+                />
+                <div className="report-grid">
+                  <article className="report-card">
+                    <h3>Markdown report</h3>
+                    <pre>{draft.artifacts.latest_markdown_report ?? "No Markdown report yet."}</pre>
+                  </article>
+                  <article className="report-card">
+                    <h3>HTML report</h3>
+                    <pre>{draft.artifacts.latest_html_report ?? "No HTML report yet."}</pre>
+                  </article>
+                </div>
+              </div>
+            ) : null}
+
+            {reviewTab === "findings" ? (
+              <ReviewTable
+                emptyCopy="No active findings match the current filter."
+                headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "Status", "Path"]}
+                rows={activeFindings.map((finding) => [
+                  finding.name,
+                  finding.kind,
+                  finding.issue ?? "—",
+                  finding.severity,
+                  finding.confidence,
+                  finding.status_code ?? "—",
+                  finding.path ?? "—",
+                ])}
+              />
+            ) : null}
+
+            {reviewTab === "deltas" ? (
+              <ReviewTable
+                emptyCopy="No persisting deltas are available."
+                headings={["Attack", "Issue", "Change summary", "Method", "Path"]}
+                rows={(draft.artifacts.latest_verification?.persisting_findings ?? []).map((finding) => [
+                  finding.name,
+                  finding.issue ?? "—",
+                  finding.delta_changes.length
+                    ? finding.delta_changes
+                        .map((change) => `${change.field} ${change.baseline} -> ${change.current}`)
+                        .join("; ")
+                    : "unchanged",
+                  finding.method,
+                  finding.path ?? "—",
+                ])}
+              />
+            ) : null}
+
+            {reviewTab === "auth" ? (
+              <div className="stack">
+                <ReviewTable
+                  emptyCopy="No auth summary recorded."
+                  headings={["Profile", "Name", "Strategy", "Acquire", "Refresh", "Failures"]}
+                  rows={(draft.artifacts.latest_summary?.auth_summary ?? []).map((entry) => [
+                    entry.profile,
+                    entry.name,
+                    entry.strategy,
+                    entry.acquire,
+                    entry.refresh,
+                    entry.failures,
+                  ])}
+                />
+                <ReviewTable
+                  emptyCopy="No auth events captured."
+                  headings={["Profile", "Name", "Strategy", "Phase", "Status", "Error"]}
+                  rows={(draft.artifacts.latest_results?.auth_events ?? []).map((event) => [
+                    event.profile ?? "—",
+                    event.name,
+                    event.strategy,
+                    event.phase,
+                    event.status_code ?? (event.success ? "ok" : "failed"),
+                    event.error ?? "—",
+                  ])}
+                />
+              </div>
+            ) : null}
+
+            {reviewTab === "artifacts" ? (
+              <div className="stack">
+                <ReviewTable
+                  emptyCopy="No jobs for this project yet."
+                  headings={["Job", "Status", "Created", "Artifacts", "Error"]}
+                  rows={currentJobs.map((job) => [
+                    job.id,
+                    job.status,
+                    new Date(job.created_at).toLocaleString(),
+                    job.artifact_names.length,
+                    job.error ?? "—",
+                  ])}
+                />
+                <ul className="artifact-list">
+                  {(latestJob?.artifact_names ?? []).length ? (
+                    latestJob?.artifact_names.map((artifactName) => (
+                      <li key={artifactName}>
+                        <a href={`/v1/jobs/${latestJob.id}/artifacts/${artifactName}`} target="_blank">
+                          {artifactName}
+                        </a>
+                      </li>
+                    ))
+                  ) : (
+                    <li>No artifacts linked to the latest job.</li>
+                  )}
+                </ul>
+              </div>
+            ) : null}
+
+            {reviewTab === "suppressions" ? (
+              <div className="stack">
+                <CodeEditor
+                  error={null}
+                  height={260}
+                  hint="Edit suppressions directly. They are applied by summary, verify, report, and promote."
+                  label="Suppressions YAML"
+                  language="yaml"
+                  onChange={(value) => {
+                    setSuppressionsText(value);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      review_draft: {
+                        ...current.review_draft,
+                        suppressions_yaml: value || null,
+                      },
+                    }));
+                  }}
+                  value={suppressionsText}
+                />
+              </div>
+            ) : null}
+
+            {reviewTab === "promote" ? (
+              <div className="stack">
+                <div className="summary-card-grid">
+                  <div className="summary-card">
+                    <span>Promoted attacks</span>
+                    <strong>{draft.artifacts.latest_promoted_suite?.attacks.length ?? 0}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>Latest run</span>
+                    <strong>{draft.artifacts.last_run_job_id ?? "—"}</strong>
+                  </div>
+                </div>
+                <pre className="json-preview">
+                  {draft.artifacts.latest_promoted_suite
+                    ? formatJson(draft.artifacts.latest_promoted_suite)
+                    : "No promoted suite yet."}
+                </pre>
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <aside className="workbench-sidebar">
+          <section className="sidebar-panel">
+            <p className="eyebrow">Project state</p>
+            <h3>Run history</h3>
+            <ul className="job-feed">
+              {currentJobs.length ? (
+                currentJobs.map((job: JobStatusResponse) => (
+                  <li className="job-feed-item" key={job.id}>
+                    <div className="job-feed-top">
+                      <code>{job.id.slice(0, 8)}</code>
+                      <span className={`status-chip ${statusTone(job.status)}`}>{job.status}</span>
+                    </div>
+                    <p>{job.base_url}</p>
+                    <small>
+                      {new Date(job.created_at).toLocaleString()}
+                      {job.error ? ` • ${job.error}` : ""}
+                    </small>
+                  </li>
+                ))
+              ) : (
+                <li className="job-feed-item">No runs yet.</li>
+              )}
+            </ul>
+          </section>
+          <section className="sidebar-panel">
+            <p className="eyebrow">Guideposts</p>
+            <h3>Current materials</h3>
+            <ul className="compact-list">
+              <li>
+                <strong>Source mode</strong>
+                <span>{draft.source_mode.replace("_", " ")}</span>
+              </li>
+              <li>
+                <strong>Suite</strong>
+                <span>{draft.artifacts.generated_suite?.attacks.length ?? 0} attacks</span>
+              </li>
+              <li>
+                <strong>Latest results</strong>
+                <span>{draft.artifacts.latest_results?.results.length ?? 0} entries</span>
+              </li>
+              <li>
+                <strong>Active findings</strong>
+                <span>{draft.artifacts.latest_summary?.active_flagged_count ?? 0}</span>
+              </li>
+            </ul>
+          </section>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,578 @@
+:root {
+  --bg: #f3ede2;
+  --panel: rgba(254, 251, 246, 0.9);
+  --panel-strong: rgba(255, 255, 255, 0.9);
+  --ink: #1f1b18;
+  --muted: #6e6359;
+  --border: rgba(76, 57, 39, 0.14);
+  --line: rgba(76, 57, 39, 0.08);
+  --accent: #0d6c63;
+  --accent-strong: #064e48;
+  --warning: #b26b00;
+  --danger: #b42318;
+  --pending: #8b5cf6;
+  --shadow: 0 20px 60px rgba(31, 23, 17, 0.09);
+  --radius-xl: 26px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --font-ui: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "Menlo", "Consolas", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-ui);
+  background:
+    radial-gradient(circle at top left, rgba(13, 108, 99, 0.16), transparent 28%),
+    radial-gradient(circle at top right, rgba(178, 107, 0, 0.12), transparent 24%),
+    linear-gradient(180deg, #f9f4eb 0%, var(--bg) 100%);
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+code,
+pre {
+  font-family: var(--font-mono);
+}
+
+.shell,
+.workbench-shell {
+  width: min(1440px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 28px 0 56px;
+}
+
+.hero-panel,
+.panel,
+.project-card,
+.sidebar-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(280px, 0.9fr);
+  gap: 28px;
+  padding: 32px;
+  border-radius: 32px;
+}
+
+.hero-copy h1,
+.workbench-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+.hero-body {
+  max-width: 70ch;
+  color: var(--muted);
+}
+
+.hero-create,
+.stack,
+.editor-field,
+.field,
+.report-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-heading,
+.workbench-header,
+.project-card-top,
+.job-feed-top,
+.header-actions,
+.action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.panel,
+.sidebar-panel {
+  padding: 24px;
+  border-radius: var(--radius-xl);
+}
+
+.panel + .panel {
+  margin-top: 22px;
+}
+
+.eyebrow,
+.project-mode,
+.step-rail-index,
+.meta-pill span,
+.field-hint,
+.summary-card span,
+.status-chip,
+.label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.73rem;
+  font-weight: 700;
+}
+
+.eyebrow,
+.project-mode,
+.field-hint,
+.hero-body,
+.empty-copy,
+.empty-state p,
+.project-card-link p,
+.job-feed-item small {
+  color: var(--muted);
+}
+
+.field-label {
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+
+.field-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.field-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field-grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.field-grid-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.text-input,
+.mode-button,
+.step-rail-button,
+.tab-button,
+.primary-button,
+.secondary-button,
+.ghost-button {
+  border-radius: 14px;
+  border: 1px solid var(--border);
+}
+
+.text-input {
+  min-height: 46px;
+  padding: 0 14px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink);
+}
+
+.text-input-large {
+  min-height: 52px;
+  font-size: 1.05rem;
+}
+
+.text-input:focus,
+.mode-button:focus,
+.step-rail-button:focus,
+.tab-button:focus,
+.primary-button:focus,
+.secondary-button:focus,
+.ghost-button:focus {
+  outline: 2px solid rgba(13, 108, 99, 0.24);
+  outline-offset: 2px;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button {
+  min-height: 44px;
+  padding: 0 16px;
+  cursor: pointer;
+  transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: white;
+  border-color: transparent;
+}
+
+.secondary-button {
+  background: rgba(13, 108, 99, 0.08);
+  color: var(--accent-strong);
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--ink);
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.ghost-button:hover,
+.mode-button:hover,
+.step-rail-button:hover,
+.tab-button:hover {
+  transform: translateY(-1px);
+}
+
+.mode-switch,
+.tab-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mode-button,
+.tab-button {
+  background: rgba(255, 255, 255, 0.56);
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.mode-button-active,
+.tab-button-active {
+  background: rgba(13, 108, 99, 0.14);
+  border-color: rgba(13, 108, 99, 0.34);
+  color: var(--accent-strong);
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.project-card {
+  border-radius: 24px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.project-card-link {
+  text-decoration: none;
+}
+
+.project-card-link h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.project-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.project-metrics dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.project-metrics dd {
+  margin: 4px 0 0;
+  font-weight: 700;
+}
+
+.project-card-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.status-chip,
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.status-idle {
+  color: var(--muted);
+}
+
+.status-completed {
+  color: var(--accent-strong);
+}
+
+.status-failed {
+  color: var(--danger);
+}
+
+.status-running {
+  color: var(--warning);
+}
+
+.status-pending {
+  color: var(--pending);
+}
+
+.workbench-layout {
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr) 290px;
+  gap: 22px;
+  align-items: start;
+}
+
+.step-rail {
+  position: sticky;
+  top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.step-rail-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.68);
+  cursor: pointer;
+}
+
+.step-rail-button-active {
+  background: rgba(13, 108, 99, 0.14);
+  border-color: rgba(13, 108, 99, 0.38);
+}
+
+.step-rail-name {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.upload-box {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border: 1px dashed rgba(13, 108, 99, 0.34);
+  border-radius: var(--radius-lg);
+  background: rgba(13, 108, 99, 0.06);
+}
+
+.editor-shell {
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(13, 108, 99, 0.22);
+}
+
+.editor-shell-error {
+  border-color: rgba(180, 35, 24, 0.4);
+}
+
+.field-error,
+.error-banner {
+  color: var(--danger);
+}
+
+.error-banner {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  background: rgba(180, 35, 24, 0.08);
+  border: 1px solid rgba(180, 35, 24, 0.22);
+  border-radius: var(--radius-md);
+}
+
+.table-shell {
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+}
+
+.data-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.table-empty {
+  text-align: center;
+  color: var(--muted);
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.checkbox-row-inline {
+  margin-top: 24px;
+}
+
+.summary-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 14px;
+}
+
+.summary-card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.summary-card strong {
+  display: block;
+  font-size: 1.55rem;
+  margin-top: 8px;
+}
+
+.report-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.report-card pre,
+.json-preview {
+  margin: 0;
+  min-height: 160px;
+  max-height: 420px;
+  overflow: auto;
+  padding: 16px;
+  border-radius: 18px;
+  background: #1f2933;
+  color: #f4f7fb;
+  white-space: pre-wrap;
+}
+
+.artifact-list,
+.compact-list,
+.job-feed {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.artifact-list,
+.compact-list,
+.job-feed {
+  display: grid;
+  gap: 10px;
+}
+
+.compact-list li,
+.job-feed-item {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.compact-list li strong {
+  font-size: 0.88rem;
+}
+
+.artifact-list a {
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+.artifact-list a:hover {
+  text-decoration: underline;
+}
+
+.sidebar-panel + .sidebar-panel {
+  margin-top: 18px;
+}
+
+.empty-state {
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px dashed var(--border);
+  background: rgba(255, 255, 255, 0.54);
+}
+
+@media (max-width: 1180px) {
+  .workbench-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .step-rail {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .step-rail-button {
+    width: auto;
+    min-width: 140px;
+  }
+
+  .field-grid-4,
+  .field-grid-3,
+  .field-grid-2,
+  .report-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .shell,
+  .workbench-shell {
+    width: min(100vw - 20px, 100%);
+    padding: 18px 0 40px;
+  }
+
+  .hero-panel {
+    grid-template-columns: 1fr;
+    padding: 22px;
+  }
+
+  .workbench-header,
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,19 @@
+import "@testing-library/jest-dom/vitest";
+import React from "react";
+import { vi } from "vitest";
+
+vi.mock("@monaco-editor/react", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange?: (value: string) => void;
+  }) =>
+    React.createElement("textarea", {
+      "aria-label": "code editor",
+      "data-testid": "code-editor",
+      onChange: (event: { target: { value: string } }) => onChange?.(event.target.value),
+      value,
+    }),
+}));

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,394 @@
+export type ProjectSourceMode = "openapi" | "graphql" | "learned" | "capture_upload";
+export type ProjectStep = "source" | "inspect" | "generate" | "run" | "review";
+export type ApiJobStatus = "pending" | "running" | "completed" | "failed";
+export type ApiReportFormat = "markdown" | "html";
+
+export interface SourcePayload {
+  name: string;
+  content: string;
+}
+
+export interface PreflightWarning {
+  code: string;
+  message: string;
+  operation_id?: string | null;
+  method?: string | null;
+  path?: string | null;
+}
+
+export interface OperationSpec {
+  operation_id: string;
+  method: string;
+  path: string;
+  protocol: string;
+  summary?: string | null;
+  tags: string[];
+  auth_required: boolean;
+  request_body_required: boolean;
+  learned_confidence?: number | null;
+}
+
+export interface InspectResponse {
+  source_kind: string;
+  operations: OperationSpec[];
+  warnings: PreflightWarning[];
+  learned_workflow_count: number;
+}
+
+export interface AttackCase {
+  type: "request" | "workflow";
+  id: string;
+  name: string;
+  kind: string;
+  operation_id: string;
+  protocol: string;
+  method: string;
+  path: string;
+  description: string;
+  tags: string[];
+  expected_outcomes?: string[];
+  terminal_attack?: AttackCase;
+}
+
+export interface AttackSuite {
+  source: string;
+  generated_at: string;
+  attacks: AttackCase[];
+}
+
+export interface LearnedModel {
+  artifact_type: "learned-model";
+  generated_at: string;
+  source_inputs: string[];
+  operations: OperationSpec[];
+  workflows: Array<{
+    id: string;
+    name: string;
+    producer_operation_id: string;
+    consumer_operation_id: string;
+    confidence: number;
+    observation_count: number;
+  }>;
+  warnings: PreflightWarning[];
+}
+
+export interface DiscoverResponse {
+  learned_model: LearnedModel;
+}
+
+export interface GenerateResponse {
+  source_kind: string;
+  suite: AttackSuite;
+  warnings: PreflightWarning[];
+}
+
+export interface AuthEvent {
+  name: string;
+  strategy: string;
+  phase: string;
+  success: boolean;
+  profile?: string | null;
+  trigger?: string | null;
+  endpoint?: string | null;
+  status_code?: number | null;
+  error?: string | null;
+}
+
+export interface ProfileAttackResult {
+  profile: string;
+  level: number;
+  anonymous: boolean;
+  url: string;
+  status_code?: number | null;
+  issue?: string | null;
+  severity: string;
+  confidence: string;
+}
+
+export interface AttackResult {
+  type: "request" | "workflow";
+  attack_id: string;
+  operation_id: string;
+  kind: string;
+  name: string;
+  protocol: string;
+  method: string;
+  path?: string | null;
+  tags: string[];
+  url: string;
+  status_code?: number | null;
+  error?: string | null;
+  duration_ms?: number | null;
+  flagged: boolean;
+  issue?: string | null;
+  severity: string;
+  confidence: string;
+  response_schema_status?: string | null;
+  response_schema_valid?: boolean | null;
+  graphql_response_valid?: boolean | null;
+  workflow_steps?: Array<{
+    name: string;
+    operation_id: string;
+    method: string;
+    url: string;
+    status_code?: number | null;
+    error?: string | null;
+  }> | null;
+  profile_results?: ProfileAttackResult[] | null;
+}
+
+export interface AttackResults {
+  source: string;
+  base_url: string;
+  executed_at: string;
+  profiles: string[];
+  auth_events: AuthEvent[];
+  results: AttackResult[];
+}
+
+export interface SummaryFinding {
+  attack_id: string;
+  name: string;
+  protocol: string;
+  kind: string;
+  issue?: string | null;
+  severity: string;
+  confidence: string;
+  status_code?: number | null;
+  url: string;
+  schema_status: string;
+}
+
+export interface AuthSummaryEntry {
+  profile: string;
+  name: string;
+  strategy: string;
+  acquire: number;
+  refresh: number;
+  failures: number;
+  triggers: string[];
+}
+
+export interface ResultsSummary {
+  source: string;
+  base_url: string;
+  executed_at: string;
+  baseline_used: boolean;
+  baseline_executed_at?: string | null;
+  total_results: number;
+  profile_count: number;
+  profile_names: string[];
+  active_flagged_count: number;
+  suppressed_flagged_count: number;
+  new_findings_count: number;
+  resolved_findings_count: number;
+  persisting_findings_count: number;
+  persisting_deltas_count: number;
+  auth_failures: number;
+  refresh_attempts: number;
+  response_schema_mismatches: number;
+  graphql_shape_mismatches: number;
+  protocol_counts: Record<string, number>;
+  issue_counts: Record<string, number>;
+  finding_severity_counts: Record<string, number>;
+  finding_confidence_counts: Record<string, number>;
+  auth_summary: AuthSummaryEntry[];
+  top_findings: SummaryFinding[];
+}
+
+export interface DeltaChangeResponse {
+  field: string;
+  baseline: string;
+  current: string;
+}
+
+export interface FindingSummaryResponse {
+  change: string;
+  attack_id: string;
+  name: string;
+  protocol: string;
+  kind: string;
+  method: string;
+  path?: string | null;
+  tags: string[];
+  issue?: string | null;
+  severity: string;
+  confidence: string;
+  status_code?: number | null;
+  url: string;
+  delta_changes: DeltaChangeResponse[];
+}
+
+export interface VerifyResponse {
+  passed: boolean;
+  baseline_used: boolean;
+  min_severity: string;
+  min_confidence: string;
+  current_findings_count: number;
+  new_findings_count: number;
+  resolved_findings_count: number;
+  persisting_findings_count: number;
+  suppressed_current_findings_count: number;
+  current_findings: FindingSummaryResponse[];
+  failing_findings: FindingSummaryResponse[];
+  new_findings: FindingSummaryResponse[];
+  resolved_findings: FindingSummaryResponse[];
+  persisting_findings: FindingSummaryResponse[];
+}
+
+export interface SuppressionRule {
+  attack_id?: string | null;
+  issue?: string | null;
+  operation_id?: string | null;
+  method?: string | null;
+  path?: string | null;
+  kind?: string | null;
+  tags: string[];
+  reason: string;
+  owner: string;
+  expires_on?: string | null;
+}
+
+export interface SuppressionsFile {
+  suppressions: SuppressionRule[];
+}
+
+export interface TriageResponse {
+  suppressions: SuppressionsFile;
+  added_count: number;
+  rendered_yaml: string;
+}
+
+export interface PromoteResponse {
+  promoted_suite: AttackSuite;
+  promoted_attack_ids: string[];
+  baseline_used: boolean;
+}
+
+export interface ReportResponse {
+  format: ApiReportFormat;
+  content: string;
+}
+
+export interface JobStatusResponse {
+  id: string;
+  kind: string;
+  status: ApiJobStatus;
+  created_at: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+  base_url: string;
+  attack_count: number;
+  project_id?: string | null;
+  error?: string | null;
+  result_available: boolean;
+  artifact_names: string[];
+}
+
+export interface ProjectInspectDraft {
+  tag: string[];
+  exclude_tag: string[];
+  path: string[];
+  exclude_path: string[];
+}
+
+export interface ProjectGenerateDraft {
+  operation: string[];
+  exclude_operation: string[];
+  method: string[];
+  exclude_method: string[];
+  kind: string[];
+  exclude_kind: string[];
+  tag: string[];
+  exclude_tag: string[];
+  path: string[];
+  exclude_path: string[];
+  pack_names: string[];
+  auto_workflows: boolean;
+  workflow_pack_names: string[];
+}
+
+export interface ProjectRunDraft {
+  base_url: string;
+  headers: Record<string, string>;
+  query: Record<string, unknown>;
+  timeout: number;
+  store_artifacts: boolean;
+  auth_plugin_names: string[];
+  auth_config_yaml?: string | null;
+  auth_profile_names: string[];
+  profile_file_yaml?: string | null;
+  profile_names: string[];
+  operation: string[];
+  exclude_operation: string[];
+  method: string[];
+  exclude_method: string[];
+  kind: string[];
+  exclude_kind: string[];
+  tag: string[];
+  exclude_tag: string[];
+  path: string[];
+  exclude_path: string[];
+}
+
+export interface ProjectReviewDraft {
+  baseline?: AttackResults | null;
+  suppressions_yaml?: string | null;
+  min_severity: string;
+  min_confidence: string;
+}
+
+export interface ProjectArtifacts {
+  learned_model?: LearnedModel | null;
+  inspect_result?: InspectResponse | null;
+  generated_suite?: AttackSuite | null;
+  latest_results?: AttackResults | null;
+  latest_summary?: ResultsSummary | null;
+  latest_verification?: VerifyResponse | null;
+  latest_markdown_report?: string | null;
+  latest_html_report?: string | null;
+  latest_suppressions?: SuppressionsFile | null;
+  latest_promoted_suite?: AttackSuite | null;
+  last_run_job_id?: string | null;
+}
+
+export interface ProjectRecord {
+  id: string;
+  name: string;
+  source_mode: ProjectSourceMode;
+  active_step: ProjectStep;
+  created_at: string;
+  updated_at: string;
+  graphql_endpoint: string;
+  source?: SourcePayload | null;
+  discover_inputs: SourcePayload[];
+  inspect_draft: ProjectInspectDraft;
+  generate_draft: ProjectGenerateDraft;
+  run_draft: ProjectRunDraft;
+  review_draft: ProjectReviewDraft;
+  artifacts: ProjectArtifacts;
+}
+
+export interface ProjectSummaryResponse {
+  id: string;
+  name: string;
+  source_mode: ProjectSourceMode;
+  active_step: ProjectStep;
+  created_at: string;
+  updated_at: string;
+  source_name?: string | null;
+  job_count: number;
+  last_run_job_id?: string | null;
+  last_run_status?: ApiJobStatus | null;
+  last_run_at?: string | null;
+  active_flagged_count?: number | null;
+}
+
+export interface ProjectListResponse {
+  projects: ProjectSummaryResponse[];
+}
+
+export interface ProjectJobsResponse {
+  project_id: string;
+  jobs: JobStatusResponse[];
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,18 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  base: "/app/",
+  plugins: [react()],
+  server: {
+    port: 4173,
+    proxy: {
+      "/v1": "http://127.0.0.1:8787",
+      "/healthz": "http://127.0.0.1:8787",
+    },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+  },
+});

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 import threading
+from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated
 
+import yaml
 from fastapi import FastAPI, HTTPException, Query
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 
 from knives_out.api_models import (
     ApiJobStatus,
@@ -25,6 +27,13 @@ from knives_out.api_models import (
     JobRecord,
     JobRetentionEntry,
     JobStatusResponse,
+    ProjectCreateRequest,
+    ProjectJobsResponse,
+    ProjectListResponse,
+    ProjectRecord,
+    ProjectSourceMode,
+    ProjectSummaryResponse,
+    ProjectUpdateRequest,
     PromoteRequest,
     PromoteResponse,
     PruneJobsRequest,
@@ -32,6 +41,7 @@ from knives_out.api_models import (
     ReportRequest,
     ReportResponse,
     RunRequest,
+    SourcePayload,
     SummaryRequest,
     SummaryResponse,
     TriageRequest,
@@ -41,6 +51,7 @@ from knives_out.api_models import (
 )
 from knives_out.api_store import ActiveJobDeletionError, DeletedJob, JobNotFoundError, JobStore
 from knives_out.models import AttackResults, ResultsSummary
+from knives_out.project_store import ProjectNotFoundError, ProjectStore
 from knives_out.services import (
     InlineInput,
     discover_model_inline,
@@ -59,9 +70,9 @@ JOB_SUMMARY_TOP_LIMIT = 3
 
 
 def _finding_summary(finding) -> FindingSummaryResponse:
-    result = finding.result
+    result = finding.result if hasattr(finding, "result") else finding
     delta_changes = []
-    if finding.delta is not None:
+    if hasattr(finding, "delta") and finding.delta is not None:
         delta_changes = [
             DeltaChangeResponse(
                 field=change.field,
@@ -71,10 +82,14 @@ def _finding_summary(finding) -> FindingSummaryResponse:
             for change in finding.delta.changes
         ]
     return FindingSummaryResponse(
-        change=finding.change,
+        change=getattr(finding, "change", "current"),
         attack_id=result.attack_id,
         name=result.name,
         protocol="rest" if result.protocol == "openapi" else result.protocol,
+        kind=result.kind,
+        method=result.method,
+        path=result.path,
+        tags=list(result.tags),
         issue=result.issue,
         severity=result.severity,
         confidence=result.confidence,
@@ -96,6 +111,7 @@ def _verify_response(verification) -> VerifyResponse:
         resolved_findings_count=len(comparison.resolved_findings),
         persisting_findings_count=len(comparison.persisting_findings),
         suppressed_current_findings_count=len(comparison.suppressed_current_findings),
+        current_findings=[_finding_summary(finding) for finding in comparison.current_findings],
         failing_findings=[_finding_summary(finding) for finding in verification.failing_findings],
         new_findings=[_finding_summary(finding) for finding in comparison.new_findings],
         resolved_findings=[_finding_summary(finding) for finding in comparison.resolved_findings],
@@ -134,6 +150,7 @@ def _job_status_response(job_store: JobStore, record: JobRecord) -> JobStatusRes
         completed_at=record.completed_at,
         base_url=record.base_url,
         attack_count=record.attack_count,
+        project_id=record.project_id,
         error=record.error,
         result_available=result_available,
         artifact_names=job_store.list_artifacts(record.id),
@@ -167,6 +184,94 @@ def _validate_prune_statuses(statuses: list[ApiJobStatus]) -> None:
                 f"Received unsupported statuses: {joined}."
             ),
         )
+
+
+def _default_frontend_dir() -> Path:
+    configured = os.environ.get("KNIVES_OUT_FRONTEND_DIR")
+    if configured:
+        return Path(configured)
+    return Path(__file__).resolve().parents[2] / "frontend" / "dist"
+
+
+def _default_source_for_mode(source_mode: ProjectSourceMode) -> SourcePayload | None:
+    if source_mode == ProjectSourceMode.openapi:
+        return SourcePayload(name="openapi.yaml", content="")
+    if source_mode == ProjectSourceMode.graphql:
+        return SourcePayload(name="schema.graphql", content="")
+    if source_mode == ProjectSourceMode.learned:
+        return SourcePayload(name="learned-model.json", content="")
+    return None
+
+
+def _project_source_name(project: ProjectRecord) -> str | None:
+    if project.source is not None:
+        return project.source.name
+    if project.discover_inputs:
+        return project.discover_inputs[0].name
+    return None
+
+
+def _project_summary(
+    project: ProjectRecord,
+    *,
+    jobs: list[JobStatusResponse],
+) -> ProjectSummaryResponse:
+    latest_job = jobs[0] if jobs else None
+    active_flagged_count = None
+    if project.artifacts.latest_summary is not None:
+        active_flagged_count = project.artifacts.latest_summary.active_flagged_count
+    return ProjectSummaryResponse(
+        id=project.id,
+        name=project.name,
+        source_mode=project.source_mode,
+        active_step=project.active_step,
+        created_at=project.created_at,
+        updated_at=project.updated_at,
+        source_name=_project_source_name(project),
+        job_count=len(jobs),
+        last_run_job_id=(
+            latest_job.id if latest_job is not None else project.artifacts.last_run_job_id
+        ),
+        last_run_status=latest_job.status if latest_job is not None else None,
+        last_run_at=(
+            latest_job.completed_at or latest_job.started_at or latest_job.created_at
+            if latest_job is not None
+            else None
+        ),
+        active_flagged_count=active_flagged_count,
+    )
+
+
+def _frontend_missing_response(frontend_root: Path) -> HTMLResponse:
+    return HTMLResponse(
+        (
+            '<!DOCTYPE html><html><body style="font-family:sans-serif;padding:24px;">'
+            "<h1>knives-out frontend not built</h1>"
+            f"<p>Expected frontend assets under <code>{frontend_root}</code>.</p>"
+            "<p>Run <code>npm install</code> and <code>npm run build</code> in "
+            "<code>frontend/</code>, then restart the API.</p>"
+            "</body></html>"
+        ),
+        status_code=503,
+    )
+
+
+def _frontend_response(frontend_root: Path, asset_path: str) -> FileResponse | HTMLResponse:
+    if not frontend_root.exists():
+        return _frontend_missing_response(frontend_root)
+
+    clean_path = asset_path.lstrip("/")
+    candidate = frontend_root / clean_path if clean_path else frontend_root / "index.html"
+    if candidate.exists() and candidate.is_file():
+        return FileResponse(candidate)
+
+    if clean_path and "." in Path(clean_path).name:
+        raise HTTPException(status_code=404, detail="Frontend asset not found.")
+
+    index_path = frontend_root / "index.html"
+    if not index_path.exists():
+        return _frontend_missing_response(frontend_root)
+    return FileResponse(index_path)
 
 
 def _run_job_worker(job_store: JobStore, job_id: str, request: RunRequest) -> None:
@@ -218,17 +323,138 @@ def _run_job_worker(job_store: JobStore, job_id: str, request: RunRequest) -> No
         job_store.update_job(failed)
 
 
-def create_app(*, data_dir: Path | None = None) -> FastAPI:
+def create_app(
+    *,
+    data_dir: Path | None = None,
+    frontend_dir: Path | None = None,
+) -> FastAPI:
     app = FastAPI(
         title="knives-out API",
         version="0.11.0",
         description="Local-first API for adversarial API testing from specs and observed traffic.",
     )
-    app.state.job_store = JobStore(data_dir or _default_data_dir())
+    root = data_dir or _default_data_dir()
+    app.state.job_store = JobStore(root)
+    app.state.project_store = ProjectStore(root)
+    app.state.frontend_dir = frontend_dir or _default_frontend_dir()
 
     @app.get("/healthz")
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/v1/projects", response_model=ProjectListResponse)
+    def list_projects() -> ProjectListResponse:
+        project_store: ProjectStore = app.state.project_store
+        job_store: JobStore = app.state.job_store
+        jobs_by_project: dict[str, list[JobStatusResponse]] = defaultdict(list)
+        for record in job_store.list_job_records():
+            if record.project_id is None:
+                continue
+            jobs_by_project[record.project_id].append(_job_status_response(job_store, record))
+        return ProjectListResponse(
+            projects=[
+                _project_summary(project, jobs=jobs_by_project.get(project.id, []))
+                for project in project_store.list_projects()
+            ]
+        )
+
+    @app.post("/v1/projects", response_model=ProjectRecord)
+    def create_project(request: ProjectCreateRequest) -> ProjectRecord:
+        project_store: ProjectStore = app.state.project_store
+        now = datetime.now(UTC)
+        record = ProjectRecord(
+            name=request.name,
+            source_mode=request.source_mode,
+            active_step=request.active_step,
+            created_at=now,
+            updated_at=now,
+            graphql_endpoint=request.graphql_endpoint,
+            source=request.source or _default_source_for_mode(request.source_mode),
+            discover_inputs=request.discover_inputs,
+            inspect_draft=request.inspect_draft,
+            generate_draft=request.generate_draft,
+            run_draft=request.run_draft,
+            review_draft=request.review_draft,
+            artifacts=request.artifacts,
+        )
+        return project_store.create_project(record)
+
+    @app.get("/v1/projects/{project_id}", response_model=ProjectRecord)
+    def get_project(project_id: str) -> ProjectRecord:
+        project_store: ProjectStore = app.state.project_store
+        try:
+            return project_store.load_project(project_id)
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+    @app.patch("/v1/projects/{project_id}", response_model=ProjectRecord)
+    def update_project(project_id: str, request: ProjectUpdateRequest) -> ProjectRecord:
+        project_store: ProjectStore = app.state.project_store
+        try:
+            current = project_store.load_project(project_id)
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+        changes = request.model_dump(exclude_unset=True)
+        if (
+            "source_mode" in changes
+            and "source" not in changes
+            and current.source is None
+            and changes["source_mode"] != ProjectSourceMode.capture_upload
+        ):
+            changes["source"] = _default_source_for_mode(changes["source_mode"])
+
+        updated = ProjectRecord.model_validate(
+            {
+                **current.model_dump(mode="python"),
+                **changes,
+                "updated_at": datetime.now(UTC),
+            }
+        )
+        return project_store.update_project(updated)
+
+    @app.delete("/v1/projects/{project_id}")
+    def delete_project(project_id: str) -> dict[str, bool]:
+        project_store: ProjectStore = app.state.project_store
+        job_store: JobStore = app.state.job_store
+        try:
+            project_store.load_project(project_id)
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+        for record in job_store.list_job_records():
+            if record.project_id != project_id:
+                continue
+            try:
+                job_store.delete_job(record.id)
+            except ActiveJobDeletionError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "Projects with active jobs cannot be deleted; wait for those jobs to "
+                        "complete or fail first."
+                    ),
+                ) from exc
+        project_store.delete_project(project_id)
+        return {"deleted": True}
+
+    @app.get("/v1/projects/{project_id}/jobs", response_model=ProjectJobsResponse)
+    def list_project_jobs(project_id: str) -> ProjectJobsResponse:
+        project_store: ProjectStore = app.state.project_store
+        job_store: JobStore = app.state.job_store
+        try:
+            project_store.load_project(project_id)
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
+        jobs = [
+            _job_status_response(job_store, record)
+            for record in job_store.list_job_records()
+            if record.project_id == project_id
+        ]
+        return ProjectJobsResponse(
+            project_id=project_id,
+            jobs=jobs,
+        )
 
     @app.post("/v1/inspect", response_model=InspectResponse)
     def inspect_endpoint(request: InspectRequest) -> InspectResponse:
@@ -332,13 +558,32 @@ def create_app(*, data_dir: Path | None = None) -> FastAPI:
             request.results,
             existing_suppressions_yaml=request.existing_suppressions_yaml,
         )
-        return TriageResponse(suppressions=suppressions_file, added_count=added_count)
+        rendered_yaml = yaml.safe_dump(
+            suppressions_file.model_dump(mode="json", exclude_none=True),
+            sort_keys=False,
+            allow_unicode=False,
+        )
+        return TriageResponse(
+            suppressions=suppressions_file,
+            added_count=added_count,
+            rendered_yaml=rendered_yaml,
+        )
 
     @app.post("/v1/runs", response_model=JobStatusResponse)
     def create_run_job(request: RunRequest) -> JobStatusResponse:
         job_store: JobStore = app.state.job_store
+        project_store: ProjectStore = app.state.project_store
+        if request.project_id is not None:
+            try:
+                project_store.load_project(request.project_id)
+            except ProjectNotFoundError as exc:
+                raise HTTPException(status_code=404, detail="Project not found.") from exc
         record = job_store.create_job(
-            JobRecord(base_url=request.base_url, attack_count=len(request.suite.attacks))
+            JobRecord(
+                base_url=request.base_url,
+                attack_count=len(request.suite.attacks),
+                project_id=request.project_id,
+            )
         )
         thread = threading.Thread(
             target=_run_job_worker,
@@ -456,6 +701,16 @@ def create_app(*, data_dir: Path | None = None) -> FastAPI:
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail="Artifact not found.") from exc
         return FileResponse(path)
+
+    @app.get("/app", include_in_schema=False)
+    def serve_frontend_index():
+        frontend_root: Path = app.state.frontend_dir
+        return _frontend_response(frontend_root, "")
+
+    @app.get("/app/{asset_path:path}", include_in_schema=False)
+    def serve_frontend_asset(asset_path: str):
+        frontend_root: Path = app.state.frontend_dir
+        return _frontend_response(frontend_root, asset_path)
 
     return app
 

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -31,6 +31,21 @@ class ApiJobStatus(StrEnum):
     failed = "failed"
 
 
+class ProjectSourceMode(StrEnum):
+    openapi = "openapi"
+    graphql = "graphql"
+    learned = "learned"
+    capture_upload = "capture_upload"
+
+
+class ProjectStep(StrEnum):
+    source = "source"
+    inspect = "inspect"
+    generate = "generate"
+    run = "run"
+    review = "review"
+
+
 class SourcePayload(BaseModel):
     name: str
     content: str
@@ -85,6 +100,7 @@ class DiscoverResponse(BaseModel):
 
 
 class RunRequest(BaseModel):
+    project_id: str | None = None
     suite: AttackSuite
     base_url: str
     headers: dict[str, str] = Field(default_factory=dict)
@@ -119,6 +135,10 @@ class FindingSummaryResponse(BaseModel):
     attack_id: str
     name: str
     protocol: str
+    kind: str
+    method: str
+    path: str | None = None
+    tags: list[str] = Field(default_factory=list)
     issue: str | None = None
     severity: str
     confidence: str
@@ -152,6 +172,7 @@ class VerifyResponse(BaseModel):
     resolved_findings_count: int
     persisting_findings_count: int
     suppressed_current_findings_count: int
+    current_findings: list[FindingSummaryResponse] = Field(default_factory=list)
     failing_findings: list[FindingSummaryResponse] = Field(default_factory=list)
     new_findings: list[FindingSummaryResponse] = Field(default_factory=list)
     resolved_findings: list[FindingSummaryResponse] = Field(default_factory=list)
@@ -197,6 +218,7 @@ class TriageRequest(BaseModel):
 class TriageResponse(BaseModel):
     suppressions: SuppressionsFile
     added_count: int
+    rendered_yaml: str
 
 
 class JobRecord(BaseModel):
@@ -208,6 +230,7 @@ class JobRecord(BaseModel):
     completed_at: datetime | None = None
     base_url: str
     attack_count: int
+    project_id: str | None = None
     error: str | None = None
 
 
@@ -220,6 +243,7 @@ class JobStatusResponse(BaseModel):
     completed_at: datetime | None = None
     base_url: str
     attack_count: int
+    project_id: str | None = None
     error: str | None = None
     result_available: bool = False
     artifact_names: list[str] = Field(default_factory=list)
@@ -266,3 +290,139 @@ class PruneJobsResponse(BaseModel):
     matched_count: int = 0
     deleted_count: int = 0
     jobs: list[JobRetentionEntry] = Field(default_factory=list)
+
+
+class ProjectInspectDraft(BaseModel):
+    tag: list[str] = Field(default_factory=list)
+    exclude_tag: list[str] = Field(default_factory=list)
+    path: list[str] = Field(default_factory=list)
+    exclude_path: list[str] = Field(default_factory=list)
+
+
+class ProjectGenerateDraft(BaseModel):
+    operation: list[str] = Field(default_factory=list)
+    exclude_operation: list[str] = Field(default_factory=list)
+    method: list[str] = Field(default_factory=list)
+    exclude_method: list[str] = Field(default_factory=list)
+    kind: list[str] = Field(default_factory=list)
+    exclude_kind: list[str] = Field(default_factory=list)
+    tag: list[str] = Field(default_factory=list)
+    exclude_tag: list[str] = Field(default_factory=list)
+    path: list[str] = Field(default_factory=list)
+    exclude_path: list[str] = Field(default_factory=list)
+    pack_names: list[str] = Field(default_factory=list)
+    auto_workflows: bool = False
+    workflow_pack_names: list[str] = Field(default_factory=list)
+
+
+class ProjectRunDraft(BaseModel):
+    base_url: str = ""
+    headers: dict[str, str] = Field(default_factory=dict)
+    query: dict[str, Any] = Field(default_factory=dict)
+    timeout: float = 10.0
+    store_artifacts: bool = True
+    auth_plugin_names: list[str] = Field(default_factory=list)
+    auth_config_yaml: str | None = None
+    auth_profile_names: list[str] = Field(default_factory=list)
+    profile_file_yaml: str | None = None
+    profile_names: list[str] = Field(default_factory=list)
+    operation: list[str] = Field(default_factory=list)
+    exclude_operation: list[str] = Field(default_factory=list)
+    method: list[str] = Field(default_factory=list)
+    exclude_method: list[str] = Field(default_factory=list)
+    kind: list[str] = Field(default_factory=list)
+    exclude_kind: list[str] = Field(default_factory=list)
+    tag: list[str] = Field(default_factory=list)
+    exclude_tag: list[str] = Field(default_factory=list)
+    path: list[str] = Field(default_factory=list)
+    exclude_path: list[str] = Field(default_factory=list)
+
+
+class ProjectReviewDraft(BaseModel):
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    min_severity: str = "high"
+    min_confidence: str = "medium"
+
+
+class ProjectArtifacts(BaseModel):
+    learned_model: LearnedModel | None = None
+    inspect_result: InspectResponse | None = None
+    generated_suite: AttackSuite | None = None
+    latest_results: AttackResults | None = None
+    latest_summary: ResultsSummary | None = None
+    latest_verification: VerifyResponse | None = None
+    latest_markdown_report: str | None = None
+    latest_html_report: str | None = None
+    latest_suppressions: SuppressionsFile | None = None
+    latest_promoted_suite: AttackSuite | None = None
+    last_run_job_id: str | None = None
+
+
+class ProjectRecord(BaseModel):
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    name: str
+    source_mode: ProjectSourceMode = ProjectSourceMode.openapi
+    active_step: ProjectStep = ProjectStep.source
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    graphql_endpoint: str = "/graphql"
+    source: SourcePayload | None = None
+    discover_inputs: list[SourcePayload] = Field(default_factory=list)
+    inspect_draft: ProjectInspectDraft = Field(default_factory=ProjectInspectDraft)
+    generate_draft: ProjectGenerateDraft = Field(default_factory=ProjectGenerateDraft)
+    run_draft: ProjectRunDraft = Field(default_factory=ProjectRunDraft)
+    review_draft: ProjectReviewDraft = Field(default_factory=ProjectReviewDraft)
+    artifacts: ProjectArtifacts = Field(default_factory=ProjectArtifacts)
+
+
+class ProjectCreateRequest(BaseModel):
+    name: str
+    source_mode: ProjectSourceMode = ProjectSourceMode.openapi
+    active_step: ProjectStep = ProjectStep.source
+    graphql_endpoint: str = "/graphql"
+    source: SourcePayload | None = None
+    discover_inputs: list[SourcePayload] = Field(default_factory=list)
+    inspect_draft: ProjectInspectDraft = Field(default_factory=ProjectInspectDraft)
+    generate_draft: ProjectGenerateDraft = Field(default_factory=ProjectGenerateDraft)
+    run_draft: ProjectRunDraft = Field(default_factory=ProjectRunDraft)
+    review_draft: ProjectReviewDraft = Field(default_factory=ProjectReviewDraft)
+    artifacts: ProjectArtifacts = Field(default_factory=ProjectArtifacts)
+
+
+class ProjectUpdateRequest(BaseModel):
+    name: str | None = None
+    source_mode: ProjectSourceMode | None = None
+    active_step: ProjectStep | None = None
+    graphql_endpoint: str | None = None
+    source: SourcePayload | None = None
+    discover_inputs: list[SourcePayload] | None = None
+    inspect_draft: ProjectInspectDraft | None = None
+    generate_draft: ProjectGenerateDraft | None = None
+    run_draft: ProjectRunDraft | None = None
+    review_draft: ProjectReviewDraft | None = None
+    artifacts: ProjectArtifacts | None = None
+
+
+class ProjectSummaryResponse(BaseModel):
+    id: str
+    name: str
+    source_mode: ProjectSourceMode
+    active_step: ProjectStep
+    created_at: datetime
+    updated_at: datetime
+    source_name: str | None = None
+    job_count: int = 0
+    last_run_job_id: str | None = None
+    last_run_status: ApiJobStatus | None = None
+    last_run_at: datetime | None = None
+    active_flagged_count: int | None = None
+
+
+class ProjectListResponse(BaseModel):
+    projects: list[ProjectSummaryResponse] = Field(default_factory=list)
+
+
+class ProjectJobsResponse(BaseModel):
+    project_id: str
+    jobs: list[JobStatusResponse] = Field(default_factory=list)

--- a/src/knives_out/api_store.py
+++ b/src/knives_out/api_store.py
@@ -181,8 +181,7 @@ class JobStore:
         rmtree(self._job_dir_path_for_delete(job_id))
         return deleted
 
-    def job_status_response(self, job_id: str) -> JobStatusResponse:
-        record = self.load_job(job_id)
+    def _job_status_from_record(self, record: JobRecord) -> JobStatusResponse:
         return JobStatusResponse(
             id=record.id,
             kind=record.kind,
@@ -192,7 +191,26 @@ class JobStore:
             completed_at=record.completed_at,
             base_url=record.base_url,
             attack_count=record.attack_count,
+            project_id=record.project_id,
             error=record.error,
-            result_available=self.result_exists(job_id),
-            artifact_names=self.list_artifacts(job_id),
+            result_available=self.result_exists(record.id),
+            artifact_names=self.list_artifacts(record.id),
         )
+
+    def list_job_statuses(
+        self,
+        *,
+        project_id: str | None = None,
+        statuses: set[ApiJobStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[JobStatusResponse]:
+        jobs: list[JobStatusResponse] = []
+        for record in self.list_jobs(statuses=statuses, limit=limit):
+            if project_id is not None and record.project_id != project_id:
+                continue
+            jobs.append(self._job_status_from_record(record))
+        return jobs
+
+    def job_status_response(self, job_id: str) -> JobStatusResponse:
+        record = self.load_job(job_id)
+        return self._job_status_from_record(record)

--- a/src/knives_out/project_store.py
+++ b/src/knives_out/project_store.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from time import monotonic, sleep
+from uuid import uuid4
+
+from pydantic import ValidationError
+
+from knives_out.api_models import ProjectRecord
+
+
+class ProjectNotFoundError(FileNotFoundError):
+    pass
+
+
+class ProjectStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.projects_dir = root / "projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    def project_dir(self, project_id: str) -> Path:
+        return self.projects_dir / project_id
+
+    def record_path(self, project_id: str) -> Path:
+        return self.project_dir(project_id) / "project.json"
+
+    def _write_json_atomic(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
+        temp_path.write_text(content, encoding="utf-8")
+        temp_path.replace(path)
+
+    def _load_json_with_retries(
+        self,
+        path: Path,
+        model,
+        *,
+        timeout_seconds: float = 0.2,
+        retry_delay_seconds: float = 0.01,
+    ):
+        last_error: ValidationError | OSError | None = None
+        deadline = monotonic() + timeout_seconds
+
+        while True:
+            try:
+                raw = path.read_text(encoding="utf-8")
+                return model.model_validate_json(raw)
+            except (OSError, ValidationError) as exc:
+                last_error = exc
+                if monotonic() >= deadline:
+                    raise
+                sleep(retry_delay_seconds)
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError(f"Unable to load JSON from {path}.")
+
+    def _write_record(self, record: ProjectRecord) -> None:
+        self._write_json_atomic(
+            self.record_path(record.id),
+            record.model_dump_json(indent=2, exclude_none=True),
+        )
+
+    def create_project(self, record: ProjectRecord) -> ProjectRecord:
+        self.project_dir(record.id).mkdir(parents=True, exist_ok=True)
+        self._write_record(record)
+        return record
+
+    def load_project(self, project_id: str) -> ProjectRecord:
+        path = self.record_path(project_id)
+        if not path.exists():
+            raise ProjectNotFoundError(project_id)
+        return self._load_json_with_retries(path, ProjectRecord)
+
+    def update_project(self, record: ProjectRecord) -> ProjectRecord:
+        self._write_record(record)
+        return record
+
+    def list_projects(self) -> list[ProjectRecord]:
+        records: list[ProjectRecord] = []
+        for record_path in sorted(self.projects_dir.glob("*/project.json")):
+            records.append(self._load_json_with_retries(record_path, ProjectRecord))
+        records.sort(key=lambda record: record.updated_at, reverse=True)
+        return records
+
+    def delete_project(self, project_id: str) -> None:
+        project_dir = self.project_dir(project_id)
+        if not project_dir.exists():
+            raise ProjectNotFoundError(project_id)
+        shutil.rmtree(project_dir)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import time
+
+import httpx
+from fastapi.testclient import TestClient
+
+from knives_out.api import create_app
+from knives_out.models import AttackCase, AttackSuite
+
+
+class _StubClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+
+    def __enter__(self) -> _StubClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def request(self, *_: object, **__: object) -> httpx.Response:
+        return self._response
+
+
+def _install_stub_response(monkeypatch, response: httpx.Response) -> None:
+    monkeypatch.setattr(
+        "knives_out.runner.httpx.Client",
+        lambda **_: _StubClient(response),
+    )
+
+
+def _attack_suite() -> AttackSuite:
+    return AttackSuite(
+        source="unit",
+        attacks=[
+            AttackCase(
+                id="atk_api",
+                name="Missing auth",
+                kind="missing_auth",
+                operation_id="getSecret",
+                method="GET",
+                path="/secrets",
+                description="Missing auth attack",
+            )
+        ],
+    )
+
+
+def test_project_crud_endpoints_and_project_summaries(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    create_response = client.post("/v1/projects", json={"name": "Workbench demo"})
+
+    assert create_response.status_code == 200
+    created_project = create_response.json()
+    assert created_project["source_mode"] == "openapi"
+    assert created_project["source"]["name"] == "openapi.yaml"
+
+    project_id = created_project["id"]
+
+    list_response = client.get("/v1/projects")
+    assert list_response.status_code == 200
+    assert list_response.json()["projects"] == [
+        {
+            "id": project_id,
+            "name": "Workbench demo",
+            "source_mode": "openapi",
+            "active_step": "source",
+            "created_at": created_project["created_at"],
+            "updated_at": created_project["updated_at"],
+            "source_name": "openapi.yaml",
+            "job_count": 0,
+            "last_run_job_id": None,
+            "last_run_status": None,
+            "last_run_at": None,
+            "active_flagged_count": None,
+        }
+    ]
+
+    patch_response = client.patch(
+        f"/v1/projects/{project_id}",
+        json={
+            "name": "GraphQL workbench",
+            "source_mode": "graphql",
+            "source": {
+                "name": "schema.graphql",
+                "content": "type Query { ping: String! }",
+            },
+            "active_step": "generate",
+        },
+    )
+
+    assert patch_response.status_code == 200
+    patched_project = patch_response.json()
+    assert patched_project["name"] == "GraphQL workbench"
+    assert patched_project["source_mode"] == "graphql"
+    assert patched_project["active_step"] == "generate"
+    assert patched_project["source"]["name"] == "schema.graphql"
+
+    get_response = client.get(f"/v1/projects/{project_id}")
+    assert get_response.status_code == 200
+    assert get_response.json()["name"] == "GraphQL workbench"
+
+    jobs_response = client.get(f"/v1/projects/{project_id}/jobs")
+    assert jobs_response.status_code == 200
+    assert jobs_response.json() == {"project_id": project_id, "jobs": []}
+
+    delete_response = client.delete(f"/v1/projects/{project_id}")
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"deleted": True}
+    assert client.get(f"/v1/projects/{project_id}").status_code == 404
+
+
+def test_run_jobs_are_attached_to_projects_and_removed_on_project_delete(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _install_stub_response(monkeypatch, httpx.Response(422, text="missing auth"))
+    client = TestClient(create_app(data_dir=tmp_path))
+    create_response = client.post("/v1/projects", json={"name": "Run demo"})
+    project_id = create_response.json()["id"]
+
+    run_response = client.post(
+        "/v1/runs",
+        json={
+            "project_id": project_id,
+            "suite": _attack_suite().model_dump(mode="json"),
+            "base_url": "https://example.com",
+            "store_artifacts": False,
+        },
+    )
+
+    assert run_response.status_code == 200
+    job_id = run_response.json()["id"]
+    assert run_response.json()["project_id"] == project_id
+
+    jobs_payload = None
+    for _ in range(50):
+        jobs_response = client.get(f"/v1/projects/{project_id}/jobs")
+        assert jobs_response.status_code == 200
+        jobs_payload = jobs_response.json()
+        if jobs_payload["jobs"] and jobs_payload["jobs"][0]["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    assert jobs_payload is not None
+    assert jobs_payload["jobs"][0]["id"] == job_id
+    assert jobs_payload["jobs"][0]["project_id"] == project_id
+    assert client.get(f"/v1/jobs/{job_id}").json()["project_id"] == project_id
+
+    delete_response = client.delete(f"/v1/projects/{project_id}")
+    assert delete_response.status_code == 200
+    assert client.get(f"/v1/jobs/{job_id}").status_code == 404
+
+
+def test_frontend_routes_serve_index_assets_and_spa_fallback(tmp_path) -> None:
+    frontend_dir = tmp_path / "frontend-dist"
+    asset_dir = frontend_dir / "assets"
+    asset_dir.mkdir(parents=True)
+    (frontend_dir / "index.html").write_text(
+        "<!doctype html><div>Workbench</div>", encoding="utf-8"
+    )
+    (asset_dir / "main.js").write_text("console.log('ready')", encoding="utf-8")
+
+    client = TestClient(create_app(data_dir=tmp_path / "api-data", frontend_dir=frontend_dir))
+
+    index_response = client.get("/app")
+    assert index_response.status_code == 200
+    assert "Workbench" in index_response.text
+
+    asset_response = client.get("/app/assets/main.js")
+    assert asset_response.status_code == 200
+    assert "ready" in asset_response.text
+
+    fallback_response = client.get("/app/projects/demo")
+    assert fallback_response.status_code == 200
+    assert "Workbench" in fallback_response.text
+
+    missing_asset_response = client.get("/app/assets/missing.js")
+    assert missing_asset_response.status_code == 404


### PR DESCRIPTION
## Summary
- add a FastAPI-served React/Vite workbench for saved projects and guided attack workflows
- add project persistence endpoints and project-linked jobs for the web UI
- document how to build and run the web workbench from the README

## Why
The repo had a local API but no first-class browser workflow for creating projects, generating suites, running them, and reviewing findings in one place.

## Impact
Developers can now use a local web interface at `/app/` for source ingestion, inspect/generate/run flows, and native review panels, while keeping data local under `.knives-out-api/`.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest -q`
- `.venv/bin/pytest --cov=src/knives_out --cov-report=term -q`
- `npm run test -- --run` (in `frontend/`)
- `npm run build` (in `frontend/`)
