### PR TITLE
Add fragment-aware GraphQL contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ want to keep only the highest-signal regressions around, follow `verify` with
 workflow, secret setup, filtering patterns, baseline-aware CI flows, and checked-in suppressions.
 GraphQL schemas follow the same `inspect` / `generate` / `run` / `report` / `verify` flow, with
 `generate` automatically emitting variable-coercion attacks from SDL or introspection input.
+Generated GraphQL contracts now stay fragment-aware across nested selection sets, response-shape
+validation, and response-schema metadata for object, interface, and union results.
 Subscription roots are now staged into the same artifact flow as `SUBSCRIBE` attacks when the
 schema exposes them, using the `graphql-transport-ws` protocol and capturing the first event or
 error frame within the normal `--timeout` budget.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,9 @@ guesswork.
 - v0.17: Artifact deep dive drawer
   - ships finding-first current-run evidence drilldown, typed artifact references, and inline
     request/response, workflow, profile, and auth-event inspection in the review workbench
+- v0.18: fragment-aware GraphQL contracts
+  - ships nested object/interface/union GraphQL contract generation with parity across emitted
+    documents, output-shape validation, and response-schema metadata
 
 ## v0.12 — local-first HTTP API
 

--- a/src/knives_out/graphql_loader.py
+++ b/src/knives_out/graphql_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -94,66 +95,35 @@ def _nullable_schema(schema: dict[str, Any], *, nullable: bool) -> dict[str, Any
     return {**schema, "nullable": True}
 
 
-def _json_schema_for_output_type(type_: Any, *, schema: GraphQLSchema) -> dict[str, Any]:
-    if isinstance(type_, GraphQLNonNull):
-        output_schema = dict(_json_schema_for_output_type(type_.of_type, schema=schema))
-        output_schema.pop("nullable", None)
-        return output_schema
+@dataclass(frozen=True)
+class _GraphQLContract:
+    shape: GraphQLOutputShape
+    selection_set: str
+    response_schema: dict[str, Any]
 
-    named_type = get_named_type(type_)
-    nullable = not isinstance(type_, GraphQLNonNull)
 
-    if isinstance(type_, GraphQLList):
-        item_schema = _json_schema_for_output_type(type_.of_type, schema=schema)
-        return _nullable_schema({"type": "array", "items": item_schema}, nullable=nullable)
+def _typename_shape() -> GraphQLOutputShape:
+    return GraphQLOutputShape(
+        kind="scalar",
+        type_name="String",
+        nullable=False,
+    )
 
-    if isinstance(named_type, GraphQLScalarType):
-        scalar_name = named_type.name
-        if scalar_name == "Int":
-            return _nullable_schema({"type": "integer"}, nullable=nullable)
-        if scalar_name == "Float":
-            return _nullable_schema({"type": "number"}, nullable=nullable)
-        if scalar_name == "Boolean":
-            return _nullable_schema({"type": "boolean"}, nullable=nullable)
-        return _nullable_schema({"type": "string"}, nullable=nullable)
 
-    if isinstance(named_type, GraphQLEnumType):
-        return _nullable_schema(
-            {"type": "string", "enum": list(named_type.values)},
-            nullable=nullable,
-        )
+def _typename_schema(type_name: str) -> dict[str, Any]:
+    return {
+        "type": "string",
+        "const": type_name,
+    }
 
-    if isinstance(named_type, GraphQLObjectType):
-        return _nullable_schema(
-            {
-                "type": "object",
-                "properties": {
-                    "__typename": {
-                        "type": "string",
-                        "const": named_type.name,
-                    }
-                },
-                "required": ["__typename"],
-            },
-            nullable=nullable,
-        )
 
-    if isinstance(named_type, (GraphQLInterfaceType, GraphQLUnionType)):
-        possible_types = [possible.name for possible in schema.get_possible_types(named_type)]
-        typename_schema: dict[str, Any] = {"type": "string"}
-        if possible_types:
-            typename_schema["enum"] = possible_types
-        return _nullable_schema(
-            {
-                "type": "object",
-                "properties": {
-                    "__typename": typename_schema,
-                },
-                "required": ["__typename"],
-            },
-            nullable=nullable,
-        )
-
+def _graphql_scalar_schema(type_name: str, *, nullable: bool) -> dict[str, Any]:
+    if type_name == "Int":
+        return _nullable_schema({"type": "integer"}, nullable=nullable)
+    if type_name == "Float":
+        return _nullable_schema({"type": "number"}, nullable=nullable)
+    if type_name == "Boolean":
+        return _nullable_schema({"type": "boolean"}, nullable=nullable)
     return _nullable_schema({"type": "string"}, nullable=nullable)
 
 
@@ -170,141 +140,162 @@ def _federated_entity_type(type_: Any) -> bool:
     return any(getattr(directive.name, "value", None) == "key" for directive in directives)
 
 
-def _graphql_shape(
+def _graphql_contract(
     type_: Any,
     *,
     schema: GraphQLSchema,
     depth: int = 0,
     seen: tuple[str, ...] = (),
     federated_schema: bool = False,
-) -> tuple[GraphQLOutputShape, str]:
+) -> _GraphQLContract:
     nullable = not isinstance(type_, GraphQLNonNull)
     inner_type = type_.of_type if isinstance(type_, GraphQLNonNull) else type_
 
     if isinstance(inner_type, GraphQLList):
-        item_shape, item_selection = _graphql_shape(
+        item_contract = _graphql_contract(
             inner_type.of_type,
             schema=schema,
             depth=depth,
             seen=seen,
             federated_schema=federated_schema,
         )
-        return (
-            GraphQLOutputShape(
+        return _GraphQLContract(
+            shape=GraphQLOutputShape(
                 kind="list",
                 type_name=str(get_named_type(inner_type)),
                 nullable=nullable,
-                item_shape=item_shape,
+                item_shape=item_contract.shape,
                 federation_hint=(
                     "Selection crosses a federated list boundary."
-                    if federated_schema and item_shape.kind in {"object", "interface", "union"}
+                    if federated_schema
+                    and item_contract.shape.kind in {"object", "interface", "union"}
                     else None
                 ),
             ),
-            item_selection,
+            selection_set=item_contract.selection_set,
+            response_schema=_nullable_schema(
+                {"type": "array", "items": item_contract.response_schema},
+                nullable=nullable,
+            ),
         )
 
     named_type = get_named_type(inner_type)
     if isinstance(named_type, GraphQLScalarType):
-        return (
-            GraphQLOutputShape(
+        return _GraphQLContract(
+            shape=GraphQLOutputShape(
                 kind="scalar",
                 type_name=named_type.name,
                 nullable=nullable,
             ),
-            "",
+            selection_set="",
+            response_schema=_graphql_scalar_schema(named_type.name, nullable=nullable),
         )
 
     if isinstance(named_type, GraphQLEnumType):
-        return (
-            GraphQLOutputShape(
+        return _GraphQLContract(
+            shape=GraphQLOutputShape(
                 kind="enum",
                 type_name=named_type.name,
                 nullable=nullable,
             ),
-            "",
+            selection_set="",
+            response_schema=_nullable_schema(
+                {"type": "string", "enum": list(named_type.values)},
+                nullable=nullable,
+            ),
         )
 
     if isinstance(named_type, GraphQLObjectType):
         type_name = named_type.name
+        federated_entity = federated_schema and _federated_entity_type(named_type)
+        response_properties = {"__typename": _typename_schema(type_name)}
+        required = ["__typename"]
         if type_name in seen or depth >= 3:
-            fields = {
-                "__typename": GraphQLOutputShape(
-                    kind="scalar",
-                    type_name="String",
-                    nullable=False,
-                )
-            }
-            return (
-                GraphQLOutputShape(
+            fields = {"__typename": _typename_shape()}
+            return _GraphQLContract(
+                shape=GraphQLOutputShape(
                     kind="object",
                     type_name=type_name,
                     nullable=nullable,
                     fields=fields,
-                    federated_entity=federated_schema and _federated_entity_type(named_type),
+                    federated_entity=federated_entity,
                     federation_hint=(
                         f"Type '{type_name}' is revisited inside a federated schema."
                         if federated_schema
                         else None
                     ),
                 ),
-                "{ __typename }",
+                selection_set="{ __typename }",
+                response_schema=_nullable_schema(
+                    {
+                        "type": "object",
+                        "properties": response_properties,
+                        "required": required,
+                    },
+                    nullable=nullable,
+                ),
             )
 
-        fields: dict[str, GraphQLOutputShape] = {
-            "__typename": GraphQLOutputShape(
-                kind="scalar",
-                type_name="String",
-                nullable=False,
-            )
-        }
+        fields: dict[str, GraphQLOutputShape] = {"__typename": _typename_shape()}
         selections = ["__typename"]
         for field_name, field in named_type.fields.items():
             if field_name.startswith("__") or not _selectable_field(field):
                 continue
-            field_shape, field_selection = _graphql_shape(
+            field_contract = _graphql_contract(
                 field.type,
                 schema=schema,
                 depth=depth + 1,
                 seen=(*seen, type_name),
                 federated_schema=federated_schema,
             )
-            fields[field_name] = field_shape
-            if field_selection:
-                selections.append(f"{field_name} {field_selection}")
+            fields[field_name] = field_contract.shape
+            response_properties[field_name] = field_contract.response_schema
+            required.append(field_name)
+            if field_contract.selection_set:
+                selections.append(f"{field_name} {field_contract.selection_set}")
             else:
                 selections.append(field_name)
-        return (
-            GraphQLOutputShape(
+        return _GraphQLContract(
+            shape=GraphQLOutputShape(
                 kind="object",
                 type_name=type_name,
                 nullable=nullable,
                 fields=fields,
-                federated_entity=federated_schema and _federated_entity_type(named_type),
+                federated_entity=federated_entity,
                 federation_hint=(
                     f"Type '{type_name}' may resolve across federated entity boundaries."
-                    if federated_schema and _federated_entity_type(named_type)
+                    if federated_entity
                     else None
                 ),
             ),
-            "{ " + " ".join(selections) + " }",
+            selection_set="{ " + " ".join(selections) + " }",
+            response_schema=_nullable_schema(
+                {
+                    "type": "object",
+                    "properties": response_properties,
+                    "required": required,
+                },
+                nullable=nullable,
+            ),
         )
 
     if isinstance(named_type, GraphQLInterfaceType):
         possible_types: dict[str, GraphQLOutputShape] = {}
+        response_variants: list[dict[str, Any]] = []
         fragments: list[str] = ["__typename"]
         for possible_type in schema.get_possible_types(named_type):
-            possible_shape, possible_selection = _graphql_shape(
-                possible_type,
+            possible_contract = _graphql_contract(
+                GraphQLNonNull(possible_type),
                 schema=schema,
                 depth=depth + 1,
                 seen=(*seen, named_type.name),
                 federated_schema=federated_schema,
             )
-            possible_types[possible_type.name] = possible_shape
-            fragments.append(f"... on {possible_type.name} {possible_selection}")
-        return (
-            GraphQLOutputShape(
+            possible_types[possible_type.name] = possible_contract.shape
+            response_variants.append(possible_contract.response_schema)
+            fragments.append(f"... on {possible_type.name} {possible_contract.selection_set}")
+        return _GraphQLContract(
+            shape=GraphQLOutputShape(
                 kind="interface",
                 type_name=named_type.name,
                 nullable=nullable,
@@ -316,24 +307,27 @@ def _graphql_shape(
                     else None
                 ),
             ),
-            "{ " + " ".join(fragments) + " }",
+            selection_set="{ " + " ".join(fragments) + " }",
+            response_schema=_nullable_schema({"oneOf": response_variants}, nullable=nullable),
         )
 
     if isinstance(named_type, GraphQLUnionType):
-        possible_types = {}
+        possible_types: dict[str, GraphQLOutputShape] = {}
+        response_variants: list[dict[str, Any]] = []
         fragments = ["__typename"]
         for possible_type in named_type.types:
-            possible_shape, possible_selection = _graphql_shape(
-                possible_type,
+            possible_contract = _graphql_contract(
+                GraphQLNonNull(possible_type),
                 schema=schema,
                 depth=depth + 1,
                 seen=(*seen, named_type.name),
                 federated_schema=federated_schema,
             )
-            possible_types[possible_type.name] = possible_shape
-            fragments.append(f"... on {possible_type.name} {possible_selection}")
-        return (
-            GraphQLOutputShape(
+            possible_types[possible_type.name] = possible_contract.shape
+            response_variants.append(possible_contract.response_schema)
+            fragments.append(f"... on {possible_type.name} {possible_contract.selection_set}")
+        return _GraphQLContract(
+            shape=GraphQLOutputShape(
                 kind="union",
                 type_name=named_type.name,
                 nullable=nullable,
@@ -345,16 +339,18 @@ def _graphql_shape(
                     else None
                 ),
             ),
-            "{ " + " ".join(fragments) + " }",
+            selection_set="{ " + " ".join(fragments) + " }",
+            response_schema=_nullable_schema({"oneOf": response_variants}, nullable=nullable),
         )
 
-    return (
-        GraphQLOutputShape(
+    return _GraphQLContract(
+        shape=GraphQLOutputShape(
             kind="scalar",
             type_name=str(named_type),
             nullable=nullable,
         ),
-        "",
+        selection_set="",
+        response_schema=_graphql_scalar_schema(str(named_type), nullable=nullable),
     )
 
 
@@ -363,8 +359,7 @@ def _graphql_document(
     operation_type: str,
     field_name: str,
     field: Any,
-    schema: GraphQLSchema,
-    federated_schema: bool,
+    selection_set: str,
 ) -> str:
     variable_definitions: list[str] = []
     argument_bindings: list[str] = []
@@ -375,11 +370,6 @@ def _graphql_document(
     operation_name = field_name[:1].upper() + field_name[1:]
     definitions = f"({', '.join(variable_definitions)})" if variable_definitions else ""
     bindings = f"({', '.join(argument_bindings)})" if argument_bindings else ""
-    _, selection_set = _graphql_shape(
-        field.type,
-        schema=schema,
-        federated_schema=federated_schema,
-    )
     selection = f" {selection_set}" if selection_set else ""
     return f"{operation_type} {operation_name}{definitions} {{ {field_name}{bindings}{selection} }}"
 
@@ -418,14 +408,14 @@ def _request_body_schema(document: str, variables_schema: dict[str, Any]) -> dic
     return schema
 
 
-def _response_schema(field_name: str, field: Any, *, schema: GraphQLSchema) -> dict[str, Any]:
+def _response_schema(field_name: str, field_response_schema: dict[str, Any]) -> dict[str, Any]:
     return {
         "type": "object",
         "properties": {
             "data": {
                 "type": "object",
                 "properties": {
-                    field_name: _json_schema_for_output_type(field.type, schema=schema),
+                    field_name: field_response_schema,
                 },
                 "required": [field_name],
             }
@@ -448,7 +438,7 @@ def _operation_specs(
     operations: list[OperationSpec] = []
     for field_name, field in root.fields.items():
         variables_schema = _variables_schema(field)
-        output_shape, _ = _graphql_shape(
+        contract = _graphql_contract(
             field.type,
             schema=schema,
             federated_schema=federated_schema,
@@ -457,16 +447,15 @@ def _operation_specs(
             operation_type=operation_type,
             field_name=field_name,
             field=field,
-            schema=schema,
-            federated_schema=federated_schema,
+            selection_set=contract.selection_set,
         )
         entity_types = sorted(
             type_name
-            for type_name, shape in output_shape.possible_types.items()
+            for type_name, shape in contract.shape.possible_types.items()
             if shape.federated_entity
         )
-        if output_shape.federated_entity:
-            entity_types.append(output_shape.type_name)
+        if contract.shape.federated_entity:
+            entity_types.append(contract.shape.type_name)
         operations.append(
             OperationSpec(
                 operation_id=field_name,
@@ -490,14 +479,14 @@ def _operation_specs(
                 response_schemas={
                     "200": ResponseSpec(
                         content_type="application/json",
-                        schema_def=_response_schema(field_name, field, schema=schema),
+                        schema_def=_response_schema(field_name, contract.response_schema),
                     )
                 },
                 graphql_operation_type=operation_type,
                 graphql_document=document,
                 graphql_variables_schema=variables_schema,
                 graphql_root_field_name=field_name,
-                graphql_output_shape=output_shape,
+                graphql_output_shape=contract.shape,
                 graphql_federated=federated_schema,
                 graphql_entity_types=sorted(set(entity_types)),
             )

--- a/src/knives_out/runner.py
+++ b/src/knives_out/runner.py
@@ -805,6 +805,9 @@ def _validate_response_schema(
     attack: AttackCase,
     response: httpx.Response,
 ) -> tuple[str | None, bool | None, str | None]:
+    if attack.protocol == "graphql":
+        return None, None, None
+
     if "graphql_error" in {
         expected.strip().lower() for expected in attack.expected_outcomes
     } and _response_has_graphql_errors(response):

--- a/tests/test_graphql_generator.py
+++ b/tests/test_graphql_generator.py
@@ -29,6 +29,39 @@ def _graphql_subscription_schema_text() -> str:
     ).strip()
 
 
+def _graphql_fragment_schema_text() -> str:
+    return dedent(
+        """
+        interface Node {
+          id: ID!
+        }
+
+        type Query {
+          search(id: ID!): SearchResult
+        }
+
+        type Book implements Node {
+          id: ID!
+          title: String!
+          author: Author
+        }
+
+        type Author {
+          id: ID!
+          name: String!
+        }
+
+        type Magazine implements Node {
+          id: ID!
+          title: String!
+          issue: Int!
+        }
+
+        union SearchResult = Book | Magazine
+        """
+    ).strip()
+
+
 def test_generate_graphql_attack_suite_emits_variable_mutations() -> None:
     suite = generate_attack_suite(
         load_operations(GRAPHQL_SPEC),
@@ -62,8 +95,15 @@ def test_generate_graphql_attack_suite_emits_variable_mutations() -> None:
                         "type": "object",
                         "properties": {
                             "__typename": {"type": "string", "const": "Book"},
+                            "id": {"type": "string"},
+                            "title": {"type": "string"},
+                            "genre": {
+                                "type": "string",
+                                "enum": ["FICTION", "NONFICTION", "REFERENCE"],
+                            },
+                            "rating": {"type": "integer", "nullable": True},
                         },
-                        "required": ["__typename"],
+                        "required": ["__typename", "id", "title", "genre", "rating"],
                     }
                 },
                 "required": ["createBook"],
@@ -101,3 +141,33 @@ def test_generate_graphql_attack_suite_includes_subscription_attacks(tmp_path) -
         attack for attack in subscription_attacks if attack.kind == "wrong_type_variable"
     )
     assert wrong_type_attack.body_json["query"].startswith("subscription BookEvents")
+
+
+def test_generate_graphql_attack_suite_preserves_fragment_aware_contracts(tmp_path) -> None:
+    schema_path = tmp_path / "fragments.graphql"
+    schema_path.write_text(_graphql_fragment_schema_text(), encoding="utf-8")
+
+    suite = generate_attack_suite(
+        load_operations(schema_path),
+        source=str(schema_path),
+    )
+
+    search_attacks = [attack for attack in suite.attacks if attack.operation_id == "search"]
+    wrong_type_attack = next(
+        attack for attack in search_attacks if attack.kind == "wrong_type_variable"
+    )
+
+    assert (
+        "... on Book { __typename id title author { __typename id name } }"
+        in (wrong_type_attack.body_json["query"])
+    )
+    assert "... on Magazine { __typename id title issue }" in wrong_type_attack.body_json["query"]
+
+    search_schema = wrong_type_attack.response_schemas["200"].schema_def["properties"]["data"][
+        "properties"
+    ]["search"]
+    assert len(search_schema["oneOf"]) == 2
+    assert {variant["properties"]["__typename"]["const"] for variant in search_schema["oneOf"]} == {
+        "Book",
+        "Magazine",
+    }

--- a/tests/test_graphql_loader.py
+++ b/tests/test_graphql_loader.py
@@ -21,6 +21,7 @@ def _graphql_schema_text() -> str:
           book(id: ID!): Book
           books(limit: Int, genre: Genre): [Book!]!
           node(id: ID!): Node
+          search(id: ID!): SearchResult
         }
 
         type Mutation {
@@ -31,6 +32,19 @@ def _graphql_schema_text() -> str:
           id: ID!
           title: String!
           genre: Genre!
+          author: Author
+        }
+
+        type Author {
+          id: ID!
+          name: String!
+          favoriteBook: Book
+        }
+
+        type Magazine implements Node {
+          id: ID!
+          title: String!
+          issue: Int!
         }
 
         input CreateBookInput {
@@ -43,6 +57,8 @@ def _graphql_schema_text() -> str:
           FICTION
           NONFICTION
         }
+
+        union SearchResult = Book | Magazine
         """
     ).strip()
 
@@ -77,6 +93,7 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
         "book",
         "books",
         "node",
+        "search",
         "createBook",
     ]
 
@@ -86,40 +103,50 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
     assert book.method == "POST"
     assert book.path == "/api/graphql"
     assert book.tags == ["graphql", "query"]
-    assert (
-        book.graphql_document
-        == "query Book($id: ID!) { book(id: $id) { __typename id title genre } }"
+    assert book.graphql_document == (
+        "query Book($id: ID!) { "
+        "book(id: $id) { "
+        "__typename id title genre author { __typename id name favoriteBook { __typename } } "
+        "} }"
     )
     assert book.graphql_root_field_name == "book"
     assert book.graphql_output_shape is not None
     assert book.graphql_output_shape.kind == "object"
-    assert sorted(book.graphql_output_shape.fields) == ["__typename", "genre", "id", "title"]
+    assert sorted(book.graphql_output_shape.fields) == [
+        "__typename",
+        "author",
+        "genre",
+        "id",
+        "title",
+    ]
+    assert sorted(book.graphql_output_shape.fields["author"].fields["favoriteBook"].fields) == [
+        "__typename"
+    ]
     assert book.graphql_variables_schema == {
         "type": "object",
         "properties": {"id": {"type": "string"}},
         "required": ["id"],
     }
     assert book.response_schemas["200"].content_type == "application/json"
-    assert book.response_schemas["200"].schema_def == {
+    book_schema = book.response_schemas["200"].schema_def["properties"]["data"]["properties"][
+        "book"
+    ]
+    assert book_schema["required"] == ["__typename", "id", "title", "genre", "author"]
+    assert book_schema["properties"]["author"]["required"] == [
+        "__typename",
+        "id",
+        "name",
+        "favoriteBook",
+    ]
+    assert book_schema["properties"]["author"]["properties"]["favoriteBook"] == {
         "type": "object",
         "properties": {
-            "data": {
-                "type": "object",
-                "properties": {
-                    "book": {
-                        "type": "object",
-                        "properties": {
-                            "__typename": {"type": "string", "const": "Book"},
-                        },
-                        "required": ["__typename"],
-                        "nullable": True,
-                    }
-                },
-                "required": ["book"],
-            }
+            "__typename": {"type": "string", "const": "Book"},
         },
-        "required": ["data"],
+        "required": ["__typename"],
+        "nullable": True,
     }
+    assert book_schema["properties"]["author"]["nullable"] is True
 
     create_book = operations[-1]
     assert create_book.graphql_operation_type == "mutation"
@@ -140,30 +167,48 @@ def test_load_graphql_operations_from_sdl(tmp_path) -> None:
     }
     assert create_book.graphql_output_shape is not None
     assert create_book.graphql_output_shape.fields["title"].type_name == "String"
-    assert create_book.response_schemas["200"].schema_def == {
-        "type": "object",
-        "properties": {
-            "data": {
-                "type": "object",
-                "properties": {
-                    "createBook": {
-                        "type": "object",
-                        "properties": {
-                            "__typename": {"type": "string", "const": "Book"},
-                        },
-                        "required": ["__typename"],
-                    }
-                },
-                "required": ["createBook"],
-            }
-        },
-        "required": ["data"],
-    }
+    create_book_schema = create_book.response_schemas["200"].schema_def["properties"]["data"][
+        "properties"
+    ]["createBook"]
+    assert create_book_schema["required"] == ["__typename", "id", "title", "genre", "author"]
+    assert create_book_schema["properties"]["author"]["properties"]["name"] == {"type": "string"}
 
     node = next(operation for operation in operations if operation.operation_id == "node")
     assert node.graphql_output_shape is not None
     assert node.graphql_output_shape.kind == "interface"
-    assert "Book" in node.graphql_output_shape.possible_types
+    assert sorted(node.graphql_output_shape.possible_types) == ["Book", "Magazine"]
+    assert "... on Book { __typename id title genre author" in (node.graphql_document or "")
+    assert "... on Magazine { __typename id title issue }" in (node.graphql_document or "")
+    node_schema = node.response_schemas["200"].schema_def["properties"]["data"]["properties"][
+        "node"
+    ]
+    assert len(node_schema["oneOf"]) == 2
+    book_variant = next(
+        variant
+        for variant in node_schema["oneOf"]
+        if variant["properties"]["__typename"]["const"] == "Book"
+    )
+    magazine_variant = next(
+        variant
+        for variant in node_schema["oneOf"]
+        if variant["properties"]["__typename"]["const"] == "Magazine"
+    )
+    assert "author" in book_variant["properties"]
+    assert "issue" in magazine_variant["properties"]
+
+    search = next(operation for operation in operations if operation.operation_id == "search")
+    assert search.graphql_output_shape is not None
+    assert search.graphql_output_shape.kind == "union"
+    assert "... on Book { __typename id title genre author" in (search.graphql_document or "")
+    assert "... on Magazine { __typename id title issue }" in (search.graphql_document or "")
+    search_schema = search.response_schemas["200"].schema_def["properties"]["data"]["properties"][
+        "search"
+    ]
+    assert len(search_schema["oneOf"]) == 2
+    assert {variant["properties"]["__typename"]["const"] for variant in search_schema["oneOf"]} == {
+        "Book",
+        "Magazine",
+    }
 
 
 def test_load_graphql_operations_includes_subscription_roots(tmp_path) -> None:
@@ -205,6 +250,7 @@ def test_spec_loader_detects_graphql_introspection_json(tmp_path) -> None:
         "book",
         "books",
         "node",
+        "search",
         "createBook",
     }
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -234,6 +234,87 @@ def _graphql_shape_book(*, nullable: bool = True) -> GraphQLOutputShape:
     )
 
 
+def _graphql_shape_author(*, nullable: bool = True) -> GraphQLOutputShape:
+    return GraphQLOutputShape(
+        kind="object",
+        type_name="Author",
+        nullable=nullable,
+        fields={
+            "__typename": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "id": GraphQLOutputShape(
+                kind="scalar",
+                type_name="ID",
+                nullable=False,
+            ),
+            "name": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+        },
+    )
+
+
+def _graphql_shape_book_with_author(*, nullable: bool = True) -> GraphQLOutputShape:
+    return GraphQLOutputShape(
+        kind="object",
+        type_name="Book",
+        nullable=nullable,
+        fields={
+            "__typename": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "id": GraphQLOutputShape(
+                kind="scalar",
+                type_name="ID",
+                nullable=False,
+            ),
+            "title": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "author": _graphql_shape_author(),
+        },
+    )
+
+
+def _graphql_shape_magazine(*, nullable: bool = True) -> GraphQLOutputShape:
+    return GraphQLOutputShape(
+        kind="object",
+        type_name="Magazine",
+        nullable=nullable,
+        fields={
+            "__typename": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "id": GraphQLOutputShape(
+                kind="scalar",
+                type_name="ID",
+                nullable=False,
+            ),
+            "title": GraphQLOutputShape(
+                kind="scalar",
+                type_name="String",
+                nullable=False,
+            ),
+            "issue": GraphQLOutputShape(
+                kind="scalar",
+                type_name="Int",
+                nullable=False,
+            ),
+        },
+    )
+
+
 def _graphql_attack_case(
     *,
     output_shape: GraphQLOutputShape | None = None,
@@ -265,6 +346,7 @@ def _graphql_subscription_attack_case(
     *,
     body_json: dict[str, object] | None = None,
     expected_outcomes: list[str] | None = None,
+    output_shape: GraphQLOutputShape | None = None,
 ) -> AttackCase:
     return AttackCase(
         id="atk_graphql_subscription",
@@ -287,7 +369,7 @@ def _graphql_subscription_attack_case(
         expected_outcomes=list(expected_outcomes or ["2xx"]),
         graphql_operation_type="subscription",
         graphql_root_field_name="bookEvents",
-        graphql_output_shape=_graphql_shape_book(),
+        graphql_output_shape=output_shape or _graphql_shape_book(),
     )
 
 
@@ -1753,6 +1835,127 @@ def test_execute_attack_suite_flags_wrong_graphql_scalar_type(monkeypatch) -> No
     assert result.graphql_response_error == "$.data.book.rating: expected Int, got string"
 
 
+def test_execute_attack_suite_flags_missing_nested_graphql_selected_field(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "book": {
+                        "__typename": "Book",
+                        "id": "1",
+                        "title": "Dune",
+                        "author": {"__typename": "Author", "id": "a1"},
+                    }
+                }
+            },
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                _graphql_attack_case(
+                    output_shape=_graphql_shape_book_with_author(),
+                )
+            ],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_error == "$.data.book.author: missing selected field 'name'"
+
+
+def test_execute_attack_suite_flags_wrong_nested_graphql_scalar_type(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "book": {
+                        "__typename": "Book",
+                        "id": "1",
+                        "title": "Dune",
+                        "author": {"__typename": "Author", "id": "a1", "name": 99},
+                    }
+                }
+            },
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                _graphql_attack_case(
+                    output_shape=_graphql_shape_book_with_author(),
+                )
+            ],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_error == "$.data.book.author.name: expected String, got integer"
+
+
+def test_execute_attack_suite_flags_graphql_list_item_shape_mismatch(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "books": [
+                        {
+                            "__typename": "Book",
+                            "id": "1",
+                            "title": 7,
+                            "rating": 5,
+                        }
+                    ]
+                }
+            },
+        ),
+    )
+
+    attack = _graphql_attack_case(
+        output_shape=GraphQLOutputShape(
+            kind="list",
+            type_name="Book",
+            nullable=False,
+            item_shape=_graphql_shape_book(nullable=False),
+        )
+    ).model_copy(
+        update={
+            "operation_id": "books",
+            "graphql_root_field_name": "books",
+            "body_json": {
+                "query": "query Books { books { __typename id title rating } }",
+                "variables": {},
+            },
+        }
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[attack]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_error == "$.data.books[0].title: expected String, got integer"
+
+
 def test_execute_attack_suite_allows_partial_graphql_data_when_shape_is_valid(monkeypatch) -> None:
     _install_stub_response(
         monkeypatch,
@@ -1863,6 +2066,141 @@ def test_execute_attack_suite_validates_graphql_union_typename(monkeypatch) -> N
     assert "expected one of ['Book']" in (result.graphql_response_error or "")
 
 
+def test_execute_attack_suite_accepts_valid_graphql_interface_runtime_type(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "node": {
+                        "__typename": "Magazine",
+                        "id": "1",
+                        "title": "Issue 1",
+                        "issue": 7,
+                    }
+                }
+            },
+        ),
+    )
+
+    attack = _graphql_attack_case(
+        output_shape=GraphQLOutputShape(
+            kind="interface",
+            type_name="Node",
+            nullable=True,
+            possible_types={
+                "Book": _graphql_shape_book(),
+                "Magazine": _graphql_shape_magazine(),
+            },
+        )
+    ).model_copy(
+        update={
+            "operation_id": "node",
+            "graphql_root_field_name": "node",
+            "body_json": {
+                "query": (
+                    "query Node($id: ID!) { "
+                    "node(id: $id) { __typename ... on Book { id title rating } "
+                    "... on Magazine { id title issue } } }"
+                ),
+                "variables": {"id": "1"},
+            },
+        }
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[attack]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "unexpected_success"
+    assert result.graphql_response_valid is True
+
+
+def test_execute_attack_suite_flags_missing_graphql_fragment_field(monkeypatch) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={"data": {"node": {"__typename": "Book", "id": "1", "rating": 5}}},
+        ),
+    )
+
+    attack = _graphql_attack_case(
+        output_shape=GraphQLOutputShape(
+            kind="interface",
+            type_name="Node",
+            nullable=True,
+            possible_types={"Book": _graphql_shape_book()},
+        )
+    ).model_copy(
+        update={
+            "operation_id": "node",
+            "graphql_root_field_name": "node",
+            "body_json": {
+                "query": (
+                    "query Node($id: ID!) { "
+                    "node(id: $id) { __typename ... on Book { id title rating } } "
+                    "}"
+                ),
+                "variables": {"id": "1"},
+            },
+        }
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(source="unit", attacks=[attack]),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_error == "$.data.node: missing selected field 'title'"
+
+
+def test_execute_attack_suite_flags_partial_graphql_fragment_data_when_shape_is_invalid(
+    monkeypatch,
+) -> None:
+    _install_stub_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "book": {
+                        "__typename": "Book",
+                        "id": "1",
+                        "title": "Dune",
+                        "author": {"__typename": "Author", "id": "a1"},
+                    }
+                },
+                "errors": [{"message": "author.name resolver failed"}],
+            },
+        ),
+    )
+
+    results = execute_attack_suite(
+        AttackSuite(
+            source="unit",
+            attacks=[
+                _graphql_attack_case(
+                    output_shape=_graphql_shape_book_with_author(),
+                )
+            ],
+        ),
+        base_url="https://example.com",
+    )
+
+    result = results.results[0]
+    assert result.flagged is True
+    assert result.issue == "graphql_response_shape_mismatch"
+    assert result.graphql_response_error == "$.data.book.author: missing selected field 'name'"
+
+
 def test_execute_attack_suite_runs_graphql_subscription_over_websocket() -> None:
     def _handler(websocket) -> None:
         init_frame = json.loads(websocket.recv())
@@ -1904,6 +2242,61 @@ def test_execute_attack_suite_runs_graphql_subscription_over_websocket() -> None
     assert result.status_code == 200
     assert result.graphql_response_valid is True
     assert result.url.endswith("/graphql")
+
+
+def test_execute_attack_suite_validates_nested_graphql_subscription_payload() -> None:
+    def _handler(websocket) -> None:
+        init_frame = json.loads(websocket.recv())
+        assert init_frame == {"type": "connection_init"}
+        websocket.send(json.dumps({"type": "connection_ack"}))
+
+        subscribe_frame = json.loads(websocket.recv())
+        assert subscribe_frame["type"] == "subscribe"
+        websocket.send(
+            json.dumps(
+                {
+                    "type": "next",
+                    "id": subscribe_frame["id"],
+                    "payload": {
+                        "data": {
+                            "bookEvents": {
+                                "__typename": "Book",
+                                "id": "1",
+                                "title": "Dune",
+                                "author": {
+                                    "__typename": "Author",
+                                    "id": "a1",
+                                    "name": "Frank Herbert",
+                                },
+                            }
+                        }
+                    },
+                }
+            )
+        )
+
+    attack = _graphql_subscription_attack_case(
+        body_json={
+            "query": (
+                "subscription BookEvents($id: ID!) { "
+                "bookEvents(id: $id) { __typename id title author { __typename id name } } "
+                "}"
+            ),
+            "variables": {"id": "1"},
+        },
+        output_shape=_graphql_shape_book_with_author(nullable=False),
+    )
+
+    with _graphql_subscription_server(_handler) as base_url:
+        results = execute_attack_suite(
+            AttackSuite(source="unit", attacks=[attack]),
+            base_url=base_url,
+        )
+
+    result = results.results[0]
+    assert result.flagged is False
+    assert result.issue is None
+    assert result.graphql_response_valid is True
 
 
 def test_execute_attack_suite_handles_graphql_subscription_ping_frames() -> None:


### PR DESCRIPTION
## Summary
- refactor GraphQL traversal so selection sets, output shapes, and response schemas come from one fragment-aware contract builder
- emit nested object and interface/union `oneOf` response schemas while keeping `graphql_output_shape` as the authoritative runtime validator
- extend loader, generator, and runner coverage for nested object, interface, union, partial-data, and subscription validation paths

## Testing
- `.venv312/bin/python -m pytest -q tests/test_graphql_loader.py tests/test_graphql_generator.py tests/test_runner.py`
- `.venv312/bin/python -m pytest -q tests/test_api.py tests/test_cli.py tests/test_docs.py tests/test_examples.py tests/test_extension_coverage.py tests/test_graphql_generator.py tests/test_graphql_loader.py tests/test_runner.py tests/test_web_app.py`
- `.venv312/bin/python -m ruff check src/knives_out/graphql_loader.py src/knives_out/runner.py tests/test_graphql_loader.py tests/test_graphql_generator.py tests/test_runner.py`
- `python3.12 -m compileall src tests`

Closes #46