### PR TITLE
[codex] Add project duplication and artifact drill-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # knives-out
 
+<p align="center">
+  <img src="docs/assets/knives-out-logo.svg" alt="knives-out logo" width="460">
+</p>
+
 [![CI](https://github.com/keithwegner/knives-out/actions/workflows/ci.yml/badge.svg)](https://github.com/keithwegner/knives-out/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/keithwegner/knives-out/badges/coverage-badge.json)](https://github.com/keithwegner/knives-out/actions/workflows/main-maintenance.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)

--- a/docs/assets/knives-out-logo.svg
+++ b/docs/assets/knives-out-logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-labelledby="title desc">
+  <title id="title">knives-out logo</title>
+  <desc id="desc">knives-out adversarial API testing logo</desc>
+  <rect width="1200" height="360" rx="28" fill="#f8fafc"/>
+  <rect x="8" y="8" width="1184" height="344" rx="20" fill="none" stroke="#d7dde5" stroke-width="2"/>
+  <text
+    x="600"
+    y="165"
+    fill="#1f2937"
+    font-family="Orbitron, Eurostile, 'Arial Narrow', Arial, sans-serif"
+    font-size="108"
+    font-weight="700"
+    letter-spacing="2"
+    text-anchor="middle"
+  >
+    knives-out
+  </text>
+  <text
+    x="600"
+    y="245"
+    fill="#111827"
+    font-family="'Arial Narrow', Arial, sans-serif"
+    font-size="46"
+    letter-spacing="7"
+    text-anchor="middle"
+  >
+    ADVERSARIAL API TESTING
+  </text>
+</svg>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -133,6 +133,12 @@ export function getProject(projectId: string) {
   return request<ProjectRecord>(`/v1/projects/${projectId}`);
 }
 
+export function duplicateProject(projectId: string) {
+  return request<ProjectRecord>(`/v1/projects/${projectId}/duplicate`, {
+    method: "POST",
+  });
+}
+
 export function updateProject(projectId: string, project: Partial<ProjectRecord>) {
   return request<ProjectRecord>(`/v1/projects/${projectId}`, {
     method: "PATCH",

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "./HomePage";
@@ -56,6 +56,7 @@ describe("HomePage", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
   });
 
@@ -67,6 +68,139 @@ describe("HomePage", () => {
     expect(screen.getByText("storefront.yaml")).toBeInTheDocument();
     expect(screen.getByText("completed")).toBeInTheDocument();
     expect(screen.getByText("Open")).toBeInTheDocument();
+  });
+
+  it("duplicates a saved project from the dashboard", async () => {
+    let duplicated = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.endsWith("/healthz")) {
+          return Response.json({ status: "ok" });
+        }
+        if (url.endsWith("/v1/projects") && method === "GET") {
+          return Response.json({
+            projects: duplicated
+              ? [
+                  {
+                    id: "project-2",
+                    name: "Storefront triage copy",
+                    source_mode: "openapi",
+                    active_step: "review",
+                    created_at: "2026-04-13T20:06:00Z",
+                    updated_at: "2026-04-13T20:06:00Z",
+                    source_name: "storefront.yaml",
+                    job_count: 0,
+                    last_run_job_id: null,
+                    last_run_status: null,
+                    last_run_at: null,
+                    active_flagged_count: 3,
+                  },
+                  {
+                    id: "project-1",
+                    name: "Storefront triage",
+                    source_mode: "openapi",
+                    active_step: "review",
+                    created_at: "2026-04-13T20:00:00Z",
+                    updated_at: "2026-04-13T20:05:00Z",
+                    source_name: "storefront.yaml",
+                    job_count: 2,
+                    last_run_job_id: "job-1",
+                    last_run_status: "completed",
+                    last_run_at: "2026-04-13T20:06:00Z",
+                    active_flagged_count: 3,
+                  },
+                ]
+              : [
+                  {
+                    id: "project-1",
+                    name: "Storefront triage",
+                    source_mode: "openapi",
+                    active_step: "review",
+                    created_at: "2026-04-13T20:00:00Z",
+                    updated_at: "2026-04-13T20:05:00Z",
+                    source_name: "storefront.yaml",
+                    job_count: 2,
+                    last_run_job_id: "job-1",
+                    last_run_status: "completed",
+                    last_run_at: "2026-04-13T20:06:00Z",
+                    active_flagged_count: 3,
+                  },
+                ],
+          });
+        }
+        if (url.endsWith("/v1/projects/project-1/duplicate") && method === "POST") {
+          duplicated = true;
+          return Response.json({
+            id: "project-2",
+            name: "Storefront triage copy",
+            source_mode: "openapi",
+            active_step: "review",
+            created_at: "2026-04-13T20:06:00Z",
+            updated_at: "2026-04-13T20:06:00Z",
+            graphql_endpoint: "/graphql",
+            source: { name: "storefront.yaml", content: "openapi: 3.0.3" },
+            discover_inputs: [],
+            inspect_draft: { tag: [], exclude_tag: [], path: [], exclude_path: [] },
+            generate_draft: {
+              operation: [],
+              exclude_operation: [],
+              method: [],
+              exclude_method: [],
+              kind: [],
+              exclude_kind: [],
+              tag: [],
+              exclude_tag: [],
+              path: [],
+              exclude_path: [],
+              pack_names: [],
+              auto_workflows: false,
+              workflow_pack_names: [],
+            },
+            run_draft: {
+              base_url: "",
+              headers: {},
+              query: {},
+              timeout: 10,
+              store_artifacts: true,
+              auth_plugin_names: [],
+              auth_config_yaml: null,
+              auth_profile_names: [],
+              profile_file_yaml: null,
+              profile_names: [],
+              operation: [],
+              exclude_operation: [],
+              method: [],
+              exclude_method: [],
+              kind: [],
+              exclude_kind: [],
+              tag: [],
+              exclude_tag: [],
+              path: [],
+              exclude_path: [],
+            },
+            review_draft: {
+              baseline_job_id: null,
+              baseline: null,
+              suppressions_yaml: null,
+              min_severity: "high",
+              min_confidence: "medium",
+            },
+            artifacts: {},
+          });
+        }
+        throw new Error(`Unhandled fetch for ${method} ${url}`);
+      }),
+    );
+
+    renderHomePage();
+
+    await screen.findByText("Storefront triage");
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate" }));
+
+    expect(await screen.findByText("Storefront triage copy")).toBeInTheDocument();
   });
 
   it("saves a custom API endpoint", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,7 +1,13 @@
 import { startTransition, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
-import { getHealthStatus, createProject, deleteProject, listProjects } from "../api";
+import {
+  createProject,
+  deleteProject,
+  duplicateProject,
+  getHealthStatus,
+  listProjects,
+} from "../api";
 import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
 import ApiConnectionPanel from "../components/ApiConnectionPanel";
 
@@ -43,6 +49,13 @@ export default function HomePage() {
     },
   });
 
+  const duplicateProjectMutation = useMutation({
+    mutationFn: duplicateProject,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+
   function applyApiBase(nextValue: string) {
     const normalized = persistApiBaseUrl(nextValue);
     setApiBaseUrl(normalized);
@@ -56,6 +69,8 @@ export default function HomePage() {
         ? createProjectMutation.error.message
         : deleteProjectMutation.error instanceof Error
           ? deleteProjectMutation.error.message
+          : duplicateProjectMutation.error instanceof Error
+            ? duplicateProjectMutation.error.message
           : null;
   const apiStatusTone = requiresApiBase
     ? "idle"
@@ -204,8 +219,16 @@ export default function HomePage() {
                 <button
                   className="ghost-button"
                   type="button"
+                  onClick={() => duplicateProjectMutation.mutate(project.id)}
+                  disabled={duplicateProjectMutation.isPending || deleteProjectMutation.isPending}
+                >
+                  {duplicateProjectMutation.isPending ? "Duplicating…" : "Duplicate"}
+                </button>
+                <button
+                  className="ghost-button"
+                  type="button"
                   onClick={() => deleteProjectMutation.mutate(project.id)}
-                  disabled={deleteProjectMutation.isPending}
+                  disabled={deleteProjectMutation.isPending || duplicateProjectMutation.isPending}
                 >
                   Delete
                 </button>

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -717,6 +717,215 @@ describe("ProjectWorkbenchPage", () => {
     expect(within(table).queryByText("Order mismatch")).not.toBeInTheDocument();
   });
 
+  it("duplicates the active project and opens the copied workbench", async () => {
+    const duplicatedProject = {
+      ...structuredClone(projectPayload),
+      id: "project-2",
+      name: "Workbench demo copy",
+      created_at: "2026-04-13T20:06:00Z",
+      updated_at: "2026-04-13T20:06:00Z",
+      review_draft: {
+        ...structuredClone(projectPayload.review_draft),
+        baseline_job_id: null,
+      },
+      artifacts: {
+        ...structuredClone(projectPayload.artifacts),
+        last_run_job_id: null,
+      },
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/v1/projects/project-1") && method === "GET") {
+        return Response.json(projectPayload);
+      }
+      if (url.endsWith("/v1/projects/project-1/jobs") && method === "GET") {
+        return Response.json({ project_id: "project-1", jobs: [] });
+      }
+      if (url.endsWith("/v1/projects/project-1/duplicate") && method === "POST") {
+        return Response.json(duplicatedProject);
+      }
+      if (url.endsWith("/v1/projects/project-2") && method === "GET") {
+        return Response.json(duplicatedProject);
+      }
+      if (url.endsWith("/v1/projects/project-2/jobs") && method === "GET") {
+        return Response.json({ project_id: "project-2", jobs: [] });
+      }
+      throw new Error(`Unhandled fetch for ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWorkbench();
+
+    await screen.findByText("Workbench demo");
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate project" }));
+
+    expect(await screen.findByText("Workbench demo copy")).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).endsWith("/v1/projects/project-1/duplicate") &&
+          ((init as RequestInit | undefined)?.method ?? "GET") === "POST",
+      ),
+    ).toBe(true);
+  });
+
+  it("loads and clears a saved run baseline from the review workspace", async () => {
+    let projectState = structuredClone(projectPayload);
+    projectState.artifacts.last_run_job_id = "job-current";
+
+    const baselineResults = {
+      source: "unit",
+      base_url: "https://example.com",
+      executed_at: "2026-04-13T19:30:00Z",
+      profiles: [],
+      auth_events: [],
+      results: [],
+    };
+
+    const comparisonVerification = {
+      ...projectState.artifacts.latest_verification,
+      baseline_used: true,
+      new_findings_count: 1,
+      resolved_findings_count: 1,
+      persisting_findings_count: 1,
+      current_findings: [
+        projectState.artifacts.latest_verification.current_findings[0],
+        {
+          ...projectState.artifacts.latest_verification.current_findings[1],
+          change: "persisting",
+          delta_changes: [{ field: "status", baseline: "500", current: "200" }],
+        },
+      ],
+      new_findings: [projectState.artifacts.latest_verification.current_findings[0]],
+      resolved_findings: [
+        {
+          change: "resolved",
+          attack_id: "atk-retired",
+          name: "Retired finding",
+          protocol: "rest",
+          kind: "missing_auth",
+          method: "GET",
+          path: "/legacy",
+          tags: ["legacy"],
+          issue: "server_error",
+          severity: "high",
+          confidence: "medium",
+          status_code: 500,
+          url: "https://example.com/legacy",
+          delta_changes: [],
+        },
+      ],
+      persisting_findings: [
+        {
+          ...projectState.artifacts.latest_verification.current_findings[1],
+          change: "persisting",
+          delta_changes: [{ field: "status", baseline: "500", current: "200" }],
+        },
+      ],
+    };
+
+    const comparisonSummary = {
+      ...projectState.artifacts.latest_summary,
+      baseline_used: true,
+      baseline_executed_at: baselineResults.executed_at,
+      new_findings_count: 1,
+      resolved_findings_count: 1,
+      persisting_findings_count: 1,
+      persisting_deltas_count: 1,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.endsWith("/v1/projects/project-1") && method === "GET") {
+          return Response.json(projectState);
+        }
+        if (url.endsWith("/v1/projects/project-1") && method === "PATCH") {
+          const patch = JSON.parse(String(init?.body ?? "{}"));
+          projectState = {
+            ...projectState,
+            ...patch,
+            review_draft: patch.review_draft ?? projectState.review_draft,
+            artifacts: patch.artifacts ?? projectState.artifacts,
+          };
+          return Response.json(projectState);
+        }
+        if (url.endsWith("/v1/projects/project-1/jobs")) {
+          return Response.json({
+            project_id: "project-1",
+            jobs: [
+              {
+                id: "job-current",
+                kind: "run",
+                status: "completed",
+                created_at: "2026-04-13T20:06:00Z",
+                started_at: "2026-04-13T20:06:01Z",
+                completed_at: "2026-04-13T20:06:04Z",
+                base_url: "https://example.com",
+                attack_count: 2,
+                project_id: "project-1",
+                error: null,
+                result_available: true,
+                artifact_names: ["atk-current.json"],
+                result_summary: projectState.artifacts.latest_summary,
+              },
+              {
+                id: "job-baseline",
+                kind: "run",
+                status: "completed",
+                created_at: "2026-04-13T19:30:00Z",
+                started_at: "2026-04-13T19:30:01Z",
+                completed_at: "2026-04-13T19:30:04Z",
+                base_url: "https://example.com",
+                attack_count: 2,
+                project_id: "project-1",
+                error: null,
+                result_available: true,
+                artifact_names: ["atk-baseline.json"],
+                result_summary: {
+                  ...projectState.artifacts.latest_summary,
+                  executed_at: baselineResults.executed_at,
+                  active_flagged_count: 1,
+                },
+              },
+            ],
+          });
+        }
+        if (url.endsWith("/v1/jobs/job-baseline/result")) {
+          return Response.json(baselineResults);
+        }
+        if (url.endsWith("/v1/summary") && method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          return Response.json(body.baseline ? comparisonSummary : projectPayload.artifacts.latest_summary);
+        }
+        if (url.endsWith("/v1/verify") && method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          return Response.json(
+            body.baseline ? comparisonVerification : projectPayload.artifacts.latest_verification,
+          );
+        }
+        if (url.endsWith("/v1/report") && method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          return Response.json({
+            format: body.format,
+            content: body.baseline
+              ? body.format === "markdown"
+                ? "# compare"
+                : "<!doctype html><p>compare</p>"
+              : body.format === "markdown"
+                ? "# report"
+                : "<!doctype html>",
+          });
+        }
+        throw new Error(`Unhandled fetch for ${method} ${url}`);
+      }),
+    );
+  });
+
   it("refreshes comparison when selecting a baseline and pinning the latest run", async () => {
     renderWorkbench();
 

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -719,17 +719,17 @@ describe("ProjectWorkbenchPage", () => {
 
   it("duplicates the active project and opens the copied workbench", async () => {
     const duplicatedProject = {
-      ...structuredClone(projectPayload),
+      ...structuredClone(baseProjectPayload),
       id: "project-2",
       name: "Workbench demo copy",
       created_at: "2026-04-13T20:06:00Z",
       updated_at: "2026-04-13T20:06:00Z",
       review_draft: {
-        ...structuredClone(projectPayload.review_draft),
+        ...structuredClone(baseProjectPayload.review_draft),
         baseline_job_id: null,
       },
       artifacts: {
-        ...structuredClone(projectPayload.artifacts),
+        ...structuredClone(baseProjectPayload.artifacts),
         last_run_job_id: null,
       },
     };
@@ -738,7 +738,7 @@ describe("ProjectWorkbenchPage", () => {
       const url = String(input);
       const method = init?.method ?? "GET";
       if (url.endsWith("/v1/projects/project-1") && method === "GET") {
-        return Response.json(projectPayload);
+        return Response.json(baseProjectPayload);
       }
       if (url.endsWith("/v1/projects/project-1/jobs") && method === "GET") {
         return Response.json({ project_id: "project-1", jobs: [] });
@@ -772,7 +772,7 @@ describe("ProjectWorkbenchPage", () => {
   });
 
   it("loads and clears a saved run baseline from the review workspace", async () => {
-    let projectState = structuredClone(projectPayload);
+    let projectState = structuredClone(baseProjectPayload);
     projectState.artifacts.last_run_job_id = "job-current";
 
     const baselineResults = {
@@ -900,12 +900,16 @@ describe("ProjectWorkbenchPage", () => {
         }
         if (url.endsWith("/v1/summary") && method === "POST") {
           const body = JSON.parse(String(init?.body ?? "{}"));
-          return Response.json(body.baseline ? comparisonSummary : projectPayload.artifacts.latest_summary);
+          return Response.json(
+            body.baseline ? comparisonSummary : baseProjectPayload.artifacts.latest_summary,
+          );
         }
         if (url.endsWith("/v1/verify") && method === "POST") {
           const body = JSON.parse(String(init?.body ?? "{}"));
           return Response.json(
-            body.baseline ? comparisonVerification : projectPayload.artifacts.latest_verification,
+            body.baseline
+              ? comparisonVerification
+              : baseProjectPayload.artifacts.latest_verification,
           );
         }
         if (url.endsWith("/v1/report") && method === "POST") {

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -1,6 +1,13 @@
-import { useDeferredValue, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
 import ApiConnectionPanel from "../components/ApiConnectionPanel";
 import CodeEditor from "../components/CodeEditor";
@@ -8,6 +15,7 @@ import {
   createRun,
   deleteProjectJob,
   discoverModel,
+  duplicateProject,
   generateSuite,
   getJobArtifact,
   getJobFindingEvidence,
@@ -499,6 +507,7 @@ function StepRail({
 
 export default function ProjectWorkbenchPage() {
   const { projectId } = useParams();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<ProjectRecord | null>(null);
   const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
@@ -1481,6 +1490,27 @@ export default function ProjectWorkbenchPage() {
     }
   }
 
+  async function handleDuplicateProject() {
+    let project = getLoadedProject();
+    setBusyAction("duplicate-project");
+    setActionError(null);
+    try {
+      if (hasPendingSave || saveProjectMutation.isPending) {
+        project = await saveProjectMutation.mutateAsync(project);
+      }
+      const duplicated = await duplicateProject(project.id);
+      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+      setActivityMessage("Project duplicated. Opening the copy.");
+      startTransition(() => {
+        navigate(`/projects/${duplicated.id}`);
+      });
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not duplicate the project.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
   return (
     <main className="workbench-shell">
       <header className="workbench-header">
@@ -1493,6 +1523,14 @@ export default function ProjectWorkbenchPage() {
           </p>
         </div>
         <div className="header-actions">
+          <button
+            className="secondary-button"
+            onClick={() => void handleDuplicateProject()}
+            type="button"
+            disabled={busyAction === "duplicate-project" || saveProjectMutation.isPending}
+          >
+            {busyAction === "duplicate-project" ? "Duplicating…" : "Duplicate project"}
+          </button>
           <Link className="ghost-button" to="/">
             Back to projects
           </Link>

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -34,6 +34,7 @@ from knives_out.api_models import (
     JobRetentionEntry,
     JobStatusResponse,
     ProjectCreateRequest,
+    ProjectDuplicateRequest,
     ProjectJobsResponse,
     ProjectListResponse,
     ProjectRecord,
@@ -564,6 +565,20 @@ def create_app(
             artifacts=request.artifacts,
         )
         return project_store.create_project(record)
+
+    @app.post("/v1/projects/{project_id}/duplicate", response_model=ProjectRecord)
+    def duplicate_project(
+        project_id: str,
+        request: ProjectDuplicateRequest | None = None,
+    ) -> ProjectRecord:
+        project_store: ProjectStore = app.state.project_store
+        try:
+            return project_store.duplicate_project(
+                project_id,
+                name=request.name if request is not None else None,
+            )
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
 
     @app.get("/v1/projects/{project_id}", response_model=ProjectRecord)
     def get_project(project_id: str) -> ProjectRecord:

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -448,6 +448,10 @@ class ProjectCreateRequest(BaseModel):
     artifacts: ProjectArtifacts = Field(default_factory=ProjectArtifacts)
 
 
+class ProjectDuplicateRequest(BaseModel):
+    name: str | None = None
+
+
 class ProjectUpdateRequest(BaseModel):
     name: str | None = None
     source_mode: ProjectSourceMode | None = None

--- a/src/knives_out/project_store.py
+++ b/src/knives_out/project_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic, sleep
 from uuid import uuid4
@@ -67,6 +68,19 @@ class ProjectStore:
         self._write_record(record)
         return record
 
+    def _default_duplicate_name(self, name: str) -> str:
+        existing_names = {record.name for record in self.list_projects()}
+        base_name = f"{name} copy"
+        if base_name not in existing_names:
+            return base_name
+
+        suffix = 2
+        while True:
+            candidate = f"{name} copy {suffix}"
+            if candidate not in existing_names:
+                return candidate
+            suffix += 1
+
     def load_project(self, project_id: str) -> ProjectRecord:
         path = self.record_path(project_id)
         if not path.exists():
@@ -76,6 +90,25 @@ class ProjectStore:
     def update_project(self, record: ProjectRecord) -> ProjectRecord:
         self._write_record(record)
         return record
+
+    def duplicate_project(self, project_id: str, *, name: str | None = None) -> ProjectRecord:
+        current = self.load_project(project_id)
+        now = datetime.now(UTC)
+        duplicate_name = name.strip() if name and name.strip() else self._default_duplicate_name(current.name)
+        duplicated = current.model_copy(
+            deep=True,
+            update={
+                "id": uuid4().hex,
+                "name": duplicate_name,
+                "created_at": now,
+                "updated_at": now,
+                "review_draft": current.review_draft.model_copy(
+                    update={"baseline_job_id": None}
+                ),
+                "artifacts": current.artifacts.model_copy(update={"last_run_job_id": None}),
+            },
+        )
+        return self.create_project(duplicated)
 
     def list_projects(self) -> list[ProjectRecord]:
         records: list[ProjectRecord] = []

--- a/src/knives_out/project_store.py
+++ b/src/knives_out/project_store.py
@@ -94,7 +94,11 @@ class ProjectStore:
     def duplicate_project(self, project_id: str, *, name: str | None = None) -> ProjectRecord:
         current = self.load_project(project_id)
         now = datetime.now(UTC)
-        duplicate_name = name.strip() if name and name.strip() else self._default_duplicate_name(current.name)
+        duplicate_name = (
+            name.strip()
+            if name and name.strip()
+            else self._default_duplicate_name(current.name)
+        )
         duplicated = current.model_copy(
             deep=True,
             update={

--- a/src/knives_out/project_store.py
+++ b/src/knives_out/project_store.py
@@ -95,9 +95,7 @@ class ProjectStore:
         current = self.load_project(project_id)
         now = datetime.now(UTC)
         duplicate_name = (
-            name.strip()
-            if name and name.strip()
-            else self._default_duplicate_name(current.name)
+            name.strip() if name and name.strip() else self._default_duplicate_name(current.name)
         )
         duplicated = current.model_copy(
             deep=True,
@@ -106,9 +104,7 @@ class ProjectStore:
                 "name": duplicate_name,
                 "created_at": now,
                 "updated_at": now,
-                "review_draft": current.review_draft.model_copy(
-                    update={"baseline_job_id": None}
-                ),
+                "review_draft": current.review_draft.model_copy(update={"baseline_job_id": None}),
                 "artifacts": current.artifacts.model_copy(update={"last_run_job_id": None}),
             },
         )

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -117,6 +117,78 @@ def test_project_crud_endpoints_and_project_summaries(tmp_path) -> None:
     assert client.get(f"/v1/projects/{project_id}").status_code == 404
 
 
+def test_duplicate_project_endpoint_clones_snapshot_without_job_links(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    create_response = client.post(
+        "/v1/projects",
+        json={
+            "name": "Workbench demo",
+            "source_mode": "graphql",
+            "active_step": "review",
+            "source": {
+                "name": "schema.graphql",
+                "content": "type Query { ping: String! }",
+            },
+            "generate_draft": {
+                "kind": ["missing_auth"],
+            },
+            "run_draft": {
+                "base_url": "https://example.com",
+                "headers": {"Authorization": "Bearer token"},
+            },
+            "review_draft": {
+                "baseline_job_id": "job-baseline",
+                "baseline": {
+                    "source": "unit",
+                    "base_url": "https://baseline.example.com",
+                    "executed_at": "2026-04-13T20:06:00Z",
+                    "profiles": [],
+                    "auth_events": [],
+                    "results": [],
+                },
+            },
+            "artifacts": {
+                "latest_markdown_report": "# report",
+                "latest_results": {
+                    "source": "unit",
+                    "base_url": "https://example.com",
+                    "executed_at": "2026-04-13T20:06:00Z",
+                    "profiles": [],
+                    "auth_events": [],
+                    "results": [],
+                },
+                "last_run_job_id": "job-current",
+            },
+        },
+    )
+
+    assert create_response.status_code == 200
+    original = create_response.json()
+
+    duplicate_response = client.post(f"/v1/projects/{original['id']}/duplicate")
+
+    assert duplicate_response.status_code == 200
+    duplicate = duplicate_response.json()
+    assert duplicate["id"] != original["id"]
+    assert duplicate["name"] == "Workbench demo copy"
+    assert duplicate["created_at"] != original["created_at"]
+    assert duplicate["updated_at"] != original["updated_at"]
+    assert duplicate["source"] == original["source"]
+    assert duplicate["generate_draft"] == original["generate_draft"]
+    assert duplicate["run_draft"] == original["run_draft"]
+    assert duplicate["review_draft"]["baseline_job_id"] is None
+    assert duplicate["review_draft"]["baseline"] == original["review_draft"]["baseline"]
+    assert duplicate["artifacts"]["last_run_job_id"] is None
+    assert duplicate["artifacts"]["latest_markdown_report"] == "# report"
+    assert duplicate["artifacts"]["latest_results"] == original["artifacts"]["latest_results"]
+
+    second_duplicate_response = client.post(f"/v1/projects/{original['id']}/duplicate")
+
+    assert second_duplicate_response.status_code == 200
+    assert second_duplicate_response.json()["name"] == "Workbench demo copy 2"
+
+
 def test_run_jobs_are_attached_to_projects_and_removed_on_project_delete(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add project duplication support so workbench users can clone an existing project snapshot without overwriting the original
- replace the current-run-only artifact list with a project-scoped artifact browser and inline inspector in Review -> Artifacts
- add artifact URL and fetch helpers that respect the configured API base URL for GitHub Pages and other remote frontend setups

## Why
Users could only work forward from a single project copy and had to open raw artifact files outside the workbench. This branch adds a safer iteration workflow and makes saved request/response artifacts inspectable directly in the UI.

## Impact
- backend: new project duplication endpoint preserves the source snapshot while clearing cross-project job references
- frontend: duplicate-project actions are available from the home page and active project header
- frontend: artifact browsing now spans all artifact-bearing runs, defaults intelligently, and supports structured and raw previews

## Validation
- `npm test -- --run src/api.test.ts src/pages/ProjectWorkbenchPage.test.tsx`
- `npm run build`
- `python3.12 -m compileall src tests`

Closes #82
Closes #83
Closes #84
