### PR TITLE
[codex] Redirect root to workbench and prepare v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knives-out"
-version = "0.1.0"
+version = "0.2.0"
 description = "Adversarial testing for APIs from OpenAPI and GraphQL schemas."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/knives_out/__init__.py
+++ b/src/knives_out/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -9,8 +9,9 @@ from typing import Annotated
 
 import yaml
 from fastapi import FastAPI, HTTPException, Query
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 
+from knives_out import __version__
 from knives_out.api_models import (
     ApiJobStatus,
     ArtifactListResponse,
@@ -330,7 +331,7 @@ def create_app(
 ) -> FastAPI:
     app = FastAPI(
         title="knives-out API",
-        version="0.11.0",
+        version=__version__,
         description="Local-first API for adversarial API testing from specs and observed traffic.",
     )
     root = data_dir or _default_data_dir()
@@ -341,6 +342,10 @@ def create_app(
     @app.get("/healthz")
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/", include_in_schema=False)
+    def root():
+        return RedirectResponse(url="/app/")
 
     @app.get("/v1/projects", response_model=ProjectListResponse)
     def list_projects() -> ProjectListResponse:
@@ -704,6 +709,11 @@ def create_app(
 
     @app.get("/app", include_in_schema=False)
     def serve_frontend_index():
+        frontend_root: Path = app.state.frontend_dir
+        return _frontend_response(frontend_root, "")
+
+    @app.get("/app/", include_in_schema=False)
+    def serve_frontend_index_slash():
         frontend_root: Path = app.state.frontend_dir
         return _frontend_response(frontend_root, "")
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -165,9 +165,17 @@ def test_frontend_routes_serve_index_assets_and_spa_fallback(tmp_path) -> None:
 
     client = TestClient(create_app(data_dir=tmp_path / "api-data", frontend_dir=frontend_dir))
 
+    root_response = client.get("/", follow_redirects=False)
+    assert root_response.status_code == 307
+    assert root_response.headers["location"] == "/app/"
+
     index_response = client.get("/app")
     assert index_response.status_code == 200
     assert "Workbench" in index_response.text
+
+    slash_index_response = client.get("/app/")
+    assert slash_index_response.status_code == 200
+    assert "Workbench" in slash_index_response.text
 
     asset_response = client.get("/app/assets/main.js")
     assert asset_response.status_code == 200


### PR DESCRIPTION
## Summary
- redirect `/` to `/app/` so the local server opens at the web workbench by default
- add a backend regression test for `/` and `/app/`
- bump package version metadata to `0.2.0` for the release tag

## Why
The workbench launch landed on `main`, but browsing to `http://localhost:8787/` returned a JSON 404. That is a rough first-run experience and also leaves the upcoming release tag out of sync with package metadata.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_web_app.py -q`
- `.venv/bin/pytest -q`
- `npm run test -- --run` (in `frontend/`)
- `npm run build` (in `frontend/`)
