### PR TITLE
Advance review workbench baseline and artifact drilldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ knives-out triage results.json --out .knives-out-ignore.yml
 `knives-out` also includes a local-first web workbench for saved projects, guided attack
 generation, background runs, and native review panels.
 
+The review step is now baseline-first: it treats the latest completed run in a saved project as the
+current comparison target, lets you pin an older completed project run as the baseline, and keeps
+that baseline selection in the saved project draft. Raw baseline JSON is still available, but only
+as an advanced external fallback when project history is not the right comparison source.
+Inside that review step, findings in Overview, New, Persisting, and Deltas now open an inline
+evidence drawer for the current compared run. The drawer resolves linked request/response
+artifacts, workflow setup steps, per-profile evidence, and run auth events without forcing you to
+leave the workbench or manually guess artifact filenames.
+
 For normal local use, build the frontend once and let the API serve it under `/app/`:
 
 ```bash
@@ -283,11 +292,15 @@ Longer execution runs use a job resource instead:
 - `DELETE /v1/jobs/{id}`
 - `POST /v1/jobs/prune`
 - `GET /v1/jobs/{id}/result`
+- `GET /v1/jobs/{id}/findings/{attack_id}/evidence`
 - `GET /v1/jobs/{id}/artifacts`
 
 The job collection and per-job status routes include a compact `result_summary` payload whenever a
 run has finished writing `result.json`, so local tools can triage recent runs without downloading
 the full result body first.
+When a caller needs structured drilldown for a current-run finding, `GET /v1/jobs/{id}/findings/{attack_id}/evidence`
+returns the selected result plus typed artifact references, workflow/profile metadata, and run auth
+context, while raw artifact bodies still come from `GET /v1/jobs/{id}/artifacts/{artifact_name}`.
 Cleanup stays explicit and local-only: the delete and prune endpoints only remove completed or failed jobs,
 and active jobs must finish before they can be deleted.
 
@@ -299,6 +312,12 @@ The web workbench also uses project resources for saved drafts and project-scope
 - `PATCH /v1/projects/{id}`
 - `DELETE /v1/projects/{id}`
 - `GET /v1/projects/{id}/jobs`
+- `POST /v1/projects/{id}/review`
+
+`POST /v1/projects/{id}/review` bundles the summary, verify, and report refresh path that the web
+workbench uses. It always reviews the latest completed run with stored results in that project as
+the current run, accepts an optional `baseline_job_id` from the same project, and only falls back
+to external baseline JSON when the review draft switches to external baseline mode.
 
 The API accepts uploaded source content and JSON artifacts in the request body. It does not expose
 arbitrary server-side file reads. FastAPI also publishes the schema at `/openapi.json` and the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -216,6 +216,14 @@ The API mirrors the same JSON artifacts through `POST /v1/inspect`, `POST /v1/ge
 `GET /v1/jobs/{id}` polling.
 Completed jobs expose a compact `result_summary` on the collection and status responses so
 downstream local tools can rank recent runs before fetching full result payloads.
+Saved projects also expose `GET /v1/projects/{id}/jobs` plus `POST /v1/projects/{id}/review` for
+the workbench’s baseline-aware review loop. That review endpoint always compares the latest
+completed run in the project against an optional pinned `baseline_job_id` from the same project,
+with external baseline JSON kept as an explicit advanced fallback.
+For current-run drilldown, `GET /v1/jobs/{id}/findings/{attack_id}/evidence` returns the selected
+finding result, typed artifact references derived from stored filenames, workflow/profile metadata,
+and the run’s auth-event context. Raw artifact bodies stay on
+`GET /v1/jobs/{id}/artifacts/{artifact_name}` so local tools can load them lazily.
 When local tools need cleanup, use `DELETE /v1/jobs/{id}` for a specific completed or failed run or
 `POST /v1/jobs/prune` to remove older completed/failed jobs in batch.
 Use `KNIVES_OUT_API_DATA_DIR` when you want the job store somewhere other than `.knives-out-api/`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,6 +28,12 @@ guesswork.
 - v0.15: staged GraphQL subscription coverage
   - ships subscription-root discovery plus bounded `graphql-transport-ws` execution in the
     existing generate/run/report pipeline
+- v0.16: ReviewOps baseline workbench
+  - ships project-scoped review refresh, pinned baseline run selection, diff-first review tabs,
+    and advanced external baseline fallback in the local web workbench
+- v0.17: Artifact deep dive drawer
+  - ships finding-first current-run evidence drilldown, typed artifact references, and inline
+    request/response, workflow, profile, and auth-event inspection in the review workbench
 
 ## v0.12 — local-first HTTP API
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,9 +5,13 @@ import type {
   DiscoverResponse,
   GenerateResponse,
   InspectResponse,
+  JobArtifactDocument,
+  JobFindingEvidenceResponse,
   JobStatusResponse,
   ProjectJobsResponse,
   ProjectListResponse,
+  ProjectReviewRequest,
+  ProjectReviewResponse,
   ProjectRecord,
   ProjectReviewDraft,
   PromoteResponse,
@@ -37,6 +41,22 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   }
 
   return (await response.json()) as T;
+}
+
+async function requestText(path: string, init?: RequestInit): Promise<string> {
+  const response = await fetch(path, {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}.`);
+  }
+
+  return await response.text();
 }
 
 export function listProjects() {
@@ -69,6 +89,23 @@ export function deleteProject(projectId: string) {
 
 export function listProjectJobs(projectId: string) {
   return request<ProjectJobsResponse>(`/v1/projects/${projectId}/jobs`);
+}
+
+export function refreshProjectReview(
+  projectId: string,
+  review: ProjectReviewDraft | ProjectReviewRequest,
+) {
+  return request<ProjectReviewResponse>(`/v1/projects/${projectId}/review`, {
+    method: "POST",
+    body: JSON.stringify({
+      baseline_mode: review.baseline_mode ?? null,
+      baseline_job_id: review.baseline_job_id ?? null,
+      baseline: review.baseline ?? null,
+      suppressions_yaml: review.suppressions_yaml ?? null,
+      min_severity: review.min_severity ?? null,
+      min_confidence: review.min_confidence ?? null,
+    }),
+  });
 }
 
 export function inspectSource(payload: {
@@ -147,6 +184,33 @@ export function createRun(payload: {
 
 export function getJobResult(jobId: string) {
   return request<AttackResults>(`/v1/jobs/${jobId}/result`);
+}
+
+export function getJobFindingEvidence(jobId: string, attackId: string) {
+  return request<JobFindingEvidenceResponse>(
+    `/v1/jobs/${encodeURIComponent(jobId)}/findings/${encodeURIComponent(attackId)}/evidence`,
+  );
+}
+
+export async function getJobArtifact(jobId: string, artifactName: string): Promise<JobArtifactDocument> {
+  const encodedName = artifactName
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const text = await requestText(`/v1/jobs/${encodeURIComponent(jobId)}/artifacts/${encodedName}`);
+  try {
+    return {
+      artifact_name: artifactName,
+      format: "json",
+      content: JSON.parse(text) as unknown,
+    };
+  } catch {
+    return {
+      artifact_name: artifactName,
+      format: "text",
+      content: text,
+    };
+  }
 }
 
 export function summarizeResults(results: AttackResults, review: ProjectReviewDraft) {

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -1,10 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectWorkbenchPage from "./ProjectWorkbenchPage";
 
-const projectPayload = {
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const baseProjectPayload = {
   id: "project-1",
   name: "Workbench demo",
   source_mode: "openapi",
@@ -61,6 +65,8 @@ const projectPayload = {
     exclude_path: [],
   },
   review_draft: {
+    baseline_mode: "job",
+    baseline_job_id: null,
     baseline: null,
     suppressions_yaml: null,
     min_severity: "high",
@@ -91,7 +97,20 @@ const projectPayload = {
       finding_severity_counts: { high: 1, medium: 1 },
       finding_confidence_counts: { high: 2 },
       auth_summary: [],
-      top_findings: [],
+      top_findings: [
+        {
+          attack_id: "atk-login",
+          name: "Login failure",
+          protocol: "rest",
+          kind: "missing_auth",
+          issue: "server_error",
+          severity: "high",
+          confidence: "high",
+          status_code: 500,
+          url: "https://example.com/login",
+          schema_status: "not_applicable",
+        },
+      ],
     },
     latest_verification: {
       passed: false,
@@ -138,7 +157,40 @@ const projectPayload = {
         },
       ],
       failing_findings: [],
-      new_findings: [],
+      new_findings: [
+        {
+          change: "new",
+          attack_id: "atk-login",
+          name: "Login failure",
+          protocol: "rest",
+          kind: "missing_auth",
+          method: "POST",
+          path: "/login",
+          tags: ["auth"],
+          issue: "server_error",
+          severity: "high",
+          confidence: "high",
+          status_code: 500,
+          url: "https://example.com/login",
+          delta_changes: [],
+        },
+        {
+          change: "new",
+          attack_id: "atk-order",
+          name: "Order mismatch",
+          protocol: "rest",
+          kind: "wrong_type_param",
+          method: "GET",
+          path: "/orders",
+          tags: ["orders"],
+          issue: "response_schema_mismatch",
+          severity: "medium",
+          confidence: "high",
+          status_code: 200,
+          url: "https://example.com/orders",
+          delta_changes: [],
+        },
+      ],
       resolved_findings: [],
       persisting_findings: [],
     },
@@ -152,9 +204,301 @@ const projectPayload = {
     },
     latest_markdown_report: "# report",
     latest_html_report: "<!doctype html>",
-    last_run_job_id: "job-1",
+    last_run_job_id: "job-2",
   },
 };
+
+const baseJobsPayload = {
+  project_id: "project-1",
+  jobs: [
+    {
+      id: "job-2",
+      kind: "run",
+      status: "completed",
+      created_at: "2026-04-13T20:05:00Z",
+      started_at: "2026-04-13T20:05:05Z",
+      completed_at: "2026-04-13T20:06:00Z",
+      base_url: "https://example.com",
+      attack_count: 2,
+      project_id: "project-1",
+      error: null,
+      result_available: true,
+      artifact_names: ["atk-login.json"],
+      result_summary: {
+        source: "unit",
+        base_url: "https://example.com",
+        executed_at: "2026-04-13T20:06:00Z",
+        baseline_used: false,
+        baseline_executed_at: null,
+        total_results: 2,
+        profile_count: 0,
+        profile_names: [],
+        active_flagged_count: 2,
+        suppressed_flagged_count: 0,
+        new_findings_count: 2,
+        resolved_findings_count: 0,
+        persisting_findings_count: 0,
+        persisting_deltas_count: 0,
+        auth_failures: 0,
+        refresh_attempts: 0,
+        response_schema_mismatches: 0,
+        graphql_shape_mismatches: 0,
+        protocol_counts: { rest: 2 },
+        issue_counts: { server_error: 1, response_schema_mismatch: 1 },
+        finding_severity_counts: { high: 1, medium: 1 },
+        finding_confidence_counts: { high: 2 },
+        auth_summary: [],
+        top_findings: [],
+      },
+    },
+    {
+      id: "job-1",
+      kind: "run",
+      status: "completed",
+      created_at: "2026-04-13T19:00:00Z",
+      started_at: "2026-04-13T19:00:05Z",
+      completed_at: "2026-04-13T19:01:00Z",
+      base_url: "https://example.com",
+      attack_count: 2,
+      project_id: "project-1",
+      error: null,
+      result_available: true,
+      artifact_names: ["atk-order.json"],
+      result_summary: {
+        source: "unit",
+        base_url: "https://example.com",
+        executed_at: "2026-04-13T19:01:00Z",
+        baseline_used: false,
+        baseline_executed_at: null,
+        total_results: 2,
+        profile_count: 0,
+        profile_names: [],
+        active_flagged_count: 1,
+        suppressed_flagged_count: 0,
+        new_findings_count: 0,
+        resolved_findings_count: 0,
+        persisting_findings_count: 0,
+        persisting_deltas_count: 0,
+        auth_failures: 0,
+        refresh_attempts: 0,
+        response_schema_mismatches: 0,
+        graphql_shape_mismatches: 0,
+        protocol_counts: { rest: 2 },
+        issue_counts: { server_error: 1 },
+        finding_severity_counts: { high: 1 },
+        finding_confidence_counts: { high: 1 },
+        auth_summary: [],
+        top_findings: [],
+      },
+    },
+  ],
+};
+
+function createReviewResponse(options: {
+  baselineJobId: string | null;
+  waitingForNewRun: boolean;
+  baselineUsed: boolean;
+}) {
+  return {
+    project_id: "project-1",
+    current_job_id: "job-2",
+    baseline_mode: "job",
+    baseline_job_id: options.baselineJobId,
+    baseline_used: options.baselineUsed,
+    waiting_for_new_run: options.waitingForNewRun,
+    results: clone(baseProjectPayload.artifacts.latest_results),
+    summary: {
+      ...clone(baseProjectPayload.artifacts.latest_summary),
+      baseline_used: options.baselineUsed,
+      baseline_executed_at: options.baselineJobId ? "2026-04-13T19:01:00Z" : null,
+      new_findings_count: options.baselineUsed ? 1 : 2,
+      resolved_findings_count: options.baselineUsed ? 1 : 0,
+      persisting_findings_count: options.baselineUsed ? 1 : 0,
+      persisting_deltas_count: options.baselineUsed ? 1 : 0,
+    },
+    verification: {
+      ...clone(baseProjectPayload.artifacts.latest_verification),
+      baseline_used: options.baselineUsed,
+      new_findings_count: options.baselineUsed ? 1 : 2,
+      resolved_findings_count: options.baselineUsed ? 1 : 0,
+      persisting_findings_count: options.baselineUsed ? 1 : 0,
+      new_findings: options.baselineUsed
+        ? [clone(baseProjectPayload.artifacts.latest_verification.new_findings[0])]
+        : clone(baseProjectPayload.artifacts.latest_verification.new_findings),
+      resolved_findings: options.baselineUsed
+        ? [
+            {
+              ...clone(baseProjectPayload.artifacts.latest_verification.new_findings[1]),
+              change: "resolved",
+            },
+          ]
+        : [],
+      persisting_findings: options.baselineUsed
+        ? [
+            {
+              ...clone(baseProjectPayload.artifacts.latest_verification.new_findings[0]),
+              change: "persisting",
+              delta_changes: [
+                { field: "status", baseline: "401", current: "500" },
+              ],
+            },
+          ]
+        : [],
+    },
+    markdown_report: "# report",
+    html_report: "<!doctype html>",
+  };
+}
+
+function createEvidenceResponse(attackId: string) {
+  if (attackId === "atk-order") {
+    return {
+      job_id: "job-2",
+      attack_id: "atk-order",
+      result: {
+        type: "request",
+        attack_id: "atk-order",
+        operation_id: "listOrders",
+        kind: "wrong_type_param",
+        name: "Order mismatch",
+        protocol: "rest",
+        method: "GET",
+        path: "/orders",
+        tags: ["orders"],
+        url: "https://example.com/orders",
+        status_code: 200,
+        flagged: true,
+        issue: "response_schema_mismatch",
+        severity: "medium",
+        confidence: "high",
+      },
+      artifacts: [
+        {
+          label: "Request artifact",
+          kind: "request",
+          artifact_name: "atk-order.json",
+          available: false,
+          profile: null,
+          step_index: null,
+        },
+      ],
+      auth_events: [],
+      highlighted_auth_events: [],
+    };
+  }
+
+  return {
+    job_id: "job-2",
+    attack_id: "atk-login",
+    result: {
+      type: "workflow",
+      attack_id: "atk-login",
+      operation_id: "login",
+      kind: "missing_auth",
+      name: "Login failure",
+      protocol: "rest",
+      method: "POST",
+      path: "/login",
+      tags: ["auth"],
+      url: "https://example.com/login",
+      status_code: 500,
+      flagged: true,
+      issue: "server_error",
+      severity: "high",
+      confidence: "high",
+      workflow_steps: [
+        {
+          name: "Create session",
+          operation_id: "createSession",
+          method: "POST",
+          url: "https://example.com/session",
+          status_code: 201,
+          duration_ms: 12.5,
+          response_excerpt: '{"session":"ok"}',
+        },
+      ],
+      profile_results: [
+        {
+          profile: "member",
+          level: 1,
+          anonymous: false,
+          url: "https://example.com/login",
+          status_code: 403,
+          flagged: true,
+          issue: "server_error",
+          severity: "high",
+          confidence: "high",
+          workflow_steps: [
+            {
+              name: "Create session",
+              operation_id: "createSession",
+              method: "POST",
+              url: "https://example.com/session",
+              status_code: 201,
+            },
+          ],
+        },
+      ],
+    },
+    artifacts: [
+      {
+        label: "Workflow terminal artifact",
+        kind: "workflow_terminal",
+        artifact_name: "atk-login.json",
+        available: true,
+        profile: null,
+        step_index: null,
+      },
+      {
+        label: "Workflow step 1",
+        kind: "workflow_step",
+        artifact_name: "atk-login-step-01.json",
+        available: true,
+        profile: null,
+        step_index: 1,
+      },
+      {
+        label: "member profile artifact",
+        kind: "profile_request",
+        artifact_name: "member/atk-login.json",
+        available: true,
+        profile: "member",
+        step_index: null,
+      },
+    ],
+    auth_events: [
+      {
+        name: "member-login",
+        strategy: "cookie",
+        phase: "acquire",
+        success: true,
+        profile: "member",
+        status_code: 200,
+        error: null,
+      },
+      {
+        name: "admin-login",
+        strategy: "cookie",
+        phase: "refresh",
+        success: false,
+        profile: "admin",
+        status_code: 401,
+        error: "expired",
+      },
+    ],
+    highlighted_auth_events: [
+      {
+        name: "member-login",
+        strategy: "cookie",
+        phase: "acquire",
+        success: true,
+        profile: "member",
+        status_code: 200,
+        error: null,
+      },
+    ],
+  };
+}
 
 function renderWorkbench() {
   const queryClient = new QueryClient({
@@ -176,47 +520,186 @@ function renderWorkbench() {
 
 describe("ProjectWorkbenchPage", () => {
   beforeEach(() => {
+    let projectPayload = clone(baseProjectPayload);
+    const jobsPayload = clone(baseJobsPayload);
+    let baselineRefreshCount = 0;
+
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
-        if (url.endsWith("/v1/projects/project-1")) {
+        const method = init?.method ?? "GET";
+
+        if (url.endsWith("/v1/projects/project-1") && method === "GET") {
           return Response.json(projectPayload);
         }
-        if (url.endsWith("/v1/projects/project-1/jobs")) {
-          return Response.json({ project_id: "project-1", jobs: [] });
+
+        if (url.endsWith("/v1/projects/project-1/jobs") && method === "GET") {
+          return Response.json(jobsPayload);
         }
-        throw new Error(`Unhandled fetch for ${url}`);
+
+        if (url.endsWith("/v1/projects/project-1") && method === "PATCH") {
+          const patch = JSON.parse(String(init?.body ?? "{}"));
+          projectPayload = {
+            ...projectPayload,
+            ...patch,
+            review_draft: {
+              ...projectPayload.review_draft,
+              ...(patch.review_draft ?? {}),
+            },
+            artifacts: {
+              ...projectPayload.artifacts,
+              ...(patch.artifacts ?? {}),
+            },
+          };
+          return Response.json(projectPayload);
+        }
+
+        if (url.endsWith("/v1/projects/project-1/review") && method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          if (body.baseline_mode === "external") {
+            return Response.json({
+              ...createReviewResponse({
+                baselineJobId: projectPayload.review_draft.baseline_job_id,
+                waitingForNewRun: false,
+                baselineUsed: false,
+              }),
+              baseline_mode: "external",
+            });
+          }
+          if (body.baseline_job_id === "job-2") {
+            return Response.json(
+              createReviewResponse({
+                baselineJobId: "job-2",
+                waitingForNewRun: true,
+                baselineUsed: false,
+              }),
+            );
+          }
+          if (body.baseline_job_id === "job-1") {
+            baselineRefreshCount += 1;
+            const reviewResponse = createReviewResponse({
+              baselineJobId: "job-1",
+              waitingForNewRun: false,
+              baselineUsed: true,
+            });
+            if (baselineRefreshCount > 1) {
+              reviewResponse.verification.current_findings = [
+                clone(baseProjectPayload.artifacts.latest_verification.new_findings[1]),
+              ];
+              reviewResponse.verification.new_findings = [];
+              reviewResponse.verification.persisting_findings = [];
+              reviewResponse.verification.current_findings_count = 1;
+              reviewResponse.verification.new_findings_count = 0;
+              reviewResponse.verification.persisting_findings_count = 0;
+              reviewResponse.summary.top_findings = [
+                {
+                  attack_id: "atk-order",
+                  name: "Order mismatch",
+                  protocol: "rest",
+                  kind: "wrong_type_param",
+                  issue: "response_schema_mismatch",
+                  severity: "medium",
+                  confidence: "high",
+                  status_code: 200,
+                  url: "https://example.com/orders",
+                  schema_status: "not_applicable",
+                },
+              ];
+            }
+            return Response.json(reviewResponse);
+          }
+          return Response.json(
+            createReviewResponse({
+              baselineJobId: null,
+              waitingForNewRun: false,
+              baselineUsed: false,
+            }),
+          );
+        }
+
+        if (url.endsWith("/v1/jobs/job-1/result") && method === "GET") {
+          return Response.json({
+            source: "unit",
+            base_url: "https://example.com",
+            executed_at: "2026-04-13T19:01:00Z",
+            profiles: [],
+            auth_events: [],
+            results: [],
+          });
+        }
+
+        if (url.endsWith("/v1/jobs/job-2/findings/atk-login/evidence") && method === "GET") {
+          return Response.json(createEvidenceResponse("atk-login"));
+        }
+
+        if (url.endsWith("/v1/jobs/job-2/findings/atk-order/evidence") && method === "GET") {
+          return Response.json(createEvidenceResponse("atk-order"));
+        }
+
+        if (url.endsWith("/v1/jobs/job-2/artifacts/atk-login.json") && method === "GET") {
+          return new Response(
+            JSON.stringify({
+              attack: { id: "atk-login", name: "Login failure" },
+              request: {
+                method: "POST",
+                url: "https://example.com/login",
+                headers: { Authorization: "Bearer demo" },
+                query: {},
+                body: { present: true, kind: "json", excerpt: '{"username":"demo"}' },
+              },
+              response: {
+                status_code: 500,
+                error: "server exploded",
+                duration_ms: 23.4,
+                body_excerpt: '{"error":"boom"}',
+              },
+            }),
+          );
+        }
+
+        if (url.endsWith("/v1/jobs/job-2/artifacts/atk-login-step-01.json") && method === "GET") {
+          return new Response('{"attack":{"id":"atk-login-step-01"}}');
+        }
+
+        if (url.endsWith("/v1/jobs/job-2/artifacts/member/atk-login.json") && method === "GET") {
+          return new Response("member artifact text");
+        }
+
+        throw new Error(`Unhandled fetch for ${method} ${url}`);
       }),
     );
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
   });
 
   it("renders the fixed step rail and disables runs without a generated suite", async () => {
     renderWorkbench();
 
-    expect(await screen.findByText("Workbench demo")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Workbench demo" })).toBeInTheDocument();
     const stepRail = screen.getByRole("navigation", { name: "Workbench steps" });
     for (const stepName of ["source", "inspect", "generate", "run", "review"]) {
-      expect(within(stepRail).getByRole("button", { name: new RegExp(stepName, "i") })).toBeInTheDocument();
+      expect(
+        within(stepRail).getByRole("button", { name: new RegExp(stepName, "i") }),
+      ).toBeInTheDocument();
     }
     expect(screen.getByRole("button", { name: "Run suite" })).toBeDisabled();
   });
 
-  it("filters findings inside the native review workbench", async () => {
+  it("filters new findings inside the diff-first review tabs", async () => {
     renderWorkbench();
 
-    await screen.findByText("Workbench demo");
-    fireEvent.click(screen.getByRole("tab", { name: "Findings" }));
+    await screen.findByRole("heading", { name: "Workbench demo" });
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
 
     const table = screen
       .getAllByRole("table")
       .find((candidate) => within(candidate).queryByText("Login failure"));
     if (!table) {
-      throw new Error("Expected the findings table to render.");
+      throw new Error("Expected the new findings table to render.");
     }
     expect(within(table).getByText("Login failure")).toBeInTheDocument();
     expect(within(table).getByText("Order mismatch")).toBeInTheDocument();
@@ -227,5 +710,106 @@ describe("ProjectWorkbenchPage", () => {
 
     expect(within(table).getByText("Login failure")).toBeInTheDocument();
     expect(within(table).queryByText("Order mismatch")).not.toBeInTheDocument();
+  });
+
+  it("refreshes comparison when selecting a baseline and pinning the latest run", async () => {
+    renderWorkbench();
+
+    await screen.findByRole("heading", { name: "Workbench demo" });
+    fireEvent.change(screen.getByLabelText("Pinned baseline run"), {
+      target: { value: "job-1" },
+    });
+
+    expect(await screen.findByText("Diffs ready")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText("Pinned baseline run")).toHaveValue("job-1"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin latest run as baseline" }));
+
+    expect(await screen.findByText("Waiting for next run")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText("Pinned baseline run")).toHaveValue("job-2"),
+    );
+  });
+
+  it("keeps external baseline JSON as an advanced fallback with validation", async () => {
+    renderWorkbench();
+
+    await screen.findByRole("heading", { name: "Workbench demo" });
+    fireEvent.click(screen.getByRole("button", { name: "External JSON" }));
+    fireEvent.click(screen.getByText("External baseline JSON"));
+
+    const editors = screen.getAllByTestId("code-editor");
+    fireEvent.change(editors.at(-1)!, { target: { value: "{" } });
+    const refreshButton = await screen.findByRole("button", { name: /Refresh/ });
+    fireEvent.click(refreshButton);
+
+    expect(
+      await screen.findByText("Fix external baseline JSON before refreshing the review workspace."),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the evidence drawer from diff findings and loads artifact content lazily", async () => {
+    renderWorkbench();
+
+    await screen.findByRole("heading", { name: "Workbench demo" });
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    fireEvent.click(screen.getByRole("button", { name: "Login failure" }));
+
+    expect(await screen.findByText("Current-run evidence")).toBeInTheDocument();
+    expect(await screen.findByText("Workflow terminal artifact")).toBeInTheDocument();
+    expect(await screen.findByText("Create session")).toBeInTheDocument();
+    expect((await screen.findAllByText("member-login")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/https:\/\/example.com\/login/)).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/server exploded/)).toBeInTheDocument();
+  });
+
+  it("keeps resolved findings summary-only and reuses the artifact viewer in the artifacts tab", async () => {
+    renderWorkbench();
+
+    await screen.findByRole("heading", { name: "Workbench demo" });
+    fireEvent.change(screen.getByLabelText("Pinned baseline run"), {
+      target: { value: "job-1" },
+    });
+
+    expect(await screen.findByText("Diffs ready")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Resolved" }));
+
+    expect(
+      await screen.findByText(
+        "Resolved findings are baseline-only in this milestone, so current-run artifact evidence is not available.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Order mismatch" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Artifacts" }));
+    expect(await screen.findByRole("button", { name: "atk-login.json" })).toBeInTheDocument();
+    expect((await screen.findAllByText(/Authorization/)).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/server exploded/)).toBeInTheDocument();
+  });
+
+  it("closes stale evidence when a refreshed comparison no longer includes the selected finding", async () => {
+    renderWorkbench();
+
+    await screen.findByRole("heading", { name: "Workbench demo" });
+    fireEvent.change(screen.getByLabelText("Pinned baseline run"), {
+      target: { value: "job-1" },
+    });
+    expect(await screen.findByText("Diffs ready")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Login failure" }));
+    expect(await screen.findByText("Current-run evidence")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh analysis" }));
+
+    expect(
+      await screen.findByText(
+        "Evidence changed with the latest run. Reopen a finding from the refreshed comparison.",
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Close evidence" })).not.toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useRef, useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
 import CodeEditor from "../components/CodeEditor";
@@ -6,34 +6,36 @@ import {
   createRun,
   discoverModel,
   generateSuite,
+  getJobArtifact,
+  getJobFindingEvidence,
   getJobResult,
   getProject,
   inspectSource,
   listProjectJobs,
   promoteResults,
-  renderReport,
-  summarizeResults,
+  refreshProjectReview,
   triageResults,
   updateProject,
-  verifyResults,
 } from "../api";
 import type {
   ApiJobStatus,
+  ArtifactReferenceResponse,
   AttackResults,
-  AttackSuite,
+  JobArtifactDocument,
   JobStatusResponse,
   ProjectRecord,
-  ProjectReviewDraft,
+  ProjectReviewBaselineMode,
   ProjectSourceMode,
   ProjectStep,
   SourcePayload,
 } from "../types";
 
 type ReviewTab =
-  | "summary"
-  | "findings"
+  | "overview"
+  | "new"
+  | "persisting"
+  | "resolved"
   | "deltas"
-  | "auth"
   | "artifacts"
   | "suppressions"
   | "promote";
@@ -100,13 +102,54 @@ function statusTone(status: ApiJobStatus | "idle") {
   return "status-idle";
 }
 
+function matchesReviewFilter(
+  finding: {
+    attack_id: string;
+    name: string;
+    kind: string;
+    issue?: string | null;
+    method: string;
+    path?: string | null;
+  },
+  filter: string,
+) {
+  if (!filter) {
+    return true;
+  }
+  const haystack = [
+    finding.attack_id,
+    finding.name,
+    finding.kind,
+    finding.issue ?? "",
+    finding.method,
+    finding.path ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(filter);
+}
+
+function formatJobMoment(value?: string | null) {
+  return value ? new Date(value).toLocaleString() : "—";
+}
+
+function summarizeJob(job: JobStatusResponse) {
+  const active = job.result_summary?.active_flagged_count;
+  const latestMoment = job.completed_at ?? job.started_at ?? job.created_at;
+  const summaryBits = [
+    formatJobMoment(latestMoment),
+    active === undefined || active === null ? null : `${active} active`,
+  ].filter(Boolean);
+  return summaryBits.join(" • ");
+}
+
 function ReviewTable({
   headings,
   rows,
   emptyCopy,
 }: {
   headings: string[];
-  rows: Array<Array<string | number | null | undefined>>;
+  rows: Array<Array<ReactNode>>;
   emptyCopy: string;
 }) {
   return (
@@ -122,7 +165,7 @@ function ReviewTable({
         <tbody>
           {rows.length ? (
             rows.map((row, index) => (
-              <tr key={`${row[0] ?? "row"}-${index}`}>
+              <tr key={`row-${index}`}>
                 {row.map((value, cellIndex) => (
                   <td key={`${index}-${cellIndex}`}>{value ?? "—"}</td>
                 ))}
@@ -137,6 +180,228 @@ function ReviewTable({
           )}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+function findingChangeLabel(change: string) {
+  if (change === "new") {
+    return "New";
+  }
+  if (change === "persisting") {
+    return "Persisting";
+  }
+  if (change === "resolved") {
+    return "Resolved";
+  }
+  return "Current";
+}
+
+function artifactKindLabel(kind: ArtifactReferenceResponse["kind"]) {
+  if (kind === "workflow_terminal") {
+    return "workflow terminal";
+  }
+  if (kind === "workflow_step") {
+    return "workflow step";
+  }
+  if (kind === "profile_request") {
+    return "profile request";
+  }
+  if (kind === "profile_workflow_step") {
+    return "profile step";
+  }
+  return "request";
+}
+
+function artifactPath(jobId: string, artifactName: string) {
+  const encodedName = artifactName
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `/v1/jobs/${jobId}/artifacts/${encodedName}`;
+}
+
+function ArtifactDocumentPreview({
+  document,
+}: {
+  document: JobArtifactDocument | null | undefined;
+}) {
+  if (!document) {
+    return <p className="empty-copy">Select an artifact to inspect.</p>;
+  }
+
+  if (
+    document.format === "json" &&
+    document.content &&
+    typeof document.content === "object" &&
+    !Array.isArray(document.content) &&
+    "request" in document.content &&
+    "response" in document.content
+  ) {
+    const content = document.content as {
+      attack?: Record<string, unknown>;
+      request?: {
+        method?: string;
+        url?: string;
+        headers?: unknown;
+        query?: unknown;
+        body?: unknown;
+      };
+      response?: {
+        status_code?: number | null;
+        error?: string | null;
+        duration_ms?: number | null;
+        body_excerpt?: string | null;
+      };
+    };
+    const attack = content.attack ?? {};
+    const request = content.request ?? {};
+    const response = content.response ?? {};
+    const body = request.body as
+      | {
+          kind?: string;
+          content_type?: string | null;
+          excerpt?: string | null;
+          present?: boolean;
+        }
+      | undefined;
+
+    return (
+      <div className="stack">
+        <div className="summary-card-grid">
+          <div className="summary-card">
+            <span>Artifact</span>
+            <strong>{String(attack.name ?? attack.id ?? document.artifact_name)}</strong>
+          </div>
+          <div className="summary-card">
+            <span>Request</span>
+            <strong>{String(request.method ?? "—")}</strong>
+          </div>
+          <div className="summary-card">
+            <span>Response</span>
+            <strong>{response.status_code ?? "—"}</strong>
+          </div>
+          <div className="summary-card">
+            <span>Duration</span>
+            <strong>{response.duration_ms ? `${response.duration_ms} ms` : "—"}</strong>
+          </div>
+        </div>
+        <article className="artifact-structured-card">
+          <h4>Request</h4>
+          <p>
+            <strong>{String(request.method ?? "—")}</strong> {String(request.url ?? "—")}
+          </p>
+          <pre className="json-preview">{formatJson(request.headers ?? {})}</pre>
+          <pre className="json-preview">{formatJson(request.query ?? {})}</pre>
+          {body?.present ? (
+            <pre className="json-preview">
+              {body.kind === "json" && body.excerpt
+                ? body.excerpt
+                : body?.excerpt || body?.content_type || "Request body present."}
+            </pre>
+          ) : (
+            <p className="field-hint">No request body recorded.</p>
+          )}
+        </article>
+        <article className="artifact-structured-card">
+          <h4>Response</h4>
+          <p>
+            <strong>Status:</strong> {response.status_code ?? "—"}{" "}
+            <strong>Error:</strong> {response.error ?? "—"}
+          </p>
+          <pre className="json-preview">{String(response.body_excerpt ?? "No response body excerpt.")}</pre>
+        </article>
+      </div>
+    );
+  }
+
+  return (
+    <pre className="json-preview">
+      {document.format === "json" ? formatJson(document.content) : String(document.content)}
+    </pre>
+  );
+}
+
+function ArtifactViewer({
+  jobId,
+  references,
+  selectedArtifactName,
+  onSelect,
+  document,
+  isLoading,
+  error,
+  emptyCopy,
+}: {
+  jobId: string;
+  references: ArtifactReferenceResponse[];
+  selectedArtifactName: string | null;
+  onSelect: (artifactName: string) => void;
+  document: JobArtifactDocument | null | undefined;
+  isLoading: boolean;
+  error: string | null;
+  emptyCopy: string;
+}) {
+  const selectedReference =
+    references.find((reference) => reference.artifact_name === selectedArtifactName) ?? null;
+
+  return (
+    <div className="artifact-viewer">
+      <ul className="artifact-reference-list">
+        {references.length ? (
+          references.map((reference) => (
+            <li
+              className={`artifact-reference-item${
+                selectedReference?.artifact_name === reference.artifact_name
+                  ? " artifact-reference-item-active"
+                  : ""
+              }`}
+              key={reference.artifact_name}
+            >
+              <button
+                className="artifact-reference-button"
+                disabled={!reference.available}
+                onClick={() => onSelect(reference.artifact_name)}
+                type="button"
+              >
+                {reference.label}
+              </button>
+              <small>{reference.artifact_name}</small>
+              <div className="artifact-reference-meta">
+                <span>{artifactKindLabel(reference.kind)}</span>
+                {reference.available ? (
+                  <a href={artifactPath(jobId, reference.artifact_name)} rel="noreferrer" target="_blank">
+                    raw
+                  </a>
+                ) : (
+                  <span>missing</span>
+                )}
+              </div>
+            </li>
+          ))
+        ) : (
+          <li className="artifact-reference-item">
+            <span>{emptyCopy}</span>
+          </li>
+        )}
+      </ul>
+      <div className="artifact-preview-panel">
+        {!selectedReference ? (
+          <p className="empty-copy">{emptyCopy}</p>
+        ) : !selectedReference.available ? (
+          <div className="empty-state">
+            <p>This artifact was expected for the finding, but it is not stored for this run.</p>
+            <small>{selectedReference.artifact_name}</small>
+          </div>
+        ) : isLoading ? (
+          <p className="empty-copy">Loading artifact…</p>
+        ) : error ? (
+          <div className="empty-state">
+            <p>{error}</p>
+          </div>
+        ) : (
+          <ArtifactDocumentPreview document={document} />
+        )}
+      </div>
     </div>
   );
 }
@@ -206,8 +471,12 @@ export default function ProjectWorkbenchPage() {
   const [baselineError, setBaselineError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [activityMessage, setActivityMessage] = useState<string | null>(null);
-  const [reviewTab, setReviewTab] = useState<ReviewTab>("summary");
+  const [reviewTab, setReviewTab] = useState<ReviewTab>("overview");
   const [reviewFilter, setReviewFilter] = useState("");
+  const [selectedEvidenceAttackId, setSelectedEvidenceAttackId] = useState<string | null>(null);
+  const [selectedDrawerArtifactName, setSelectedDrawerArtifactName] = useState<string | null>(null);
+  const [selectedArtifactsTabArtifactName, setSelectedArtifactsTabArtifactName] = useState<string | null>(null);
+  const [evidenceNotice, setEvidenceNotice] = useState<string | null>(null);
   const [trackedJobId, setTrackedJobId] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const syncedJobIdRef = useRef<string | null>(null);
@@ -224,6 +493,33 @@ export default function ProjectWorkbenchPage() {
     queryFn: () => listProjectJobs(projectId!),
     enabled: Boolean(projectId),
     refetchInterval: trackedJobId ? 1500 : false,
+  });
+
+  const currentJobs = projectJobsQuery.data?.jobs ?? [];
+  const completedReviewJobs = currentJobs.filter(
+    (job) => job.status === "completed" && job.result_available,
+  );
+  const currentReviewedJob =
+    currentJobs.find((job) => job.id === draft?.artifacts.last_run_job_id) ??
+    completedReviewJobs[0] ??
+    null;
+
+  const findingEvidenceQuery = useQuery({
+    queryKey: ["jobFindingEvidence", currentReviewedJob?.id, selectedEvidenceAttackId],
+    queryFn: () => getJobFindingEvidence(currentReviewedJob!.id, selectedEvidenceAttackId!),
+    enabled: Boolean(currentReviewedJob?.id && selectedEvidenceAttackId),
+  });
+
+  const drawerArtifactQuery = useQuery({
+    queryKey: ["jobArtifact", currentReviewedJob?.id, selectedDrawerArtifactName],
+    queryFn: () => getJobArtifact(currentReviewedJob!.id, selectedDrawerArtifactName!),
+    enabled: Boolean(currentReviewedJob?.id && selectedDrawerArtifactName),
+  });
+
+  const artifactsTabArtifactQuery = useQuery({
+    queryKey: ["jobArtifact", currentReviewedJob?.id, "artifacts-tab", selectedArtifactsTabArtifactName],
+    queryFn: () => getJobArtifact(currentReviewedJob!.id, selectedArtifactsTabArtifactName!),
+    enabled: Boolean(currentReviewedJob?.id && selectedArtifactsTabArtifactName),
   });
 
   const saveProjectMutation = useMutation({
@@ -267,6 +563,52 @@ export default function ProjectWorkbenchPage() {
     return draft;
   }
 
+  function commitDraft(project: ProjectRecord) {
+    setDraft(project);
+    setHasPendingSave(true);
+  }
+
+  function withReviewBundle(project: ProjectRecord, review: Awaited<ReturnType<typeof refreshProjectReview>>) {
+    return {
+      ...project,
+      active_step: "review" as const,
+      artifacts: {
+        ...project.artifacts,
+        last_run_job_id: review.current_job_id,
+        latest_results: review.results,
+        latest_summary: review.summary,
+        latest_verification: review.verification,
+        latest_markdown_report: review.markdown_report,
+        latest_html_report: review.html_report,
+      },
+    };
+  }
+
+  async function runReviewRefresh(project: ProjectRecord, successMessage: string) {
+    if (project.review_draft.baseline_mode === "external" && baselineError) {
+      setActionError("Fix external baseline JSON before refreshing the review workspace.");
+      return;
+    }
+    setBusyAction("refresh-review");
+    setActionError(null);
+    try {
+      const review = await refreshProjectReview(project.id, project.review_draft);
+      commitDraft(withReviewBundle(project, review));
+      setReviewTab("overview");
+      setActivityMessage(
+        review.waiting_for_new_run
+          ? "Baseline pinned to the latest completed run. New diffs will appear after the next completed run."
+          : successMessage,
+      );
+      setActionError(null);
+      void projectJobsQuery.refetch();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not refresh review workspace.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
   useEffect(() => {
     if (!projectQuery.data) {
       return;
@@ -306,40 +648,64 @@ export default function ProjectWorkbenchPage() {
     }
 
     syncedJobIdRef.current = job.id;
-    setBusyAction("refresh-review");
     void (async () => {
       try {
-        const results = await getJobResult(job.id);
-        const reviewDraft: ProjectReviewDraft = draft.review_draft;
-        const [summary, verification, markdownReport, htmlReport] = await Promise.all([
-          summarizeResults(results, reviewDraft),
-          verifyResults(results, reviewDraft),
-          renderReport(results, reviewDraft, "markdown"),
-          renderReport(results, reviewDraft, "html"),
-        ]);
-        applyDraftUpdate((current) => ({
-          ...current,
-          active_step: "review",
-          artifacts: {
-            ...current.artifacts,
-            last_run_job_id: job.id,
-            latest_results: results,
-            latest_summary: summary,
-            latest_verification: verification,
-            latest_markdown_report: markdownReport.content,
-            latest_html_report: htmlReport.content,
-          },
-        }));
-        setActivityMessage("Run finished and the review workspace is up to date.");
-        setActionError(null);
-      } catch (error) {
-        setActionError(error instanceof Error ? error.message : "Could not refresh review data.");
+        await runReviewRefresh(draft, "Run finished and the review workspace is up to date.");
       } finally {
-        setBusyAction(null);
         setTrackedJobId(null);
       }
     })();
   }, [draft, projectJobsQuery.data, trackedJobId]);
+
+  useEffect(() => {
+    const currentFindingIds = new Set(
+      draft?.artifacts.latest_verification?.current_findings.map((finding) => finding.attack_id) ?? [],
+    );
+    if (!selectedEvidenceAttackId) {
+      return;
+    }
+    if (currentFindingIds.has(selectedEvidenceAttackId)) {
+      return;
+    }
+    setSelectedEvidenceAttackId(null);
+    setSelectedDrawerArtifactName(null);
+    setEvidenceNotice("Evidence changed with the latest run. Reopen a finding from the refreshed comparison.");
+  }, [draft?.artifacts.latest_verification, selectedEvidenceAttackId]);
+
+  useEffect(() => {
+    const references = findingEvidenceQuery.data?.artifacts ?? [];
+    if (!selectedEvidenceAttackId) {
+      if (selectedDrawerArtifactName !== null) {
+        setSelectedDrawerArtifactName(null);
+      }
+      return;
+    }
+    if (!references.length) {
+      if (selectedDrawerArtifactName !== null) {
+        setSelectedDrawerArtifactName(null);
+      }
+      return;
+    }
+    if (selectedDrawerArtifactName && references.some((artifact) => artifact.artifact_name === selectedDrawerArtifactName)) {
+      return;
+    }
+    const nextArtifact = references.find((artifact) => artifact.available) ?? references[0];
+    setSelectedDrawerArtifactName(nextArtifact.artifact_name);
+  }, [findingEvidenceQuery.data, selectedDrawerArtifactName, selectedEvidenceAttackId]);
+
+  useEffect(() => {
+    const artifactNames = currentReviewedJob?.artifact_names ?? [];
+    if (!artifactNames.length) {
+      if (selectedArtifactsTabArtifactName !== null) {
+        setSelectedArtifactsTabArtifactName(null);
+      }
+      return;
+    }
+    if (selectedArtifactsTabArtifactName && artifactNames.includes(selectedArtifactsTabArtifactName)) {
+      return;
+    }
+    setSelectedArtifactsTabArtifactName(artifactNames[0]);
+  }, [currentReviewedJob, selectedArtifactsTabArtifactName]);
 
   if (!projectId) {
     return (
@@ -361,25 +727,93 @@ export default function ProjectWorkbenchPage() {
     );
   }
 
-  const currentJobs = projectJobsQuery.data?.jobs ?? [];
   const latestJob = currentJobs[0];
-  const activeFindings =
-    draft.artifacts.latest_verification?.current_findings.filter((finding) => {
-      if (!deferredReviewFilter) {
-        return true;
+  const baselineReviewedJob = draft.review_draft.baseline_job_id
+    ? currentJobs.find((job) => job.id === draft.review_draft.baseline_job_id) ?? null
+    : null;
+  const verification = draft.artifacts.latest_verification;
+  const currentFindings = verification?.current_findings ?? [];
+  const newFindingIds = new Set(verification?.new_findings.map((finding) => finding.attack_id) ?? []);
+  const persistingFindingIds = new Set(
+    verification?.persisting_findings.map((finding) => finding.attack_id) ?? [],
+  );
+  const selectedEvidenceFinding = selectedEvidenceAttackId
+    ? currentFindings.find((finding) => finding.attack_id === selectedEvidenceAttackId) ?? null
+    : null;
+  const selectedEvidenceChange = selectedEvidenceAttackId
+    ? newFindingIds.has(selectedEvidenceAttackId)
+      ? "new"
+      : persistingFindingIds.has(selectedEvidenceAttackId)
+        ? "persisting"
+        : "current"
+    : null;
+  const reviewWaitingForNewRun =
+    draft.review_draft.baseline_mode === "job" &&
+    Boolean(currentReviewedJob && baselineReviewedJob && currentReviewedJob.id === baselineReviewedJob.id);
+  const newFindings =
+    verification?.new_findings.filter((finding) => matchesReviewFilter(finding, deferredReviewFilter)) ?? [];
+  const persistingFindings =
+    verification?.persisting_findings.filter((finding) =>
+      matchesReviewFilter(finding, deferredReviewFilter),
+    ) ?? [];
+  const resolvedFindings =
+    verification?.resolved_findings.filter((finding) =>
+      matchesReviewFilter(finding, deferredReviewFilter),
+    ) ?? [];
+  const deltaFindings = persistingFindings.filter((finding) => finding.delta_changes.length);
+  const artifactBrowserReferences = (currentReviewedJob?.artifact_names ?? []).map(
+    (artifactName): ArtifactReferenceResponse => ({
+      label: artifactName,
+      kind: artifactName.includes("-step-")
+        ? artifactName.includes("/")
+          ? "profile_workflow_step"
+          : "workflow_step"
+        : artifactName.includes("/")
+          ? "profile_request"
+          : "request",
+      artifact_name: artifactName,
+      available: true,
+      profile: artifactName.includes("/") ? artifactName.split("/")[0] : null,
+      step_index: null,
+    }),
+  );
+  const findingEvidenceError =
+    findingEvidenceQuery.error instanceof Error ? findingEvidenceQuery.error.message : null;
+  const drawerArtifactError =
+    drawerArtifactQuery.error instanceof Error ? drawerArtifactQuery.error.message : null;
+  const artifactsTabArtifactError =
+    artifactsTabArtifactQuery.error instanceof Error ? artifactsTabArtifactQuery.error.message : null;
+
+  async function resolvePromotionReview(project: ProjectRecord) {
+    if (project.review_draft.baseline_mode === "external") {
+      if (baselineError) {
+        throw new Error("Fix external baseline JSON before promoting findings.");
       }
-      const haystack = [
-        finding.attack_id,
-        finding.name,
-        finding.kind,
-        finding.issue ?? "",
-        finding.method,
-        finding.path ?? "",
-      ]
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(deferredReviewFilter);
-    }) ?? [];
+      return project.review_draft;
+    }
+    if (!project.review_draft.baseline_job_id) {
+      return project.review_draft;
+    }
+    const baselineResults = await getJobResult(project.review_draft.baseline_job_id);
+    return {
+      ...project.review_draft,
+      baseline: baselineResults,
+    };
+  }
+
+  function openFindingEvidence(finding: { attack_id: string }) {
+    setSelectedEvidenceAttackId(finding.attack_id);
+    setSelectedDrawerArtifactName(null);
+    setEvidenceNotice(null);
+  }
+
+  function findingAction(label: string, finding: { attack_id: string }) {
+    return (
+      <button className="finding-link" onClick={() => openFindingEvidence(finding)} type="button">
+        {label}
+      </button>
+    );
+  }
 
   async function handleSourceUpload(files: FileList | null) {
     if (!files?.length) {
@@ -545,39 +979,11 @@ export default function ProjectWorkbenchPage() {
 
   async function handleRefreshReview() {
     const project = getLoadedProject();
-    if (!project.artifacts.latest_results) {
-      setActionError("Run a suite first so there is data to analyze.");
+    if (!completedReviewJobs.length) {
+      setActionError("Run a suite first so there is a completed project run to analyze.");
       return;
     }
-    if (baselineError) {
-      setActionError("Fix baseline JSON before refreshing the review workspace.");
-      return;
-    }
-    setBusyAction("refresh-review");
-    setActionError(null);
-    try {
-      const [summary, verification, markdownReport, htmlReport] = await Promise.all([
-        summarizeResults(project.artifacts.latest_results, project.review_draft),
-        verifyResults(project.artifacts.latest_results, project.review_draft),
-        renderReport(project.artifacts.latest_results, project.review_draft, "markdown"),
-        renderReport(project.artifacts.latest_results, project.review_draft, "html"),
-      ]);
-      applyDraftUpdate((current) => ({
-        ...current,
-        artifacts: {
-          ...current.artifacts,
-          latest_summary: summary,
-          latest_verification: verification,
-          latest_markdown_report: markdownReport.content,
-          latest_html_report: htmlReport.content,
-        },
-      }));
-      setActivityMessage("Review panels refreshed.");
-    } catch (error) {
-      setActionError(error instanceof Error ? error.message : "Could not refresh review panels.");
-    } finally {
-      setBusyAction(null);
-    }
+    await runReviewRefresh(project, "Review workspace refreshed.");
   }
 
   async function handleGenerateSuppressions() {
@@ -620,10 +1026,11 @@ export default function ProjectWorkbenchPage() {
     setBusyAction("promote");
     setActionError(null);
     try {
+      const promotionReview = await resolvePromotionReview(project);
       const promoted = await promoteResults(
         project.artifacts.latest_results,
         project.artifacts.generated_suite,
-        project.review_draft,
+        promotionReview,
       );
       applyDraftUpdate((current) => ({
         ...current,
@@ -639,6 +1046,55 @@ export default function ProjectWorkbenchPage() {
     } finally {
       setBusyAction(null);
     }
+  }
+
+  async function handleBaselineModeChange(nextMode: ProjectReviewBaselineMode) {
+    const project = getLoadedProject();
+    const nextProject = {
+      ...project,
+      review_draft: {
+        ...project.review_draft,
+        baseline_mode: nextMode,
+      },
+    };
+    commitDraft(nextProject);
+    if (completedReviewJobs.length) {
+      await runReviewRefresh(
+        nextProject,
+        nextMode === "external"
+          ? "Review workspace switched to external baseline mode."
+          : "Review workspace switched to project history baseline mode.",
+      );
+    }
+  }
+
+  async function handleBaselineJobChange(jobId: string) {
+    const project = getLoadedProject();
+    const nextProject = {
+      ...project,
+      review_draft: {
+        ...project.review_draft,
+        baseline_mode: "job" as const,
+        baseline_job_id: jobId || null,
+      },
+    };
+    commitDraft(nextProject);
+    if (completedReviewJobs.length) {
+      await runReviewRefresh(
+        nextProject,
+        jobId
+          ? "Pinned a project run as the baseline."
+          : "Cleared the baseline selection for this review workspace.",
+      );
+    }
+  }
+
+  async function handlePinLatestBaseline() {
+    if (!currentReviewedJob) {
+      setActionError("Run a suite first so there is a completed run to pin as the baseline.");
+      return;
+    }
+    await handleBaselineJobChange(currentReviewedJob.id);
   }
 
   return (
@@ -1226,12 +1682,12 @@ export default function ProjectWorkbenchPage() {
             <div className="section-heading">
               <div>
                 <p className="eyebrow">Review</p>
-                <h2>Native triage and regression workspace</h2>
+                <h2>Baseline-aware review workspace</h2>
               </div>
               <div className="action-row">
                 <button
                   className="secondary-button"
-                  disabled={busyAction === "refresh-review" || !draft.artifacts.latest_results}
+                  disabled={busyAction === "refresh-review" || !completedReviewJobs.length}
                   onClick={() => void handleRefreshReview()}
                   type="button"
                 >
@@ -1254,6 +1710,49 @@ export default function ProjectWorkbenchPage() {
                   {busyAction === "promote" ? "Promoting…" : "Promote findings"}
                 </button>
               </div>
+            </div>
+            <div className="compare-banner">
+              <article className="compare-card">
+                <span>Current run</span>
+                <strong>{currentReviewedJob ? currentReviewedJob.id.slice(0, 8) : "No completed run"}</strong>
+                <small>
+                  {currentReviewedJob
+                    ? `${summarizeJob(currentReviewedJob)} • ${currentReviewedJob.base_url}`
+                    : "Run a suite to create the current comparison target."}
+                </small>
+              </article>
+              <article className="compare-card">
+                <span>Baseline</span>
+                <strong>
+                  {draft.review_draft.baseline_mode === "external"
+                    ? "External JSON"
+                    : baselineReviewedJob
+                      ? baselineReviewedJob.id.slice(0, 8)
+                      : "Not pinned"}
+                </strong>
+                <small>
+                  {draft.review_draft.baseline_mode === "external"
+                    ? draft.review_draft.baseline
+                      ? "Advanced fallback is active for this comparison."
+                      : "External mode is active, but no baseline JSON is loaded yet."
+                    : baselineReviewedJob
+                      ? `${summarizeJob(baselineReviewedJob)}`
+                      : "Select a prior completed run or pin the latest run first."}
+                </small>
+              </article>
+              <article className="compare-card">
+                <span>Compare state</span>
+                <strong>
+                  {reviewWaitingForNewRun
+                    ? "Waiting for next run"
+                    : draft.artifacts.latest_summary?.baseline_used
+                      ? "Diffs ready"
+                      : "Latest run only"}
+                </strong>
+                <small>
+                  Last refreshed {formatJobMoment(draft.artifacts.latest_summary?.executed_at)}
+                </small>
+              </article>
             </div>
             <div className="field-grid field-grid-3">
               <label className="field">
@@ -1310,43 +1809,104 @@ export default function ProjectWorkbenchPage() {
                 />
               </label>
             </div>
-            <CodeEditor
-              error={baselineError}
-              height={220}
-              hint="Optional baseline results JSON for regression-aware review."
-              label="Baseline results JSON"
-              language="json"
-              onChange={(value) => {
-                setBaselineText(value);
-                if (!value.trim()) {
-                  setBaselineError(null);
-                  applyDraftUpdate((current) => ({
-                    ...current,
-                    review_draft: { ...current.review_draft, baseline: null },
-                  }));
-                  return;
-                }
-                try {
-                  const parsed = JSON.parse(value) as AttackResults;
-                  setBaselineError(null);
-                  applyDraftUpdate((current) => ({
-                    ...current,
-                    review_draft: { ...current.review_draft, baseline: parsed },
-                  }));
-                } catch (error) {
-                  setBaselineError(error instanceof Error ? error.message : "Invalid JSON.");
-                }
-              }}
-              value={baselineText}
-            />
+            <div className="field-grid field-grid-3">
+              <div className="field">
+                <span className="field-label">Baseline source</span>
+                <div className="mode-switch">
+                  {(["job", "external"] as ProjectReviewBaselineMode[]).map((mode) => (
+                    <button
+                      className={`mode-button${
+                        draft.review_draft.baseline_mode === mode ? " mode-button-active" : ""
+                      }`}
+                      key={mode}
+                      onClick={() => void handleBaselineModeChange(mode)}
+                      type="button"
+                    >
+                      {mode === "job" ? "Project history" : "External JSON"}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <label className="field">
+                <span className="field-label">Pinned baseline run</span>
+                <select
+                  aria-label="Pinned baseline run"
+                  className="text-input"
+                  disabled={draft.review_draft.baseline_mode !== "job"}
+                  value={draft.review_draft.baseline_job_id ?? ""}
+                  onChange={(event) => void handleBaselineJobChange(event.target.value)}
+                >
+                  <option value="">No pinned baseline</option>
+                  {completedReviewJobs.map((job) => (
+                    <option key={job.id} value={job.id}>
+                      {`${job.id.slice(0, 8)} • ${summarizeJob(job)}`}
+                    </option>
+                  ))}
+                </select>
+                <span className="field-hint">Pick a completed run from this project’s history.</span>
+              </label>
+              <div className="field">
+                <span className="field-label">Latest run shortcut</span>
+                <div className="action-row">
+                  <button
+                    className="secondary-button"
+                    disabled={!currentReviewedJob || busyAction === "refresh-review"}
+                    onClick={() => void handlePinLatestBaseline()}
+                    type="button"
+                  >
+                    Pin latest run as baseline
+                  </button>
+                </div>
+                <span className="field-hint">
+                  Record today’s latest completed run, then wait for the next completed run to diff against it.
+                </span>
+              </div>
+            </div>
+
+            <details className="advanced-panel">
+              <summary>External baseline JSON</summary>
+              <p className="field-hint">
+                Advanced fallback for comparison inputs that do not come from this project’s run history.
+              </p>
+              <CodeEditor
+                error={baselineError}
+                height={220}
+                hint="Only used when baseline source is set to External JSON."
+                label="External baseline results JSON"
+                language="json"
+                onChange={(value) => {
+                  setBaselineText(value);
+                  if (!value.trim()) {
+                    setBaselineError(null);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      review_draft: { ...current.review_draft, baseline: null },
+                    }));
+                    return;
+                  }
+                  try {
+                    const parsed = JSON.parse(value) as AttackResults;
+                    setBaselineError(null);
+                    applyDraftUpdate((current) => ({
+                      ...current,
+                      review_draft: { ...current.review_draft, baseline: parsed },
+                    }));
+                  } catch (error) {
+                    setBaselineError(error instanceof Error ? error.message : "Invalid JSON.");
+                  }
+                }}
+                value={baselineText}
+              />
+            </details>
 
             <div className="tab-row" role="tablist" aria-label="Review panels">
               {(
                 [
-                  ["summary", "Summary"],
-                  ["findings", "Findings"],
+                  ["overview", "Overview"],
+                  ["new", "New"],
+                  ["persisting", "Persisting"],
+                  ["resolved", "Resolved"],
                   ["deltas", "Deltas"],
-                  ["auth", "Auth"],
                   ["artifacts", "Artifacts"],
                   ["suppressions", "Suppressions"],
                   ["promote", "Promote"],
@@ -1356,6 +1916,7 @@ export default function ProjectWorkbenchPage() {
                   className={`tab-button${reviewTab === tab ? " tab-button-active" : ""}`}
                   key={tab}
                   onClick={() => setReviewTab(tab)}
+                  aria-selected={reviewTab === tab}
                   role="tab"
                   type="button"
                 >
@@ -1364,7 +1925,139 @@ export default function ProjectWorkbenchPage() {
               ))}
             </div>
 
-            {reviewTab === "summary" ? (
+            {selectedEvidenceAttackId && currentReviewedJob ? (
+              <section className="evidence-drawer">
+                <div className="section-heading">
+                  <div>
+                    <p className="eyebrow">Current-run evidence</p>
+                    <h3>{selectedEvidenceFinding?.name ?? selectedEvidenceAttackId}</h3>
+                    <p className="field-hint">
+                      {findingChangeLabel(selectedEvidenceChange ?? "current")} finding from run{" "}
+                      <code>{currentReviewedJob.id.slice(0, 8)}</code>
+                    </p>
+                  </div>
+                  <button
+                    className="secondary-button"
+                    onClick={() => {
+                      setSelectedEvidenceAttackId(null);
+                      setSelectedDrawerArtifactName(null);
+                    }}
+                    type="button"
+                  >
+                    Close evidence
+                  </button>
+                </div>
+                {findingEvidenceQuery.isLoading ? (
+                  <p className="empty-copy">Loading finding evidence…</p>
+                ) : findingEvidenceError ? (
+                  <div className="empty-state">
+                    <p>{findingEvidenceError}</p>
+                  </div>
+                ) : findingEvidenceQuery.data ? (
+                  <div className="stack">
+                    <div className="summary-card-grid">
+                      <div className="summary-card">
+                        <span>Compare state</span>
+                        <strong>{findingChangeLabel(selectedEvidenceChange ?? "current")}</strong>
+                      </div>
+                      <div className="summary-card">
+                        <span>Issue</span>
+                        <strong>{findingEvidenceQuery.data.result.issue ?? "—"}</strong>
+                      </div>
+                      <div className="summary-card">
+                        <span>Severity</span>
+                        <strong>{findingEvidenceQuery.data.result.severity}</strong>
+                      </div>
+                      <div className="summary-card">
+                        <span>Status</span>
+                        <strong>{findingEvidenceQuery.data.result.status_code ?? "—"}</strong>
+                      </div>
+                    </div>
+                    <ReviewTable
+                      emptyCopy="No evidence metadata for this finding."
+                      headings={["Method", "Path", "Kind", "URL"]}
+                      rows={[
+                        [
+                          findingEvidenceQuery.data.result.method,
+                          findingEvidenceQuery.data.result.path ?? "—",
+                          findingEvidenceQuery.data.result.kind,
+                          findingEvidenceQuery.data.result.url,
+                        ],
+                      ]}
+                    />
+                    {(findingEvidenceQuery.data.result.workflow_steps ?? []).length ? (
+                      <ReviewTable
+                        emptyCopy="No workflow steps recorded."
+                        headings={["Step", "Method", "Status", "Duration", "URL"]}
+                        rows={(findingEvidenceQuery.data.result.workflow_steps ?? []).map((step) => [
+                          step.name,
+                          step.method,
+                          step.status_code ?? "—",
+                          step.duration_ms ? `${step.duration_ms} ms` : "—",
+                          step.url,
+                        ])}
+                      />
+                    ) : null}
+                    {(findingEvidenceQuery.data.result.profile_results ?? []).length ? (
+                      <ReviewTable
+                        emptyCopy="No profile evidence recorded."
+                        headings={["Profile", "Level", "Status", "Issue", "Severity", "Workflow steps"]}
+                        rows={(findingEvidenceQuery.data.result.profile_results ?? []).map((profile) => [
+                          profile.anonymous ? `${profile.profile} (anonymous)` : profile.profile,
+                          profile.level,
+                          profile.status_code ?? "—",
+                          profile.issue ?? "—",
+                          profile.severity,
+                          profile.workflow_steps?.length ?? 0,
+                        ])}
+                      />
+                    ) : null}
+                    <ArtifactViewer
+                      document={drawerArtifactQuery.data}
+                      emptyCopy="No artifact references were derived for this finding."
+                      error={drawerArtifactError}
+                      isLoading={drawerArtifactQuery.isLoading}
+                      jobId={currentReviewedJob.id}
+                      onSelect={setSelectedDrawerArtifactName}
+                      references={findingEvidenceQuery.data.artifacts}
+                      selectedArtifactName={selectedDrawerArtifactName}
+                    />
+                    {findingEvidenceQuery.data.highlighted_auth_events.length ? (
+                      <ReviewTable
+                        emptyCopy="No matching auth events."
+                        headings={["Profile", "Name", "Strategy", "Phase", "Status", "Error"]}
+                        rows={findingEvidenceQuery.data.highlighted_auth_events.map((event) => [
+                          event.profile ?? "—",
+                          event.name,
+                          event.strategy,
+                          event.phase,
+                          event.status_code ?? (event.success ? "ok" : "failed"),
+                          event.error ?? "—",
+                        ])}
+                      />
+                    ) : null}
+                    <ReviewTable
+                      emptyCopy="No auth events captured for this run."
+                      headings={["Profile", "Name", "Strategy", "Phase", "Status", "Error"]}
+                      rows={findingEvidenceQuery.data.auth_events.map((event) => [
+                        event.profile ?? "—",
+                        event.name,
+                        event.strategy,
+                        event.phase,
+                        event.status_code ?? (event.success ? "ok" : "failed"),
+                        event.error ?? "—",
+                      ])}
+                    />
+                  </div>
+                ) : null}
+              </section>
+            ) : evidenceNotice ? (
+              <div className="empty-state">
+                <p>{evidenceNotice}</p>
+              </div>
+            ) : null}
+
+            {reviewTab === "overview" ? (
               <div className="stack">
                 <div className="summary-card-grid">
                   <div className="summary-card">
@@ -1377,18 +2070,22 @@ export default function ProjectWorkbenchPage() {
                   </div>
                   <div className="summary-card">
                     <span>New</span>
-                    <strong>{draft.artifacts.latest_summary?.new_findings_count ?? 0}</strong>
+                    <strong>{draft.artifacts.latest_verification?.new_findings_count ?? 0}</strong>
                   </div>
                   <div className="summary-card">
-                    <span>Persisting deltas</span>
-                    <strong>{draft.artifacts.latest_summary?.persisting_deltas_count ?? 0}</strong>
+                    <span>Persisting</span>
+                    <strong>{draft.artifacts.latest_verification?.persisting_findings_count ?? 0}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>Resolved</span>
+                    <strong>{draft.artifacts.latest_verification?.resolved_findings_count ?? 0}</strong>
                   </div>
                 </div>
                 <ReviewTable
                   emptyCopy="Run a suite and refresh analysis to populate the summary."
                   headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "URL"]}
                   rows={(draft.artifacts.latest_summary?.top_findings ?? []).map((finding) => [
-                    finding.name,
+                    findingAction(finding.name, finding),
                     finding.kind,
                     finding.issue ?? "—",
                     finding.severity,
@@ -1396,25 +2093,27 @@ export default function ProjectWorkbenchPage() {
                     finding.url,
                   ])}
                 />
-                <div className="report-grid">
-                  <article className="report-card">
-                    <h3>Markdown report</h3>
-                    <pre>{draft.artifacts.latest_markdown_report ?? "No Markdown report yet."}</pre>
-                  </article>
-                  <article className="report-card">
-                    <h3>HTML report</h3>
-                    <pre>{draft.artifacts.latest_html_report ?? "No HTML report yet."}</pre>
-                  </article>
-                </div>
+                <ReviewTable
+                  emptyCopy="No auth summary recorded for this run."
+                  headings={["Profile", "Name", "Strategy", "Acquire", "Refresh", "Failures"]}
+                  rows={(draft.artifacts.latest_summary?.auth_summary ?? []).map((entry) => [
+                    entry.profile,
+                    entry.name,
+                    entry.strategy,
+                    entry.acquire,
+                    entry.refresh,
+                    entry.failures,
+                  ])}
+                />
               </div>
             ) : null}
 
-            {reviewTab === "findings" ? (
+            {reviewTab === "new" ? (
               <ReviewTable
-                emptyCopy="No active findings match the current filter."
+                emptyCopy="No new findings match the current filter."
                 headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "Status", "Path"]}
-                rows={activeFindings.map((finding) => [
-                  finding.name,
+                rows={newFindings.map((finding) => [
+                  findingAction(finding.name, finding),
                   finding.kind,
                   finding.issue ?? "—",
                   finding.severity,
@@ -1425,12 +2124,49 @@ export default function ProjectWorkbenchPage() {
               />
             ) : null}
 
+            {reviewTab === "persisting" ? (
+              <ReviewTable
+                emptyCopy="No persisting findings match the current filter."
+                headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "Status", "Path"]}
+                rows={persistingFindings.map((finding) => [
+                  findingAction(finding.name, finding),
+                  finding.kind,
+                  finding.issue ?? "—",
+                  finding.severity,
+                  finding.confidence,
+                  finding.status_code ?? "—",
+                  finding.path ?? "—",
+                ])}
+              />
+            ) : null}
+
+            {reviewTab === "resolved" ? (
+              <div className="stack">
+                <p className="field-hint">
+                  Resolved findings are baseline-only in this milestone, so current-run artifact evidence is not available.
+                </p>
+                <ReviewTable
+                  emptyCopy="No resolved findings match the current filter."
+                  headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "Status", "Path"]}
+                  rows={resolvedFindings.map((finding) => [
+                    finding.name,
+                    finding.kind,
+                    finding.issue ?? "—",
+                    finding.severity,
+                    finding.confidence,
+                    finding.status_code ?? "—",
+                    finding.path ?? "—",
+                  ])}
+                />
+              </div>
+            ) : null}
+
             {reviewTab === "deltas" ? (
               <ReviewTable
-                emptyCopy="No persisting deltas are available."
+                emptyCopy="No persisting deltas are available for the current comparison."
                 headings={["Attack", "Issue", "Change summary", "Method", "Path"]}
-                rows={(draft.artifacts.latest_verification?.persisting_findings ?? []).map((finding) => [
-                  finding.name,
+                rows={deltaFindings.map((finding) => [
+                  findingAction(finding.name, finding),
                   finding.issue ?? "—",
                   finding.delta_changes.length
                     ? finding.delta_changes
@@ -1443,20 +2179,30 @@ export default function ProjectWorkbenchPage() {
               />
             ) : null}
 
-            {reviewTab === "auth" ? (
+            {reviewTab === "artifacts" ? (
               <div className="stack">
                 <ReviewTable
-                  emptyCopy="No auth summary recorded."
-                  headings={["Profile", "Name", "Strategy", "Acquire", "Refresh", "Failures"]}
-                  rows={(draft.artifacts.latest_summary?.auth_summary ?? []).map((entry) => [
-                    entry.profile,
-                    entry.name,
-                    entry.strategy,
-                    entry.acquire,
-                    entry.refresh,
-                    entry.failures,
+                  emptyCopy="No jobs for this project yet."
+                  headings={["Job", "Status", "Completed", "Active", "Artifacts", "Error"]}
+                  rows={currentJobs.map((job) => [
+                    job.id,
+                    job.status,
+                    formatJobMoment(job.completed_at ?? job.started_at ?? job.created_at),
+                    job.result_summary?.active_flagged_count ?? "—",
+                    job.artifact_names.length,
+                    job.error ?? "—",
                   ])}
                 />
+                <div className="report-grid">
+                  <article className="report-card">
+                    <h3>Markdown report</h3>
+                    <pre>{draft.artifacts.latest_markdown_report ?? "No Markdown report yet."}</pre>
+                  </article>
+                  <article className="report-card">
+                    <h3>HTML report</h3>
+                    <pre>{draft.artifacts.latest_html_report ?? "No HTML report yet."}</pre>
+                  </article>
+                </div>
                 <ReviewTable
                   emptyCopy="No auth events captured."
                   headings={["Profile", "Name", "Strategy", "Phase", "Status", "Error"]}
@@ -1469,35 +2215,22 @@ export default function ProjectWorkbenchPage() {
                     event.error ?? "—",
                   ])}
                 />
-              </div>
-            ) : null}
-
-            {reviewTab === "artifacts" ? (
-              <div className="stack">
-                <ReviewTable
-                  emptyCopy="No jobs for this project yet."
-                  headings={["Job", "Status", "Created", "Artifacts", "Error"]}
-                  rows={currentJobs.map((job) => [
-                    job.id,
-                    job.status,
-                    new Date(job.created_at).toLocaleString(),
-                    job.artifact_names.length,
-                    job.error ?? "—",
-                  ])}
-                />
-                <ul className="artifact-list">
-                  {(latestJob?.artifact_names ?? []).length ? (
-                    latestJob?.artifact_names.map((artifactName) => (
-                      <li key={artifactName}>
-                        <a href={`/v1/jobs/${latestJob.id}/artifacts/${artifactName}`} target="_blank">
-                          {artifactName}
-                        </a>
-                      </li>
-                    ))
-                  ) : (
-                    <li>No artifacts linked to the latest job.</li>
-                  )}
-                </ul>
+                {currentReviewedJob ? (
+                  <ArtifactViewer
+                    document={artifactsTabArtifactQuery.data}
+                    emptyCopy="No artifacts linked to the current compared run."
+                    error={artifactsTabArtifactError}
+                    isLoading={artifactsTabArtifactQuery.isLoading}
+                    jobId={currentReviewedJob.id}
+                    onSelect={setSelectedArtifactsTabArtifactName}
+                    references={artifactBrowserReferences}
+                    selectedArtifactName={selectedArtifactsTabArtifactName}
+                  />
+                ) : (
+                  <div className="empty-state">
+                    <p>No current compared run is available for artifact inspection.</p>
+                  </div>
+                )}
               </div>
             ) : null}
 
@@ -1532,8 +2265,8 @@ export default function ProjectWorkbenchPage() {
                     <strong>{draft.artifacts.latest_promoted_suite?.attacks.length ?? 0}</strong>
                   </div>
                   <div className="summary-card">
-                    <span>Latest run</span>
-                    <strong>{draft.artifacts.last_run_job_id ?? "—"}</strong>
+                    <span>Current run</span>
+                    <strong>{currentReviewedJob?.id ?? "—"}</strong>
                   </div>
                 </div>
                 <pre className="json-preview">
@@ -1549,6 +2282,30 @@ export default function ProjectWorkbenchPage() {
         <aside className="workbench-sidebar">
           <section className="sidebar-panel">
             <p className="eyebrow">Project state</p>
+            <h3>Compare context</h3>
+            <ul className="compact-list">
+              <li>
+                <strong>Current run</strong>
+                <span>{currentReviewedJob ? currentReviewedJob.id.slice(0, 8) : "—"}</span>
+              </li>
+              <li>
+                <strong>Pinned baseline</strong>
+                <span>
+                  {draft.review_draft.baseline_mode === "external"
+                    ? "External JSON"
+                    : baselineReviewedJob
+                      ? baselineReviewedJob.id.slice(0, 8)
+                      : "—"}
+                </span>
+              </li>
+              <li>
+                <strong>Last compared</strong>
+                <span>{formatJobMoment(draft.artifacts.latest_summary?.executed_at)}</span>
+              </li>
+            </ul>
+          </section>
+          <section className="sidebar-panel">
+            <p className="eyebrow">Project state</p>
             <h3>Run history</h3>
             <ul className="job-feed">
               {currentJobs.length ? (
@@ -1556,11 +2313,20 @@ export default function ProjectWorkbenchPage() {
                   <li className="job-feed-item" key={job.id}>
                     <div className="job-feed-top">
                       <code>{job.id.slice(0, 8)}</code>
-                      <span className={`status-chip ${statusTone(job.status)}`}>{job.status}</span>
+                      <div className="job-feed-badges">
+                        {currentReviewedJob?.id === job.id ? (
+                          <span className="status-chip status-running">current</span>
+                        ) : null}
+                        {draft.review_draft.baseline_mode === "job" &&
+                        draft.review_draft.baseline_job_id === job.id ? (
+                          <span className="status-chip status-pending">baseline</span>
+                        ) : null}
+                        <span className={`status-chip ${statusTone(job.status)}`}>{job.status}</span>
+                      </div>
                     </div>
                     <p>{job.base_url}</p>
                     <small>
-                      {new Date(job.created_at).toLocaleString()}
+                      {summarizeJob(job)}
                       {job.error ? ` • ${job.error}` : ""}
                     </small>
                   </li>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -453,6 +453,63 @@ pre {
   gap: 14px;
 }
 
+.compare-banner {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.compare-card {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid rgba(13, 108, 99, 0.18);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(13, 108, 99, 0.08), rgba(255, 255, 255, 0.72));
+}
+
+.compare-card strong {
+  font-size: 1.05rem;
+}
+
+.advanced-panel {
+  margin: 18px 0;
+  padding: 14px;
+  border: 1px dashed rgba(13, 108, 99, 0.28);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.46);
+}
+
+.advanced-panel summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.finding-link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--accent-strong);
+  cursor: pointer;
+  font-weight: 700;
+  text-align: left;
+}
+
+.finding-link:hover {
+  text-decoration: underline;
+}
+
+.evidence-drawer {
+  margin: 18px 0;
+  padding: 18px;
+  border: 1px solid rgba(13, 108, 99, 0.22);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, rgba(13, 108, 99, 0.06), rgba(255, 255, 255, 0.82));
+}
+
 .summary-card {
   border: 1px solid var(--line);
   border-radius: 18px;
@@ -470,6 +527,79 @@ pre {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
+}
+
+.artifact-viewer {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.95fr) minmax(0, 1.35fr);
+  gap: 16px;
+}
+
+.artifact-reference-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.artifact-reference-item,
+.artifact-preview-panel,
+.artifact-structured-card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.artifact-reference-item {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+}
+
+.artifact-reference-item-active {
+  border-color: rgba(13, 108, 99, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(13, 108, 99, 0.18);
+}
+
+.artifact-reference-button {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-weight: 700;
+  text-align: left;
+}
+
+.artifact-reference-button:disabled {
+  cursor: default;
+  color: var(--muted);
+}
+
+.artifact-reference-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.artifact-reference-meta a {
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+.artifact-reference-meta a:hover {
+  text-decoration: underline;
+}
+
+.artifact-preview-panel {
+  padding: 16px;
+}
+
+.artifact-structured-card {
+  padding: 16px;
 }
 
 .report-card pre,
@@ -514,6 +644,13 @@ pre {
   font-size: 0.88rem;
 }
 
+.job-feed-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 .artifact-list a {
   color: var(--accent-strong);
   text-decoration: none;
@@ -553,7 +690,9 @@ pre {
   .field-grid-4,
   .field-grid-3,
   .field-grid-2,
-  .report-grid {
+  .artifact-viewer,
+  .report-grid,
+  .compare-banner {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,13 @@ export type ProjectSourceMode = "openapi" | "graphql" | "learned" | "capture_upl
 export type ProjectStep = "source" | "inspect" | "generate" | "run" | "review";
 export type ApiJobStatus = "pending" | "running" | "completed" | "failed";
 export type ApiReportFormat = "markdown" | "html";
+export type ProjectReviewBaselineMode = "job" | "external";
+export type ArtifactReferenceKind =
+  | "request"
+  | "workflow_terminal"
+  | "workflow_step"
+  | "profile_request"
+  | "profile_workflow_step";
 
 export interface SourcePayload {
   name: string;
@@ -95,14 +102,35 @@ export interface AuthEvent {
 }
 
 export interface ProfileAttackResult {
+  protocol?: string;
   profile: string;
   level: number;
   anonymous: boolean;
   url: string;
   status_code?: number | null;
+  error?: string | null;
+  duration_ms?: number | null;
+  flagged?: boolean;
   issue?: string | null;
   severity: string;
   confidence: string;
+  response_excerpt?: string | null;
+  response_schema_status?: string | null;
+  response_schema_valid?: boolean | null;
+  response_schema_error?: string | null;
+  graphql_response_valid?: boolean | null;
+  graphql_response_error?: string | null;
+  graphql_response_hint?: string | null;
+  workflow_steps?: Array<{
+    name: string;
+    operation_id: string;
+    method: string;
+    url: string;
+    status_code?: number | null;
+    error?: string | null;
+    duration_ms?: number | null;
+    response_excerpt?: string | null;
+  }> | null;
 }
 
 export interface AttackResult {
@@ -133,6 +161,8 @@ export interface AttackResult {
     url: string;
     status_code?: number | null;
     error?: string | null;
+    duration_ms?: number | null;
+    response_excerpt?: string | null;
   }> | null;
   profile_results?: ProfileAttackResult[] | null;
 }
@@ -283,6 +313,31 @@ export interface JobStatusResponse {
   error?: string | null;
   result_available: boolean;
   artifact_names: string[];
+  result_summary?: ResultsSummary | null;
+}
+
+export interface ArtifactReferenceResponse {
+  label: string;
+  kind: ArtifactReferenceKind;
+  artifact_name: string;
+  available: boolean;
+  profile?: string | null;
+  step_index?: number | null;
+}
+
+export interface JobFindingEvidenceResponse {
+  job_id: string;
+  attack_id: string;
+  result: AttackResult;
+  artifacts: ArtifactReferenceResponse[];
+  auth_events: AuthEvent[];
+  highlighted_auth_events: AuthEvent[];
+}
+
+export interface JobArtifactDocument {
+  artifact_name: string;
+  format: "json" | "text";
+  content: unknown;
 }
 
 export interface ProjectInspectDraft {
@@ -332,10 +387,35 @@ export interface ProjectRunDraft {
 }
 
 export interface ProjectReviewDraft {
+  baseline_mode: ProjectReviewBaselineMode;
+  baseline_job_id?: string | null;
   baseline?: AttackResults | null;
   suppressions_yaml?: string | null;
   min_severity: string;
   min_confidence: string;
+}
+
+export interface ProjectReviewRequest {
+  baseline_mode?: ProjectReviewBaselineMode | null;
+  baseline_job_id?: string | null;
+  baseline?: AttackResults | null;
+  suppressions_yaml?: string | null;
+  min_severity?: string | null;
+  min_confidence?: string | null;
+}
+
+export interface ProjectReviewResponse {
+  project_id: string;
+  current_job_id: string;
+  baseline_mode: ProjectReviewBaselineMode;
+  baseline_job_id?: string | null;
+  baseline_used: boolean;
+  waiting_for_new_run: boolean;
+  results: AttackResults;
+  summary: ResultsSummary;
+  verification: VerifyResponse;
+  markdown_report: string;
+  html_report: string;
 }
 
 export interface ProjectArtifacts {

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -792,6 +792,7 @@ def create_app(
                 detail="Active jobs cannot be deleted; wait for completion or failure first.",
             ) from exc
         return DeleteJobResponse(deleted=_retention_entry(deleted))
+
     @app.post("/v1/inspect", response_model=InspectResponse)
     def inspect_endpoint(request: InspectRequest) -> InspectResponse:
         result = inspect_source_inline(

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import threading
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -15,6 +16,8 @@ from knives_out import __version__
 from knives_out.api_models import (
     ApiJobStatus,
     ArtifactListResponse,
+    ArtifactReferenceKind,
+    ArtifactReferenceResponse,
     DeleteJobResponse,
     DeltaChangeResponse,
     DiscoverRequest,
@@ -24,6 +27,7 @@ from knives_out.api_models import (
     GenerateResponse,
     InspectRequest,
     InspectResponse,
+    JobFindingEvidenceResponse,
     JobListResponse,
     JobRecord,
     JobRetentionEntry,
@@ -32,6 +36,10 @@ from knives_out.api_models import (
     ProjectJobsResponse,
     ProjectListResponse,
     ProjectRecord,
+    ProjectReviewBaselineMode,
+    ProjectReviewDraft,
+    ProjectReviewRequest,
+    ProjectReviewResponse,
     ProjectSourceMode,
     ProjectSummaryResponse,
     ProjectUpdateRequest,
@@ -51,7 +59,7 @@ from knives_out.api_models import (
     VerifyResponse,
 )
 from knives_out.api_store import ActiveJobDeletionError, DeletedJob, JobNotFoundError, JobStore
-from knives_out.models import AttackResults, ResultsSummary
+from knives_out.models import AttackResult, AttackResults, ResultsSummary
 from knives_out.project_store import ProjectNotFoundError, ProjectStore
 from knives_out.services import (
     InlineInput,
@@ -68,6 +76,8 @@ from knives_out.services import (
 
 PRUNEABLE_JOB_STATUSES = frozenset({ApiJobStatus.completed, ApiJobStatus.failed})
 JOB_SUMMARY_TOP_LIMIT = 3
+PROJECT_REVIEW_TOP_LIMIT = 50
+_PROFILE_ARTIFACT_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
 def _finding_summary(finding) -> FindingSummaryResponse:
@@ -204,6 +214,94 @@ def _default_source_for_mode(source_mode: ProjectSourceMode) -> SourcePayload | 
     return None
 
 
+def _profile_artifact_segment(profile_name: str) -> str:
+    return _PROFILE_ARTIFACT_SEGMENT_RE.sub("-", profile_name).strip("-") or "profile"
+
+
+def _artifact_reference(
+    available_artifacts: set[str],
+    *,
+    label: str,
+    kind: ArtifactReferenceKind,
+    artifact_name: str,
+    profile: str | None = None,
+    step_index: int | None = None,
+) -> ArtifactReferenceResponse:
+    return ArtifactReferenceResponse(
+        label=label,
+        kind=kind,
+        artifact_name=artifact_name,
+        available=artifact_name in available_artifacts,
+        profile=profile,
+        step_index=step_index,
+    )
+
+
+def _finding_artifact_references(
+    available_artifacts: set[str],
+    result: AttackResult,
+) -> list[ArtifactReferenceResponse]:
+    references = [
+        _artifact_reference(
+            available_artifacts,
+            label="Request artifact" if result.type == "request" else "Workflow terminal artifact",
+            kind=(
+                ArtifactReferenceKind.request
+                if result.type == "request"
+                else ArtifactReferenceKind.workflow_terminal
+            ),
+            artifact_name=f"{result.attack_id}.json",
+        )
+    ]
+    for index, _ in enumerate(result.workflow_steps or [], start=1):
+        references.append(
+            _artifact_reference(
+                available_artifacts,
+                label=f"Workflow step {index}",
+                kind=ArtifactReferenceKind.workflow_step,
+                artifact_name=f"{result.attack_id}-step-{index:02d}.json",
+                step_index=index,
+            )
+        )
+    for profile_result in result.profile_results or []:
+        profile_segment = _profile_artifact_segment(profile_result.profile)
+        references.append(
+            _artifact_reference(
+                available_artifacts,
+                label=f"{profile_result.profile} profile artifact",
+                kind=ArtifactReferenceKind.profile_request,
+                artifact_name=f"{profile_segment}/{result.attack_id}.json",
+                profile=profile_result.profile,
+            )
+        )
+        for index, _ in enumerate(profile_result.workflow_steps or [], start=1):
+            references.append(
+                _artifact_reference(
+                    available_artifacts,
+                    label=f"{profile_result.profile} step {index}",
+                    kind=ArtifactReferenceKind.profile_workflow_step,
+                    artifact_name=f"{profile_segment}/{result.attack_id}-step-{index:02d}.json",
+                    profile=profile_result.profile,
+                    step_index=index,
+                )
+            )
+    return references
+
+
+def _finding_result(results: AttackResults, attack_id: str) -> AttackResult:
+    for result in results.results:
+        if result.attack_id == attack_id:
+            return result
+    raise HTTPException(status_code=404, detail="Finding not found for job.")
+
+
+def _highlighted_auth_events(results: AttackResults, result: AttackResult):
+    if not result.profile_results:
+        return []
+    profiles = {profile_result.profile for profile_result in result.profile_results}
+    return [event for event in results.auth_events if event.profile in profiles]
+
+
 def _project_source_name(project: ProjectRecord) -> str | None:
     if project.source is not None:
         return project.source.name
@@ -241,6 +339,51 @@ def _project_summary(
         ),
         active_flagged_count=active_flagged_count,
     )
+
+
+def _effective_project_review_draft(
+    project: ProjectRecord,
+    request: ProjectReviewRequest,
+) -> ProjectReviewDraft:
+    changes = request.model_dump(exclude_unset=True)
+    if not changes:
+        return project.review_draft
+    return ProjectReviewDraft.model_validate(
+        {
+            **project.review_draft.model_dump(mode="python"),
+            **changes,
+        }
+    )
+
+
+def _latest_completed_project_job(job_store: JobStore, project_id: str) -> JobRecord | None:
+    for record in job_store.list_job_records():
+        if record.project_id != project_id:
+            continue
+        if record.status != ApiJobStatus.completed:
+            continue
+        if not job_store.result_exists(record.id):
+            continue
+        return record
+    return None
+
+
+def _project_baseline_job(job_store: JobStore, project_id: str, baseline_job_id: str) -> JobRecord:
+    try:
+        record = job_store.load_job(baseline_job_id)
+    except JobNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Baseline job not found.") from exc
+    if record.project_id != project_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Baseline job must belong to the same project.",
+        )
+    if record.status != ApiJobStatus.completed or not job_store.result_exists(record.id):
+        raise HTTPException(
+            status_code=400,
+            detail="Baseline job must be completed and have stored results.",
+        )
+    return record
 
 
 def _frontend_missing_response(frontend_root: Path) -> HTMLResponse:
@@ -459,6 +602,82 @@ def create_app(
         return ProjectJobsResponse(
             project_id=project_id,
             jobs=jobs,
+        )
+
+    @app.post("/v1/projects/{project_id}/review", response_model=ProjectReviewResponse)
+    def review_project(
+        project_id: str,
+        request: ProjectReviewRequest,
+    ) -> ProjectReviewResponse:
+        project_store: ProjectStore = app.state.project_store
+        job_store: JobStore = app.state.job_store
+        try:
+            project = project_store.load_project(project_id)
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+        review_draft = _effective_project_review_draft(project, request)
+        current_job = _latest_completed_project_job(job_store, project_id)
+        if current_job is None:
+            raise HTTPException(
+                status_code=409,
+                detail="No completed project run with stored results is available for review.",
+            )
+
+        waiting_for_new_run = False
+        baseline_results = None
+        if review_draft.baseline_mode == ProjectReviewBaselineMode.job:
+            if review_draft.baseline_job_id:
+                baseline_job = _project_baseline_job(
+                    job_store,
+                    project_id,
+                    review_draft.baseline_job_id,
+                )
+                if baseline_job.id == current_job.id:
+                    waiting_for_new_run = True
+                else:
+                    baseline_results = job_store.load_result(baseline_job.id)
+        elif review_draft.baseline is not None:
+            baseline_results = review_draft.baseline
+
+        results = job_store.load_result(current_job.id)
+        summary = summarize_results_from_models(
+            results,
+            baseline=baseline_results,
+            suppressions_yaml=review_draft.suppressions_yaml,
+            top_limit=PROJECT_REVIEW_TOP_LIMIT,
+        )
+        verification = verify_results_from_models(
+            results,
+            baseline=baseline_results,
+            suppressions_yaml=review_draft.suppressions_yaml,
+            min_severity=review_draft.min_severity,
+            min_confidence=review_draft.min_confidence,
+        )
+        markdown_report = render_report_from_models(
+            results,
+            baseline=baseline_results,
+            suppressions_yaml=review_draft.suppressions_yaml,
+            format="markdown",
+        )
+        html_report = render_report_from_models(
+            results,
+            baseline=baseline_results,
+            suppressions_yaml=review_draft.suppressions_yaml,
+            format="html",
+        )
+        return ProjectReviewResponse(
+            project_id=project_id,
+            current_job_id=current_job.id,
+            baseline_mode=review_draft.baseline_mode,
+            baseline_job_id=review_draft.baseline_job_id,
+            baseline_used=summary.baseline_used,
+            waiting_for_new_run=waiting_for_new_run,
+            results=results,
+            summary=SummaryResponse(**summary.model_dump(mode="python")),
+            verification=_verify_response(verification),
+            markdown_report=markdown_report,
+            html_report=html_report,
         )
 
     @app.post("/v1/inspect", response_model=InspectResponse)
@@ -688,6 +907,32 @@ def create_app(
             return job_store.load_result(job_id)
         except JobNotFoundError as exc:
             raise HTTPException(status_code=404, detail="Job result not available.") from exc
+
+    @app.get(
+        "/v1/jobs/{job_id}/findings/{attack_id}/evidence",
+        response_model=JobFindingEvidenceResponse,
+    )
+    def get_job_finding_evidence(job_id: str, attack_id: str) -> JobFindingEvidenceResponse:
+        job_store: JobStore = app.state.job_store
+        try:
+            job_store.load_job(job_id)
+        except JobNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Job not found.") from exc
+        try:
+            results = job_store.load_result(job_id)
+        except JobNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Job result not available.") from exc
+
+        result = _finding_result(results, attack_id)
+        artifacts = _finding_artifact_references(set(job_store.list_artifacts(job_id)), result)
+        return JobFindingEvidenceResponse(
+            job_id=job_id,
+            attack_id=attack_id,
+            result=result,
+            artifacts=artifacts,
+            auth_events=results.auth_events,
+            highlighted_auth_events=_highlighted_auth_events(results, result),
+        )
 
     @app.get("/v1/jobs/{job_id}/artifacts", response_model=ArtifactListResponse)
     def get_job_artifacts(job_id: str) -> ArtifactListResponse:

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -8,8 +8,10 @@ from uuid import uuid4
 from pydantic import BaseModel, Field
 
 from knives_out.models import (
+    AttackResult,
     AttackResults,
     AttackSuite,
+    AuthEvent,
     LearnedModel,
     OperationSpec,
     PreflightWarning,
@@ -44,6 +46,19 @@ class ProjectStep(StrEnum):
     generate = "generate"
     run = "run"
     review = "review"
+
+
+class ProjectReviewBaselineMode(StrEnum):
+    job = "job"
+    external = "external"
+
+
+class ArtifactReferenceKind(StrEnum):
+    request = "request"
+    workflow_terminal = "workflow_terminal"
+    workflow_step = "workflow_step"
+    profile_request = "profile_request"
+    profile_workflow_step = "profile_workflow_step"
 
 
 class SourcePayload(BaseModel):
@@ -255,6 +270,24 @@ class ArtifactListResponse(BaseModel):
     artifacts: list[str] = Field(default_factory=list)
 
 
+class ArtifactReferenceResponse(BaseModel):
+    label: str
+    kind: ArtifactReferenceKind
+    artifact_name: str
+    available: bool = False
+    profile: str | None = None
+    step_index: int | None = None
+
+
+class JobFindingEvidenceResponse(BaseModel):
+    job_id: str
+    attack_id: str
+    result: AttackResult
+    artifacts: list[ArtifactReferenceResponse] = Field(default_factory=list)
+    auth_events: list[AuthEvent] = Field(default_factory=list)
+    highlighted_auth_events: list[AuthEvent] = Field(default_factory=list)
+
+
 class JobListResponse(BaseModel):
     count: int
     jobs: list[JobStatusResponse] = Field(default_factory=list)
@@ -339,10 +372,35 @@ class ProjectRunDraft(BaseModel):
 
 
 class ProjectReviewDraft(BaseModel):
+    baseline_mode: ProjectReviewBaselineMode = ProjectReviewBaselineMode.job
+    baseline_job_id: str | None = None
     baseline: AttackResults | None = None
     suppressions_yaml: str | None = None
     min_severity: str = "high"
     min_confidence: str = "medium"
+
+
+class ProjectReviewRequest(BaseModel):
+    baseline_mode: ProjectReviewBaselineMode | None = None
+    baseline_job_id: str | None = None
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    min_severity: str | None = None
+    min_confidence: str | None = None
+
+
+class ProjectReviewResponse(BaseModel):
+    project_id: str
+    current_job_id: str
+    baseline_mode: ProjectReviewBaselineMode
+    baseline_job_id: str | None = None
+    baseline_used: bool = False
+    waiting_for_new_run: bool = False
+    results: AttackResults
+    summary: SummaryResponse
+    verification: VerifyResponse
+    markdown_report: str
+    html_report: str
 
 
 class ProjectArtifacts(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,16 @@ from fastapi.testclient import TestClient
 from knives_out.api import create_app
 from knives_out.api_models import ApiJobStatus, JobRecord
 from knives_out.api_store import JobStore
-from knives_out.models import AttackCase, AttackResult, AttackResults, AttackSuite, LearnedModel
+from knives_out.models import (
+    AttackCase,
+    AttackResult,
+    AttackResults,
+    AttackSuite,
+    AuthEvent,
+    LearnedModel,
+    ProfileAttackResult,
+    WorkflowStepResult,
+)
 
 OPENAPI_SPEC = dedent(
     """
@@ -139,6 +148,104 @@ def _baseline_results() -> AttackResults:
     )
 
 
+def _workflow_profile_results() -> AttackResults:
+    return AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        profiles=["member", "anonymous"],
+        auth_events=[
+            AuthEvent(
+                name="member-login",
+                strategy="cookie",
+                phase="acquire",
+                success=True,
+                profile="member",
+                endpoint="/login",
+                status_code=200,
+            ),
+            AuthEvent(
+                name="anonymous-fallback",
+                strategy="header",
+                phase="refresh",
+                success=False,
+                profile="anonymous",
+                endpoint="/graphql",
+                status_code=401,
+                error="expired token",
+            ),
+            AuthEvent(
+                name="admin-session",
+                strategy="cookie",
+                phase="acquire",
+                success=True,
+                profile="admin",
+                endpoint="/admin",
+                status_code=200,
+            ),
+        ],
+        results=[
+            AttackResult(
+                type="workflow",
+                attack_id="wf_checkout",
+                operation_id="checkout",
+                kind="authorization_inversion",
+                name="Checkout workflow",
+                method="POST",
+                path="/checkout",
+                url="https://example.com/checkout",
+                status_code=500,
+                flagged=True,
+                issue="authorization_inversion",
+                severity="high",
+                confidence="medium",
+                workflow_steps=[
+                    WorkflowStepResult(
+                        name="Create cart",
+                        operation_id="createCart",
+                        method="POST",
+                        url="https://example.com/cart",
+                        status_code=201,
+                        duration_ms=12.4,
+                        response_excerpt='{"id":"cart-1"}',
+                    )
+                ],
+                profile_results=[
+                    ProfileAttackResult(
+                        profile="member",
+                        level=1,
+                        anonymous=False,
+                        url="https://example.com/checkout",
+                        status_code=403,
+                        flagged=True,
+                        issue="authorization_inversion",
+                        severity="high",
+                        confidence="high",
+                        workflow_steps=[
+                            WorkflowStepResult(
+                                name="Create cart",
+                                operation_id="createCart",
+                                method="POST",
+                                url="https://example.com/cart",
+                                status_code=201,
+                            )
+                        ],
+                    ),
+                    ProfileAttackResult(
+                        profile="anonymous",
+                        level=0,
+                        anonymous=True,
+                        url="https://example.com/checkout",
+                        status_code=200,
+                        flagged=False,
+                        severity="none",
+                        confidence="none",
+                    ),
+                ],
+            )
+        ],
+    )
+
+
 def _stored_job(
     store: JobStore,
     *,
@@ -147,6 +254,7 @@ def _stored_job(
     completed_at: datetime | None = None,
     base_url: str = "https://example.com",
     attack_count: int = 1,
+    project_id: str | None = None,
     error: str | None = None,
     with_result: bool = False,
     with_artifact: bool = False,
@@ -158,6 +266,7 @@ def _stored_job(
                 "created_at": created_at,
                 "started_at": created_at,
                 "completed_at": completed_at,
+                "project_id": project_id,
                 "error": error,
             }
         )
@@ -269,6 +378,144 @@ def test_run_job_lifecycle_and_artifacts(tmp_path, monkeypatch) -> None:
     artifact_response = client.get(f"/v1/jobs/{job_id}/artifacts/atk_api.json")
     assert artifact_response.status_code == 200
     assert artifact_response.json()["attack"]["id"] == "atk_api"
+
+
+def test_job_finding_evidence_endpoint_returns_request_artifact_context(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    record = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+        with_result=True,
+        with_artifact=True,
+    )
+
+    response = client.get(f"/v1/jobs/{record.id}/findings/atk_api/evidence")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["job_id"] == record.id
+    assert payload["attack_id"] == "atk_api"
+    assert payload["result"]["attack_id"] == "atk_api"
+    assert payload["artifacts"] == [
+        {
+            "label": "Request artifact",
+            "kind": "request",
+            "artifact_name": "atk_api.json",
+            "available": True,
+            "profile": None,
+            "step_index": None,
+        }
+    ]
+    assert payload["auth_events"] == []
+    assert payload["highlighted_auth_events"] == []
+
+
+def test_job_finding_evidence_endpoint_returns_workflow_and_profile_artifacts(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    record = store.create_job(
+        JobRecord(base_url="https://example.com", attack_count=1).model_copy(
+            update={
+                "status": ApiJobStatus.completed,
+                "created_at": datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+                "started_at": datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+                "completed_at": datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+            }
+    )
+    )
+    store.write_result(record.id, _workflow_profile_results())
+    artifact_root = store.artifact_dir(record.id)
+    (artifact_root / "wf_checkout.json").write_text(
+        '{"attack":{"id":"wf_checkout"}}',
+        encoding="utf-8",
+    )
+    (artifact_root / "wf_checkout-step-01.json").write_text(
+        '{"attack":{"id":"wf_checkout-step-01"}}',
+        encoding="utf-8",
+    )
+    member_root = artifact_root / "member"
+    member_root.mkdir(parents=True, exist_ok=True)
+    (member_root / "wf_checkout.json").write_text(
+        '{"attack":{"id":"wf_checkout","profile":"member"}}',
+        encoding="utf-8",
+    )
+    (member_root / "wf_checkout-step-01.json").write_text(
+        '{"attack":{"id":"wf_checkout-step-01","profile":"member"}}',
+        encoding="utf-8",
+    )
+
+    response = client.get(f"/v1/jobs/{record.id}/findings/wf_checkout/evidence")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result"]["type"] == "workflow"
+    assert payload["result"]["workflow_steps"][0]["name"] == "Create cart"
+    assert [artifact["artifact_name"] for artifact in payload["artifacts"]] == [
+        "wf_checkout.json",
+        "wf_checkout-step-01.json",
+        "member/wf_checkout.json",
+        "member/wf_checkout-step-01.json",
+        "anonymous/wf_checkout.json",
+    ]
+    assert [artifact["available"] for artifact in payload["artifacts"]] == [
+        True,
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert [artifact["kind"] for artifact in payload["artifacts"]] == [
+        "workflow_terminal",
+        "workflow_step",
+        "profile_request",
+        "profile_workflow_step",
+        "profile_request",
+    ]
+    assert [event["profile"] for event in payload["highlighted_auth_events"]] == [
+        "member",
+        "anonymous",
+    ]
+    assert len(payload["auth_events"]) == 3
+
+
+def test_job_finding_evidence_endpoint_handles_missing_results_attacks_and_artifacts(
+    tmp_path,
+) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    missing_result = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+    )
+    no_artifact = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 13, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 13, 1, tzinfo=UTC),
+        with_result=True,
+    )
+
+    assert client.get("/v1/jobs/missing/findings/atk_api/evidence").status_code == 404
+
+    missing_result_response = client.get(f"/v1/jobs/{missing_result.id}/findings/atk_api/evidence")
+    assert missing_result_response.status_code == 404
+    assert missing_result_response.json()["detail"] == "Job result not available."
+
+    missing_finding_response = client.get(f"/v1/jobs/{no_artifact.id}/findings/missing/evidence")
+    assert missing_finding_response.status_code == 404
+    assert missing_finding_response.json()["detail"] == "Finding not found for job."
+
+    no_artifact_response = client.get(f"/v1/jobs/{no_artifact.id}/findings/atk_api/evidence")
+    assert no_artifact_response.status_code == 200
+    assert no_artifact_response.json()["artifacts"][0]["available"] is False
 
 
 def test_run_job_status_endpoints_404_for_missing_job(tmp_path) -> None:
@@ -505,6 +752,193 @@ def test_job_list_endpoint_returns_recent_jobs_and_filters_status(tmp_path) -> N
     filtered_payload = filtered_response.json()
     assert filtered_payload["count"] == 1
     assert [job["id"] for job in filtered_payload["jobs"]] == [completed_record.id]
+
+
+def test_project_review_endpoint_uses_latest_completed_run_and_selected_baseline(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    project_id = client.post("/v1/projects", json={"name": "Review demo"}).json()["id"]
+
+    baseline_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 11, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 11, 1, tzinfo=UTC),
+        project_id=project_id,
+    )
+    current_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+        project_id=project_id,
+    )
+    store.write_result(
+        baseline_job.id,
+        _baseline_results().model_copy(update={"base_url": "https://example.com"}),
+    )
+    store.write_result(
+        current_job.id,
+        _flagged_results().model_copy(update={"base_url": "https://example.com"}),
+    )
+
+    response = client.post(
+        f"/v1/projects/{project_id}/review",
+        json={"baseline_mode": "job", "baseline_job_id": baseline_job.id},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["project_id"] == project_id
+    assert payload["current_job_id"] == current_job.id
+    assert payload["baseline_job_id"] == baseline_job.id
+    assert payload["baseline_mode"] == "job"
+    assert payload["baseline_used"] is True
+    assert payload["waiting_for_new_run"] is False
+    assert payload["summary"]["baseline_used"] is True
+    assert payload["verification"]["baseline_used"] is True
+    assert payload["verification"]["persisting_findings_count"] == 1
+    assert payload["verification"]["persisting_findings"][0]["delta_changes"][0]["field"] == (
+        "severity"
+    )
+
+
+def test_project_review_endpoint_rejects_invalid_baseline_jobs(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    project_id = client.post("/v1/projects", json={"name": "Review demo"}).json()["id"]
+    other_project_id = client.post("/v1/projects", json={"name": "Other"}).json()["id"]
+
+    current_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+        project_id=project_id,
+    )
+    store.write_result(current_job.id, _flagged_results())
+
+    other_project_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 11, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 11, 1, tzinfo=UTC),
+        project_id=other_project_id,
+        with_result=True,
+    )
+    no_result_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 10, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 10, 1, tzinfo=UTC),
+        project_id=project_id,
+    )
+
+    missing_response = client.post(
+        f"/v1/projects/{project_id}/review",
+        json={"baseline_mode": "job", "baseline_job_id": "missing"},
+    )
+    assert missing_response.status_code == 404
+    assert missing_response.json()["detail"] == "Baseline job not found."
+
+    cross_project_response = client.post(
+        f"/v1/projects/{project_id}/review",
+        json={"baseline_mode": "job", "baseline_job_id": other_project_job.id},
+    )
+    assert cross_project_response.status_code == 400
+    assert cross_project_response.json()["detail"] == (
+        "Baseline job must belong to the same project."
+    )
+
+    no_result_response = client.post(
+        f"/v1/projects/{project_id}/review",
+        json={"baseline_mode": "job", "baseline_job_id": no_result_job.id},
+    )
+    assert no_result_response.status_code == 400
+    assert no_result_response.json()["detail"] == (
+        "Baseline job must be completed and have stored results."
+    )
+
+
+def test_project_review_endpoint_rejects_invalid_external_baseline_json(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    project_id = client.post("/v1/projects", json={"name": "Review demo"}).json()["id"]
+
+    current_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+        project_id=project_id,
+        with_result=True,
+    )
+
+    assert current_job.project_id == project_id
+
+    response = client.post(
+        f"/v1/projects/{project_id}/review",
+        json={"baseline_mode": "external", "baseline": {"unexpected": "shape"}},
+    )
+
+    assert response.status_code == 422
+
+
+def test_project_review_endpoint_waits_when_latest_run_is_pinned_as_baseline(tmp_path) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    store = app.state.job_store
+    project_id = client.post("/v1/projects", json={"name": "Review demo"}).json()["id"]
+
+    current_job = _stored_job(
+        store,
+        status=ApiJobStatus.completed,
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
+        project_id=project_id,
+        with_result=True,
+    )
+
+    response = client.post(
+        f"/v1/projects/{project_id}/review",
+        json={"baseline_mode": "job", "baseline_job_id": current_job.id},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["current_job_id"] == current_job.id
+    assert payload["baseline_job_id"] == current_job.id
+    assert payload["baseline_used"] is False
+    assert payload["waiting_for_new_run"] is True
+
+
+def test_project_update_persists_review_baseline_selection(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+    project_id = client.post("/v1/projects", json={"name": "Review demo"}).json()["id"]
+
+    response = client.patch(
+        f"/v1/projects/{project_id}",
+        json={
+            "review_draft": {
+                "baseline_mode": "job",
+                "baseline_job_id": "job-baseline",
+                "baseline": None,
+                "suppressions_yaml": None,
+                "min_severity": "medium",
+                "min_confidence": "low",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["review_draft"]["baseline_mode"] == "job"
+    assert payload["review_draft"]["baseline_job_id"] == "job-baseline"
+    assert payload["review_draft"]["min_severity"] == "medium"
+    assert payload["review_draft"]["min_confidence"] == "low"
 
 
 def test_job_store_lists_nested_artifacts_and_rejects_path_traversal(tmp_path) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -426,7 +426,7 @@ def test_job_finding_evidence_endpoint_returns_workflow_and_profile_artifacts(tm
                 "started_at": datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
                 "completed_at": datetime(2026, 4, 13, 12, 1, tzinfo=UTC),
             }
-    )
+        )
     )
     store.write_result(record.id, _workflow_profile_results())
     artifact_root = store.artifact_dir(record.id)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -38,11 +38,15 @@ def test_readme_includes_ci_guidance() -> None:
     assert "POST /v1/runs" in readme
     assert "DELETE /v1/jobs/{id}" in readme
     assert "POST /v1/jobs/prune" in readme
+    assert "GET /v1/jobs/{id}/findings/{attack_id}/evidence" in readme
     assert "GET /v1/jobs/{id}/artifacts" in readme
     assert "completed or failed jobs" in readme
     assert "GET /v1/jobs" in readme
     assert "GET /v1/jobs/{id}/artifacts" in readme
     assert "result_summary" in readme
+    assert "POST /v1/projects/{id}/review" in readme
+    assert "baseline_job_id" in readme
+    assert "external baseline mode" in readme
     assert "--profile-file examples/auth_profiles/anonymous-user-admin.yml" in readme
     assert "anonymous_access" in readme
     assert "--auto-workflows" in readme
@@ -132,6 +136,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "knives-out discover capture.ndjson --out learned-model.json" in ci_doc
     assert "GET /v1/jobs" in ci_doc
     assert "result_summary" in ci_doc
+    assert "POST /v1/projects/{id}/review" in ci_doc
+    assert "baseline_job_id" in ci_doc
     assert "examples/auth_configs/user-admin.yml" in ci_doc
     assert "examples/auth_configs/client-credentials.yml" in ci_doc
     assert "examples/auth_profiles/anonymous-user-admin.yml" in ci_doc
@@ -148,6 +154,7 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "POST /v1/runs" in ci_doc
     assert "DELETE /v1/jobs/{id}" in ci_doc
     assert "POST /v1/jobs/prune" in ci_doc
+    assert "GET /v1/jobs/{id}/findings/{attack_id}/evidence" in ci_doc
     assert "KNIVES_OUT_API_DATA_DIR" in ci_doc
     assert "knives-out summary results.json --out summary.json" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
@@ -216,6 +223,8 @@ def test_roadmap_and_architecture_describe_next_milestones() -> None:
     assert "learned-model artifacts" in roadmap
     assert "v0.11: deeper GraphQL coverage" in roadmap
     assert "v0.15: staged GraphQL subscription coverage" in roadmap
+    assert "v0.16: ReviewOps baseline workbench" in roadmap
+    assert "v0.17: Artifact deep dive drawer" in roadmap
     assert "## v0.14 — smoke-test integration coverage" in roadmap
     assert "deterministic fixture apps and checked-in inputs only" in roadmap
     assert "#58: CLI happy path against a local API fixture" in roadmap

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -147,11 +147,62 @@ def test_run_jobs_are_attached_to_projects_and_removed_on_project_delete(
     assert jobs_payload is not None
     assert jobs_payload["jobs"][0]["id"] == job_id
     assert jobs_payload["jobs"][0]["project_id"] == project_id
+    assert jobs_payload["jobs"][0]["completed_at"] is not None
+    assert jobs_payload["jobs"][0]["result_available"] is True
+    assert jobs_payload["jobs"][0]["result_summary"]["total_results"] == 1
     assert client.get(f"/v1/jobs/{job_id}").json()["project_id"] == project_id
 
     delete_response = client.delete(f"/v1/projects/{project_id}")
     assert delete_response.status_code == 200
     assert client.get(f"/v1/jobs/{job_id}").status_code == 404
+
+
+def test_project_review_artifact_evidence_endpoint_supports_current_run_drilldown(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _install_stub_response(monkeypatch, httpx.Response(422, text="missing auth"))
+    client = TestClient(create_app(data_dir=tmp_path))
+    project_id = client.post("/v1/projects", json={"name": "Review demo"}).json()["id"]
+
+    run_response = client.post(
+        "/v1/runs",
+        json={
+            "project_id": project_id,
+            "suite": _attack_suite().model_dump(mode="json"),
+            "base_url": "https://example.com",
+            "store_artifacts": True,
+        },
+    )
+    assert run_response.status_code == 200
+
+    job_id = run_response.json()["id"]
+    for _ in range(50):
+        job_response = client.get(f"/v1/jobs/{job_id}")
+        assert job_response.status_code == 200
+        if job_response.json()["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    review_response = client.post(f"/v1/projects/{project_id}/review", json={})
+    assert review_response.status_code == 200
+    assert review_response.json()["current_job_id"] == job_id
+
+    evidence_response = client.get(f"/v1/jobs/{job_id}/findings/atk_api/evidence")
+    assert evidence_response.status_code == 200
+    payload = evidence_response.json()
+    assert payload["job_id"] == job_id
+    assert payload["result"]["attack_id"] == "atk_api"
+    assert payload["artifacts"] == [
+        {
+            "label": "Request artifact",
+            "kind": "request",
+            "artifact_name": "atk_api.json",
+            "available": True,
+            "profile": None,
+            "step_index": None,
+        }
+    ]
 
 
 def test_frontend_routes_serve_index_assets_and_spa_fallback(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add project-scoped baseline review refresh and persisted baseline selection in the local workbench
- add current-run finding evidence drilldown with typed artifact references and lazy artifact loading
- update backend, frontend, tests, and docs for the review workbench flow

## Validation
- .venv/bin/python -m pytest tests/test_api.py tests/test_web_app.py tests/test_docs.py
- .venv/bin/ruff check src/knives_out/api.py src/knives_out/api_models.py tests/test_api.py tests/test_web_app.py tests/test_docs.py
- cd frontend && npm run test -- --run
- cd frontend && npm run build