### PR TITLE
Fix GitHub Pages API setup UX

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listProjects } from "./api";
+
+describe("api", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sanitizes HTML error responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response("<!DOCTYPE html><html><body>404</body></html>", {
+          status: 404,
+          statusText: "Not Found",
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
+      }),
+    );
+
+    try {
+      await listProjects();
+      throw new Error("Expected listProjects to fail.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain("returned HTML instead of the JSON API");
+      expect(message).not.toContain("<!DOCTYPE html>");
+    }
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -17,10 +17,51 @@ import type {
   TriageResponse,
   VerifyResponse,
 } from "./types";
-import { buildApiUrl } from "./apiConfig";
+import { buildApiUrl, needsConfiguredApiBase } from "./apiConfig";
+
+function requestFailureMessage(requestUrl: string, response: Response): string {
+  return `Request to ${requestUrl} failed with ${response.status}${response.statusText ? ` ${response.statusText}` : ""}.`;
+}
+
+async function parseErrorMessage(response: Response, requestUrl: string): Promise<string> {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    try {
+      const payload = (await response.json()) as Record<string, unknown>;
+      const detail =
+        typeof payload.detail === "string"
+          ? payload.detail
+          : typeof payload.message === "string"
+            ? payload.message
+            : null;
+      if (detail) {
+        return detail;
+      }
+    } catch {
+      return requestFailureMessage(requestUrl, response);
+    }
+    return requestFailureMessage(requestUrl, response);
+  }
+
+  const text = (await response.text()).trim();
+  if (contentType.includes("text/html")) {
+    return `${requestFailureMessage(requestUrl, response)} The endpoint returned HTML instead of the JSON API. Check the configured API base URL.`;
+  }
+  if (!text) {
+    return requestFailureMessage(requestUrl, response);
+  }
+  const snippet = text.replace(/\s+/g, " ").slice(0, 180);
+  return `${requestFailureMessage(requestUrl, response)} ${snippet}`;
+}
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(buildApiUrl(path), {
+  if (needsConfiguredApiBase()) {
+    throw new Error("Set the API base URL before using the GitHub Pages workbench.");
+  }
+
+  const requestUrl = buildApiUrl(path);
+  const response = await fetch(requestUrl, {
     ...init,
     headers: {
       ...(init?.body ? { "Content-Type": "application/json" } : {}),
@@ -29,12 +70,18 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   });
 
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed with status ${response.status}.`);
+    throw new Error(await parseErrorMessage(response, requestUrl));
   }
 
   if (response.status === 204) {
     return undefined as T;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    throw new Error(
+      `Request to ${requestUrl} succeeded but returned ${contentType || "non-JSON content"} instead of JSON.`,
+    );
   }
 
   return (await response.json()) as T;

--- a/frontend/src/apiConfig.test.ts
+++ b/frontend/src/apiConfig.test.ts
@@ -3,6 +3,8 @@ import {
   buildApiUrl,
   describeApiBaseUrl,
   getApiBaseUrl,
+  isStaticHostedShell,
+  needsConfiguredApiBase,
   normalizeApiBaseUrl,
   persistApiBaseUrl,
 } from "./apiConfig";
@@ -29,5 +31,14 @@ describe("apiConfig", () => {
     expect(getApiBaseUrl()).toBe("");
     expect(buildApiUrl("/healthz")).toBe("/healthz");
     expect(describeApiBaseUrl("")).toBe("same origin");
+  });
+
+  it("requires an explicit API base on GitHub Pages", () => {
+    expect(isStaticHostedShell("keithwegner.github.io", "/knives-out/")).toBe(true);
+    expect(needsConfiguredApiBase("", "keithwegner.github.io", "/knives-out/")).toBe(true);
+    expect(
+      needsConfiguredApiBase("https://api.example.com", "keithwegner.github.io", "/knives-out/"),
+    ).toBe(false);
+    expect(needsConfiguredApiBase("", "localhost", "/app/")).toBe(false);
   });
 });

--- a/frontend/src/apiConfig.ts
+++ b/frontend/src/apiConfig.ts
@@ -7,6 +7,12 @@ function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
+function normalizeBasePath(value: string | null | undefined): string {
+  const trimmed = value?.trim() || "/";
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
 export function normalizeApiBaseUrl(value: string | null | undefined): string {
   if (!value) {
     return "";
@@ -40,6 +46,25 @@ export function persistApiBaseUrl(value: string): string {
 
 export function describeApiBaseUrl(value: string): string {
   return value || "same origin";
+}
+
+export function isStaticHostedShell(
+  hostname = typeof window === "undefined" ? "" : window.location.hostname,
+  basePath = import.meta.env.BASE_URL,
+): boolean {
+  const normalizedBasePath = normalizeBasePath(basePath);
+  return (
+    hostname.endsWith(".github.io") ||
+    (normalizedBasePath !== "/" && normalizedBasePath !== "/app/")
+  );
+}
+
+export function needsConfiguredApiBase(
+  apiBaseUrl = getApiBaseUrl(),
+  hostname = typeof window === "undefined" ? "" : window.location.hostname,
+  basePath = import.meta.env.BASE_URL,
+): boolean {
+  return !normalizeApiBaseUrl(apiBaseUrl) && isStaticHostedShell(hostname, basePath);
 }
 
 export function buildApiUrl(path: string): string {

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -22,6 +22,7 @@ function renderHomePage() {
 
 describe("HomePage", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -86,5 +87,25 @@ describe("HomePage", () => {
     fireEvent.click(saveButton);
 
     expect(window.localStorage.getItem("knives-out.api-base-url")).toBe("https://api.example.com");
+  });
+
+  it("shows a concise error when the endpoint returns HTML", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response("<!DOCTYPE html><html><body>404</body></html>", {
+          status: 404,
+          statusText: "Not Found",
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
+      }),
+    );
+
+    renderHomePage();
+
+    expect(
+      await screen.findByText(/returned HTML instead of the JSON API/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/<!DOCTYPE html>/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import { startTransition, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
 import { getHealthStatus, createProject, deleteProject, listProjects } from "../api";
-import { getApiBaseUrl, persistApiBaseUrl } from "../apiConfig";
+import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
 import ApiConnectionPanel from "../components/ApiConnectionPanel";
 
 export default function HomePage() {
@@ -10,16 +10,19 @@ export default function HomePage() {
   const queryClient = useQueryClient();
   const [newProjectName, setNewProjectName] = useState("Security workbench");
   const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
+  const requiresApiBase = needsConfiguredApiBase(apiBaseUrl);
 
   const projectListQuery = useQuery({
     queryKey: ["projects", apiBaseUrl],
     queryFn: listProjects,
+    enabled: !requiresApiBase,
     retry: false,
   });
 
   const healthQuery = useQuery({
     queryKey: ["health", apiBaseUrl],
     queryFn: getHealthStatus,
+    enabled: !requiresApiBase,
     retry: false,
   });
 
@@ -54,21 +57,27 @@ export default function HomePage() {
         : deleteProjectMutation.error instanceof Error
           ? deleteProjectMutation.error.message
           : null;
-  const apiStatusTone = healthQuery.isLoading
-    ? "pending"
+  const apiStatusTone = requiresApiBase
+    ? "idle"
+    : healthQuery.isLoading
+      ? "pending"
+      : healthQuery.isSuccess
+        ? "completed"
+        : "failed";
+  const apiStatusLabel = requiresApiBase
+    ? "configure API"
+    : healthQuery.isLoading
+      ? "checking"
+      : healthQuery.isSuccess
+        ? "connected"
+        : "unreachable";
+  const apiDescription = requiresApiBase
+    ? "This GitHub Pages deployment only hosts the frontend shell. Set the API base URL to a reachable knives-out server to load projects and run workflows."
     : healthQuery.isSuccess
-      ? "completed"
-      : "failed";
-  const apiStatusLabel = healthQuery.isLoading
-    ? "checking"
-    : healthQuery.isSuccess
-      ? "connected"
-      : "unreachable";
-  const apiDescription = healthQuery.isSuccess
-    ? "The workbench can reach the configured API. Projects and runs will use this endpoint."
-    : apiBaseUrl
-      ? "The configured API endpoint is not responding yet. Make sure the deployed backend is reachable and allows cross-origin requests."
-      : "This static frontend needs a reachable knives-out API when it is not served by `knives-out serve` on the same origin.";
+      ? "The workbench can reach the configured API. Projects and runs will use this endpoint."
+      : apiBaseUrl
+        ? "The configured API endpoint is not responding yet. Make sure the deployed backend is reachable and allows cross-origin requests."
+        : "This static frontend needs a reachable knives-out API when it is not served by `knives-out serve` on the same origin.";
 
   return (
     <main className="shell">
@@ -85,7 +94,7 @@ export default function HomePage() {
           className="hero-create"
           onSubmit={(event) => {
             event.preventDefault();
-            if (!newProjectName.trim()) {
+            if (requiresApiBase || !newProjectName.trim()) {
               return;
             }
             createProjectMutation.mutate(newProjectName.trim());
@@ -100,8 +109,16 @@ export default function HomePage() {
               placeholder="Name the workbench"
             />
           </label>
-          <button className="primary-button" type="submit" disabled={createProjectMutation.isPending}>
-            {createProjectMutation.isPending ? "Creating…" : "Open workbench"}
+          <button
+            className="primary-button"
+            type="submit"
+            disabled={createProjectMutation.isPending || requiresApiBase}
+          >
+            {createProjectMutation.isPending
+              ? "Creating…"
+              : requiresApiBase
+                ? "Connect API first"
+                : "Open workbench"}
           </button>
         </form>
       </section>
@@ -130,14 +147,23 @@ export default function HomePage() {
         </div>
 
         {projectListQuery.isLoading ? <p className="empty-copy">Loading projects…</p> : null}
-        {!projectListQuery.isLoading && projectListQuery.isError ? (
+        {!projectListQuery.isLoading && requiresApiBase ? (
+          <div className="empty-state">
+            <p>Add a reachable API endpoint above to load saved projects.</p>
+            <p>The Pages site only serves the UI. Project drafts and runs live on the API backend.</p>
+          </div>
+        ) : null}
+        {!projectListQuery.isLoading && !requiresApiBase && projectListQuery.isError ? (
           <div className="empty-state">
             <p>Projects could not be loaded from the configured API.</p>
             <p>Check the API endpoint panel above, then retry after the backend is reachable.</p>
           </div>
         ) : null}
 
-        {!projectListQuery.isLoading && !projectListQuery.isError && !projectListQuery.data?.projects.length ? (
+        {!projectListQuery.isLoading &&
+        !requiresApiBase &&
+        !projectListQuery.isError &&
+        !projectListQuery.data?.projects.length ? (
           <div className="empty-state">
             <p>No saved projects yet.</p>
             <p>Start with an OpenAPI or GraphQL source and the workbench will hold the drafts.</p>

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -1,7 +1,7 @@
 import { useDeferredValue, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
-import { getApiBaseUrl, persistApiBaseUrl } from "../apiConfig";
+import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
 import ApiConnectionPanel from "../components/ApiConnectionPanel";
 import CodeEditor from "../components/CodeEditor";
 import {
@@ -274,18 +274,19 @@ export default function ProjectWorkbenchPage() {
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const syncedJobIdRef = useRef<string | null>(null);
   const deferredReviewFilter = useDeferredValue(reviewFilter.trim().toLowerCase());
+  const requiresApiBase = needsConfiguredApiBase(apiBaseUrl);
 
   const projectQuery = useQuery({
     queryKey: ["project", projectId, apiBaseUrl],
     queryFn: () => getProject(projectId!),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !requiresApiBase,
     retry: false,
   });
 
   const projectJobsQuery = useQuery({
     queryKey: ["projectJobs", projectId, apiBaseUrl],
     queryFn: () => listProjectJobs(projectId!),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !requiresApiBase,
     refetchInterval: trackedJobId ? 1500 : false,
     retry: false,
   });
@@ -334,6 +335,7 @@ export default function ProjectWorkbenchPage() {
   function applyApiBase(nextValue: string) {
     const normalized = persistApiBaseUrl(nextValue);
     setApiBaseUrl(normalized);
+    setDraft(null);
     setActionError(null);
     void queryClient.invalidateQueries();
   }
@@ -409,6 +411,36 @@ export default function ProjectWorkbenchPage() {
       <main className="shell">
         <section className="panel">
           <p className="empty-copy">Missing project id.</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (requiresApiBase) {
+    return (
+      <main className="shell">
+        <section className="panel stack">
+          <div>
+            <p className="eyebrow">Workbench unavailable</p>
+            <h2>Connect the API before loading this project</h2>
+            <p className="hero-body">
+              This GitHub Pages deployment only hosts the frontend shell. Set the API base URL to a
+              reachable knives-out server, then reopen the project.
+            </p>
+          </div>
+          <ApiConnectionPanel
+            apiBaseUrl={apiBaseUrl}
+            description="Saved projects, jobs, and review data live on the API backend. Once the endpoint is set, the workbench will load this project from there."
+            onApply={applyApiBase}
+            statusLabel="configure API"
+            statusTone="idle"
+            title="Reconnect the workbench"
+          />
+          <div className="action-row">
+            <Link className="ghost-button" to="/">
+              Back to projects
+            </Link>
+          </div>
         </section>
       </main>
     );


### PR DESCRIPTION
## Summary
- keep the Pages-hosted workbench in a clean configure-API state instead of probing a missing same-origin backend
- sanitize HTML and other non-JSON API errors so the UI shows actionable messages instead of raw page content
- add focused frontend coverage for Pages detection and error handling

## Testing
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/pytest -q
- ./.venv/bin/pytest --cov=src/knives_out --cov-report=term -q
- npm run test -- --run
- npm run build