### PR TITLE
Add GitHub Pages deployment for the web workbench

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - uses: actions/configure-pages@v5
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Build frontend for GitHub Pages
+        working-directory: frontend
+        env:
+          VITE_APP_BASE_PATH: "/${{ github.event.repository.name }}/"
+          VITE_API_BASE_URL: ""
+        run: npm run build
+      - name: Add SPA fallback
+        run: cp frontend/dist/index.html frontend/dist/404.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -251,6 +251,22 @@ Then open [http://127.0.0.1:4173/app/](http://127.0.0.1:4173/app/). The Vite dev
 The workbench is intentionally local-only and single-user in v1. Saved project drafts, jobs, and
 artifacts all live under `.knives-out-api/` unless you override `KNIVES_OUT_API_DATA_DIR`.
 
+### GitHub Pages
+
+This repository also includes a GitHub Pages workflow at `.github/workflows/pages.yml` that
+publishes the frontend as a static SPA under the repository path, for example
+`https://keithwegner.github.io/knives-out/`.
+
+That Pages site is only the frontend shell. To make it functional you must point it at a reachable
+`knives-out` API:
+
+1. deploy the API somewhere reachable over HTTPS
+2. enable CORS on that API with `KNIVES_OUT_CORS_ALLOW_ORIGINS=https://keithwegner.github.io`
+3. open the published Pages site and set the API base URL in the `API endpoint` panel
+
+If you prefer a baked-in default for the static build, set `VITE_API_BASE_URL` when building the
+frontend for Pages.
+
 ## Local API
 
 `knives-out` can also run as a local-first HTTP API instead of only as a CLI.
@@ -263,6 +279,14 @@ knives-out serve --host 127.0.0.1 --port 8787
 
 By default the API stores job state and request/response artifacts under `.knives-out-api/`.
 Set `KNIVES_OUT_API_DATA_DIR` if you want that store somewhere else.
+
+For browser clients hosted on a different origin, set `KNIVES_OUT_CORS_ALLOW_ORIGINS` to a
+comma-separated list of allowed origins, for example:
+
+```bash
+export KNIVES_OUT_CORS_ALLOW_ORIGINS="https://keithwegner.github.io"
+knives-out serve --host 0.0.0.0 --port 8787
+```
 
 The synchronous endpoints mirror the short CLI flows:
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -17,9 +17,10 @@ import type {
   TriageResponse,
   VerifyResponse,
 } from "./types";
+import { buildApiUrl } from "./apiConfig";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(path, {
+  const response = await fetch(buildApiUrl(path), {
     ...init,
     headers: {
       ...(init?.body ? { "Content-Type": "application/json" } : {}),
@@ -37,6 +38,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   }
 
   return (await response.json()) as T;
+}
+
+export function getHealthStatus() {
+  return request<{ status: string }>("/healthz");
 }
 
 export function listProjects() {

--- a/frontend/src/apiConfig.test.ts
+++ b/frontend/src/apiConfig.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildApiUrl,
+  describeApiBaseUrl,
+  getApiBaseUrl,
+  normalizeApiBaseUrl,
+  persistApiBaseUrl,
+} from "./apiConfig";
+
+describe("apiConfig", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes and persists configured API base URLs", () => {
+    expect(normalizeApiBaseUrl(" https://api.example.com/ ")).toBe("https://api.example.com");
+    expect(persistApiBaseUrl("https://api.example.com/")).toBe("https://api.example.com");
+    expect(getApiBaseUrl()).toBe("https://api.example.com");
+    expect(buildApiUrl("/v1/projects")).toBe("https://api.example.com/v1/projects");
+  });
+
+  it("clears back to same-origin mode", () => {
+    persistApiBaseUrl("https://api.example.com");
+    expect(describeApiBaseUrl(getApiBaseUrl())).toBe("https://api.example.com");
+
+    persistApiBaseUrl("");
+
+    expect(getApiBaseUrl()).toBe("");
+    expect(buildApiUrl("/healthz")).toBe("/healthz");
+    expect(describeApiBaseUrl("")).toBe("same origin");
+  });
+});

--- a/frontend/src/apiConfig.ts
+++ b/frontend/src/apiConfig.ts
@@ -1,0 +1,49 @@
+const API_BASE_STORAGE_KEY = "knives-out.api-base-url";
+
+function trimTrailingSlash(value: string): string {
+  if (!value || value === "/") {
+    return value;
+  }
+  return value.replace(/\/+$/, "");
+}
+
+export function normalizeApiBaseUrl(value: string | null | undefined): string {
+  if (!value) {
+    return "";
+  }
+  return trimTrailingSlash(value.trim());
+}
+
+export function defaultApiBaseUrl(): string {
+  return normalizeApiBaseUrl(import.meta.env.VITE_API_BASE_URL);
+}
+
+export function getApiBaseUrl(): string {
+  if (typeof window === "undefined") {
+    return defaultApiBaseUrl();
+  }
+  const stored = window.localStorage.getItem(API_BASE_STORAGE_KEY);
+  return stored === null ? defaultApiBaseUrl() : normalizeApiBaseUrl(stored);
+}
+
+export function persistApiBaseUrl(value: string): string {
+  const normalized = normalizeApiBaseUrl(value);
+  if (typeof window !== "undefined") {
+    if (normalized) {
+      window.localStorage.setItem(API_BASE_STORAGE_KEY, normalized);
+    } else {
+      window.localStorage.removeItem(API_BASE_STORAGE_KEY);
+    }
+  }
+  return normalized;
+}
+
+export function describeApiBaseUrl(value: string): string {
+  return value || "same origin";
+}
+
+export function buildApiUrl(path: string): string {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  const base = getApiBaseUrl();
+  return base ? `${base}${cleanPath}` : cleanPath;
+}

--- a/frontend/src/components/ApiConnectionPanel.tsx
+++ b/frontend/src/components/ApiConnectionPanel.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { describeApiBaseUrl } from "../apiConfig";
+
+interface ApiConnectionPanelProps {
+  apiBaseUrl: string;
+  description: string;
+  statusLabel: string;
+  statusTone: "completed" | "failed" | "pending" | "idle";
+  title: string;
+  onApply: (value: string) => void;
+}
+
+export default function ApiConnectionPanel({
+  apiBaseUrl,
+  description,
+  statusLabel,
+  statusTone,
+  title,
+  onApply,
+}: ApiConnectionPanelProps) {
+  const [draft, setDraft] = useState(apiBaseUrl);
+
+  useEffect(() => {
+    setDraft(apiBaseUrl);
+  }, [apiBaseUrl]);
+
+  return (
+    <section className="panel connection-panel">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">API endpoint</p>
+          <h2>{title}</h2>
+        </div>
+        <div className={`status-chip status-${statusTone}`}>{statusLabel}</div>
+      </div>
+      <p className="hero-body">{description}</p>
+      <div className="field-grid field-grid-2">
+        <label className="field">
+          <span className="field-label">Base URL</span>
+          <input
+            aria-label="API base URL"
+            className="text-input"
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="https://api.example.com"
+            value={draft}
+          />
+          <span className="field-hint">
+            Leave this empty when the frontend is served by `knives-out serve`. Use an absolute
+            URL for GitHub Pages or other static hosts.
+          </span>
+        </label>
+        <div className="connection-meta">
+          <div className="summary-card">
+            <span>Current endpoint</span>
+            <strong>{describeApiBaseUrl(apiBaseUrl)}</strong>
+          </div>
+          <div className="action-row">
+            <button className="secondary-button" onClick={() => onApply(draft)} type="button">
+              Save endpoint
+            </button>
+            <button className="ghost-button" onClick={() => onApply("")} type="button">
+              Use same origin
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,11 +6,12 @@ import App from "./App";
 import "./styles.css";
 
 const queryClient = new QueryClient();
+const routerBase = import.meta.env.BASE_URL === "/" ? undefined : import.meta.env.BASE_URL.replace(/\/$/, "");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename="/app">
+      <BrowserRouter basename={routerBase}>
         <App />
       </BrowserRouter>
     </QueryClientProvider>

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "./HomePage";
@@ -24,26 +24,33 @@ describe("HomePage", () => {
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        Response.json({
-          projects: [
-            {
-              id: "project-1",
-              name: "Storefront triage",
-              source_mode: "openapi",
-              active_step: "review",
-              created_at: "2026-04-13T20:00:00Z",
-              updated_at: "2026-04-13T20:05:00Z",
-              source_name: "storefront.yaml",
-              job_count: 2,
-              last_run_job_id: "job-1",
-              last_run_status: "completed",
-              last_run_at: "2026-04-13T20:06:00Z",
-              active_flagged_count: 3,
-            },
-          ],
-        }),
-      ),
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/healthz")) {
+          return Response.json({ status: "ok" });
+        }
+        if (url.endsWith("/v1/projects")) {
+          return Response.json({
+            projects: [
+              {
+                id: "project-1",
+                name: "Storefront triage",
+                source_mode: "openapi",
+                active_step: "review",
+                created_at: "2026-04-13T20:00:00Z",
+                updated_at: "2026-04-13T20:05:00Z",
+                source_name: "storefront.yaml",
+                job_count: 2,
+                last_run_job_id: "job-1",
+                last_run_status: "completed",
+                last_run_at: "2026-04-13T20:06:00Z",
+                active_flagged_count: 3,
+              },
+            ],
+          });
+        }
+        throw new Error(`Unhandled fetch for ${url}`);
+      }),
     );
   });
 
@@ -55,8 +62,29 @@ describe("HomePage", () => {
     renderHomePage();
 
     expect(await screen.findByText("Storefront triage")).toBeInTheDocument();
+    expect(screen.getByText("connected")).toBeInTheDocument();
     expect(screen.getByText("storefront.yaml")).toBeInTheDocument();
     expect(screen.getByText("completed")).toBeInTheDocument();
     expect(screen.getByText("Open")).toBeInTheDocument();
+  });
+
+  it("saves a custom API endpoint", async () => {
+    renderHomePage();
+
+    await screen.findByText("Storefront triage");
+    const apiBaseInput = screen.getAllByLabelText("API base URL").at(-1);
+    if (!apiBaseInput) {
+      throw new Error("Expected the API base URL input to render.");
+    }
+    fireEvent.change(apiBaseInput, {
+      target: { value: "https://api.example.com/" },
+    });
+    const saveButton = screen.getAllByRole("button", { name: "Save endpoint" }).at(-1);
+    if (!saveButton) {
+      throw new Error("Expected the save endpoint action to render.");
+    }
+    fireEvent.click(saveButton);
+
+    expect(window.localStorage.getItem("knives-out.api-base-url")).toBe("https://api.example.com");
   });
 });

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,16 +1,26 @@
 import { startTransition, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
-import { createProject, deleteProject, listProjects } from "../api";
+import { getHealthStatus, createProject, deleteProject, listProjects } from "../api";
+import { getApiBaseUrl, persistApiBaseUrl } from "../apiConfig";
+import ApiConnectionPanel from "../components/ApiConnectionPanel";
 
 export default function HomePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [newProjectName, setNewProjectName] = useState("Security workbench");
+  const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
 
   const projectListQuery = useQuery({
-    queryKey: ["projects"],
+    queryKey: ["projects", apiBaseUrl],
     queryFn: listProjects,
+    retry: false,
+  });
+
+  const healthQuery = useQuery({
+    queryKey: ["health", apiBaseUrl],
+    queryFn: getHealthStatus,
+    retry: false,
   });
 
   const createProjectMutation = useMutation({
@@ -29,6 +39,36 @@ export default function HomePage() {
       await queryClient.invalidateQueries({ queryKey: ["projects"] });
     },
   });
+
+  function applyApiBase(nextValue: string) {
+    const normalized = persistApiBaseUrl(nextValue);
+    setApiBaseUrl(normalized);
+    void queryClient.invalidateQueries();
+  }
+
+  const homeError =
+    projectListQuery.error instanceof Error
+      ? projectListQuery.error.message
+      : createProjectMutation.error instanceof Error
+        ? createProjectMutation.error.message
+        : deleteProjectMutation.error instanceof Error
+          ? deleteProjectMutation.error.message
+          : null;
+  const apiStatusTone = healthQuery.isLoading
+    ? "pending"
+    : healthQuery.isSuccess
+      ? "completed"
+      : "failed";
+  const apiStatusLabel = healthQuery.isLoading
+    ? "checking"
+    : healthQuery.isSuccess
+      ? "connected"
+      : "unreachable";
+  const apiDescription = healthQuery.isSuccess
+    ? "The workbench can reach the configured API. Projects and runs will use this endpoint."
+    : apiBaseUrl
+      ? "The configured API endpoint is not responding yet. Make sure the deployed backend is reachable and allows cross-origin requests."
+      : "This static frontend needs a reachable knives-out API when it is not served by `knives-out serve` on the same origin.";
 
   return (
     <main className="shell">
@@ -66,6 +106,17 @@ export default function HomePage() {
         </form>
       </section>
 
+      {homeError ? <div className="error-banner">{homeError}</div> : null}
+
+      <ApiConnectionPanel
+        apiBaseUrl={apiBaseUrl}
+        description={apiDescription}
+        onApply={applyApiBase}
+        statusLabel={apiStatusLabel}
+        statusTone={apiStatusTone}
+        title="Choose where the UI talks to the API"
+      />
+
       <section className="panel">
         <div className="section-heading">
           <div>
@@ -79,8 +130,14 @@ export default function HomePage() {
         </div>
 
         {projectListQuery.isLoading ? <p className="empty-copy">Loading projects…</p> : null}
+        {!projectListQuery.isLoading && projectListQuery.isError ? (
+          <div className="empty-state">
+            <p>Projects could not be loaded from the configured API.</p>
+            <p>Check the API endpoint panel above, then retry after the backend is reachable.</p>
+          </div>
+        ) : null}
 
-        {!projectListQuery.isLoading && !projectListQuery.data?.projects.length ? (
+        {!projectListQuery.isLoading && !projectListQuery.isError && !projectListQuery.data?.projects.length ? (
           <div className="empty-state">
             <p>No saved projects yet.</p>
             <p>Start with an OpenAPI or GraphQL source and the workbench will hold the drafts.</p>

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -1,6 +1,8 @@
 import { useDeferredValue, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
+import { getApiBaseUrl, persistApiBaseUrl } from "../apiConfig";
+import ApiConnectionPanel from "../components/ApiConnectionPanel";
 import CodeEditor from "../components/CodeEditor";
 import {
   createRun,
@@ -251,6 +253,7 @@ export default function ProjectWorkbenchPage() {
   const { projectId } = useParams();
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<ProjectRecord | null>(null);
+  const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
   const [hasPendingSave, setHasPendingSave] = useState(false);
   const [sourceText, setSourceText] = useState("");
   const [headersText, setHeadersText] = useState("{}");
@@ -273,16 +276,18 @@ export default function ProjectWorkbenchPage() {
   const deferredReviewFilter = useDeferredValue(reviewFilter.trim().toLowerCase());
 
   const projectQuery = useQuery({
-    queryKey: ["project", projectId],
+    queryKey: ["project", projectId, apiBaseUrl],
     queryFn: () => getProject(projectId!),
     enabled: Boolean(projectId),
+    retry: false,
   });
 
   const projectJobsQuery = useQuery({
-    queryKey: ["projectJobs", projectId],
+    queryKey: ["projectJobs", projectId, apiBaseUrl],
     queryFn: () => listProjectJobs(projectId!),
     enabled: Boolean(projectId),
     refetchInterval: trackedJobId ? 1500 : false,
+    retry: false,
   });
 
   const saveProjectMutation = useMutation({
@@ -324,6 +329,13 @@ export default function ProjectWorkbenchPage() {
       throw new Error("Project is not loaded yet.");
     }
     return draft;
+  }
+
+  function applyApiBase(nextValue: string) {
+    const normalized = persistApiBaseUrl(nextValue);
+    setApiBaseUrl(normalized);
+    setActionError(null);
+    void queryClient.invalidateQueries();
   }
 
   useEffect(() => {
@@ -397,6 +409,35 @@ export default function ProjectWorkbenchPage() {
       <main className="shell">
         <section className="panel">
           <p className="empty-copy">Missing project id.</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (projectQuery.isError) {
+    const errorMessage =
+      projectQuery.error instanceof Error ? projectQuery.error.message : "Could not load the project.";
+    return (
+      <main className="shell">
+        <section className="panel stack">
+          <div>
+            <p className="eyebrow">Workbench unavailable</p>
+            <h2>Could not load this project</h2>
+            <p className="hero-body">{errorMessage}</p>
+          </div>
+          <ApiConnectionPanel
+            apiBaseUrl={apiBaseUrl}
+            description="If you are using GitHub Pages or another static host, point the workbench at a reachable knives-out API and try again."
+            onApply={applyApiBase}
+            statusLabel="retry setup"
+            statusTone="failed"
+            title="Reconnect the workbench"
+          />
+          <div className="action-row">
+            <Link className="ghost-button" to="/">
+              Back to projects
+            </Link>
+          </div>
         </section>
       </main>
     );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -576,6 +576,16 @@ pre {
   background: rgba(255, 255, 255, 0.54);
 }
 
+.connection-panel {
+  margin-top: 22px;
+}
+
+.connection-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 @media (max-width: 1180px) {
   .workbench-layout {
     grid-template-columns: 1fr;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,18 +1,29 @@
 import react from "@vitejs/plugin-react";
+import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
-  base: "/app/",
-  plugins: [react()],
-  server: {
-    port: 4173,
-    proxy: {
-      "/v1": "http://127.0.0.1:8787",
-      "/healthz": "http://127.0.0.1:8787",
+function normalizeBasePath(value: string | undefined): string {
+  const configured = value?.trim() || "/app/";
+  const withLeadingSlash = configured.startsWith("/") ? configured : `/${configured}`;
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    base: normalizeBasePath(env.VITE_APP_BASE_PATH),
+    plugins: [react()],
+    server: {
+      port: 4173,
+      proxy: {
+        "/v1": "http://127.0.0.1:8787",
+        "/healthz": "http://127.0.0.1:8787",
+      },
     },
-  },
-  test: {
-    environment: "jsdom",
-    setupFiles: "./src/test/setup.ts",
-  },
+    test: {
+      environment: "jsdom",
+      setupFiles: "./src/test/setup.ts",
+    },
+  };
 });

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 import yaml
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 
 from knives_out import __version__
@@ -194,6 +195,11 @@ def _default_frontend_dir() -> Path:
     return Path(__file__).resolve().parents[2] / "frontend" / "dist"
 
 
+def _cors_allowed_origins() -> list[str]:
+    configured = os.environ.get("KNIVES_OUT_CORS_ALLOW_ORIGINS", "")
+    return [origin.strip() for origin in configured.split(",") if origin.strip()]
+
+
 def _default_source_for_mode(source_mode: ProjectSourceMode) -> SourcePayload | None:
     if source_mode == ProjectSourceMode.openapi:
         return SourcePayload(name="openapi.yaml", content="")
@@ -334,6 +340,15 @@ def create_app(
         version=__version__,
         description="Local-first API for adversarial API testing from specs and observed traffic.",
     )
+    allowed_origins = _cors_allowed_origins()
+    if allowed_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=allowed_origins,
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
     root = data_dir or _default_data_dir()
     app.state.job_store = JobStore(root)
     app.state.project_store = ProjectStore(root)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -192,3 +192,19 @@ def test_frontend_routes_serve_index_assets_and_spa_fallback(tmp_path) -> None:
 
     missing_asset_response = client.get("/app/assets/missing.js")
     assert missing_asset_response.status_code == 404
+
+
+def test_create_app_applies_configured_cors_origins(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("KNIVES_OUT_CORS_ALLOW_ORIGINS", "https://keithwegner.github.io")
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.options(
+        "/healthz",
+        headers={
+            "Origin": "https://keithwegner.github.io",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://keithwegner.github.io"


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that builds and deploys the static frontend under the repository path
- make the SPA base path and API endpoint configurable so the hosted UI can talk to a reachable knives-out API
- document the Pages deployment flow and add backend CORS coverage for cross-origin browser access

## Testing
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/pytest -q
- ./.venv/bin/pytest --cov=src/knives_out --cov-report=term -q
- npm run test -- --run
- npm run build