### PR TITLE
[codex] Add SARIF export workflow

### DIFF
--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 env:
   SPEC_PATH: examples/openapi/storefront.yaml
@@ -130,6 +131,20 @@ jobs:
             --out regression-attacks.json
           # For baseline-aware promotion, add:
           #   --baseline previous-results.json
+      - name: Export SARIF findings
+        if: always()
+        run: |
+          knives-out export results.json --format sarif --out results.sarif
+          # To add regression metadata:
+          # knives-out export results.json \
+          #   --format sarif \
+          #   --baseline previous-results.json \
+          #   --out results.sarif
+      - name: Upload SARIF to GitHub code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
       - name: Upload run artifacts
         if: always()
         uses: actions/upload-artifact@v6
@@ -140,6 +155,7 @@ jobs:
             attacks.json
             regression-attacks.json
             results.json
+            results.sarif
             report.md
             report.html
             regression-report.md

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Given an OpenAPI spec, GraphQL schema, or learned traffic model, `knives-out` ca
 - run those attacks against a live base URL
 - produce a Markdown report that highlights suspicious outcomes
 - produce an HTML report with linked request and response artifacts
+- export SARIF findings for CI-native code-scanning review
 - verify findings for CI gating
 - promote qualifying findings back into a reusable regression suite
 - suppress or triage known findings so CI stays focused on active risk
@@ -204,6 +205,12 @@ Generate a machine-readable summary for dashboards or CI annotations:
 knives-out summary results.json --out summary.json
 ```
 
+Export active findings as SARIF for CI-native code scanning:
+
+```bash
+knives-out export results.json --format sarif --out results.sarif
+```
+
 Promote qualifying findings back into a reusable regression suite:
 
 ```bash
@@ -306,6 +313,7 @@ The synchronous endpoints mirror the short CLI flows:
 - `POST /v1/inspect`
 - `POST /v1/generate`
 - `POST /v1/discover`
+- `POST /v1/export`
 - `POST /v1/report`
 - `POST /v1/summary`
 - `POST /v1/verify`
@@ -390,6 +398,9 @@ status, severity, confidence, or schema outcome drifted between runs.
 When you want a compact machine-readable artifact for dashboards, annotations, or follow-on
 automation, `knives-out summary results.json --out summary.json` emits the same counts and top
 findings as structured JSON.
+When you want code-scanning or PR-native triage inside CI, `knives-out export results.json --format sarif --out results.sarif`
+emits SARIF 2.1.0 from the same active unsuppressed findings, with optional baseline change
+metadata when you also pass `--baseline previous-results.json`.
 When you want stateful coverage, generate with `--auto-workflows` first, then add
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
 you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
@@ -410,7 +421,8 @@ error frame within the normal `--timeout` budget.
 Shadow Twin capture and discovery fit the same path too:
 `capture -> discover -> generate -> run -> report -> verify`.
 If you want to drive that workflow from another local tool instead of shelling out, `knives-out serve`
-now exposes the same core actions over HTTP with background `run` jobs, summary responses, and
+now exposes the same core actions over HTTP with background `run` jobs, summary responses, export
+responses, and
 artifact download routes.
 If you keep a `.knives-out-ignore.yml` file in the repo root, `report`, `verify`, and `promote`
 will load it automatically. Use `knives-out triage results.json` to seed new entries when you want
@@ -595,6 +607,27 @@ If `.knives-out-ignore.yml` exists in the repo root, `report` will automatically
 findings separately. You can also point at another file explicitly with `--suppressions path/to.yml`.
 When the run used `--profile-file`, the report includes a per-profile outcome table under each
 attack so you can compare status codes and issues by identity.
+
+### `export`
+
+Renders a machine-readable CI export from a results JSON file.
+
+```bash
+knives-out export results.json --format sarif --out results.sarif
+```
+
+You can include a prior `results.json` as a baseline to attach `new` vs `persisting` metadata and
+persisting delta details to the exported SARIF findings:
+
+```bash
+knives-out export results.json \
+  --format sarif \
+  --baseline previous-results.json \
+  --out results.sarif
+```
+
+`export` auto-loads `.knives-out-ignore.yml` when present and excludes suppressed findings by
+default, so CI-facing SARIF stays aligned with the rest of the review flow.
 
 ### `verify`
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,10 +7,11 @@
 3. run that suite against a dev or staging deployment
 4. render a Markdown report for review
 5. optionally render an HTML report with linked artifacts
-6. verify the results against a CI policy
-7. optionally promote qualifying findings into a smaller regression suite
-8. optionally maintain a checked-in suppressions file for accepted findings
-9. publish the JSON results, reports, regression suite, and per-attack artifacts
+6. optionally export SARIF for code scanning or PR-native review
+7. verify the results against a CI policy
+8. optionally promote qualifying findings into a smaller regression suite
+9. optionally maintain a checked-in suppressions file for accepted findings
+10. publish the JSON results, reports, SARIF export, regression suite, and per-attack artifacts
 
 The repository includes a ready-to-adapt GitHub Actions example at
 `.github/workflows/dev-environment-example.yml`.
@@ -63,6 +64,7 @@ That default behavior is intentional for review-first workflows:
 - `results.json` stays available for automation
 - `report.md` stays available for humans
 - `report.html` can present a linked artifact index for faster triage
+- `results.sarif` can feed code scanning and pipeline-native review systems
 - `artifacts/` keeps one request/response record per attack for debugging
 
 `knives-out verify` is the built-in gating step. It reads `results.json`, applies severity and
@@ -104,6 +106,46 @@ The tool does not fetch that baseline for you. Your workflow is responsible for 
 `previous-results.json` in the workspace before this step.
 When you use a baseline, `verify` also prints a compact summary for persisting findings whose
 status, severity, confidence, or schema outcome changed between runs.
+
+## Optional: SARIF export for code scanning
+
+Use this when you want the active unsuppressed findings to show up in GitHub code scanning or any
+other SARIF-capable pipeline sink. This export is complementary to `verify`: it helps teams review
+findings in native CI surfaces, but it does not change pass/fail behavior by itself.
+
+The simplest form is:
+
+```bash
+knives-out export results.json --format sarif --out results.sarif
+```
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+```
+
+```yaml
+- name: Export SARIF findings
+  if: always()
+  run: |
+    knives-out export results.json \
+      --format sarif \
+      --out results.sarif
+    # To add regression context to the SARIF properties:
+    # knives-out export results.json \
+    #   --format sarif \
+    #   --baseline previous-results.json \
+    #   --out results.sarif
+```
+
+```yaml
+- name: Upload SARIF to GitHub code scanning
+  if: always()
+  uses: github/codeql-action/upload-sarif@v4
+  with:
+    sarif_file: results.sarif
+```
 
 ## Optional: checked-in suppressions
 
@@ -211,8 +253,8 @@ server on loopback:
 ```
 
 The API mirrors the same JSON artifacts through `POST /v1/inspect`, `POST /v1/generate`,
-`POST /v1/discover`, `POST /v1/report`, `POST /v1/summary`, `POST /v1/verify`, `POST /v1/promote`,
-`POST /v1/triage`, and background `POST /v1/runs` jobs with `GET /v1/jobs` browsing and
+`POST /v1/discover`, `POST /v1/export`, `POST /v1/report`, `POST /v1/summary`, `POST /v1/verify`,
+`POST /v1/promote`, `POST /v1/triage`, and background `POST /v1/runs` jobs with `GET /v1/jobs` browsing and
 `GET /v1/jobs/{id}` polling.
 Completed jobs expose a compact `result_summary` on the collection and status responses so
 downstream local tools can rank recent runs before fetching full result payloads.

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -23,6 +23,8 @@ from knives_out.api_models import (
     DeltaChangeResponse,
     DiscoverRequest,
     DiscoverResponse,
+    ExportRequest,
+    ExportResponse,
     FindingSummaryResponse,
     GenerateRequest,
     GenerateResponse,
@@ -66,6 +68,7 @@ from knives_out.project_store import ProjectNotFoundError, ProjectStore
 from knives_out.services import (
     InlineInput,
     discover_model_inline,
+    export_results_from_models,
     generate_suite_from_inline,
     inspect_source_inline,
     promote_results_from_models,
@@ -866,6 +869,16 @@ def create_app(
             format=request.format.value,
         )
         return ReportResponse(format=request.format, content=rendered)
+
+    @app.post("/v1/export", response_model=ExportResponse)
+    def export_endpoint(request: ExportRequest) -> ExportResponse:
+        content = export_results_from_models(
+            request.results,
+            baseline=request.baseline,
+            suppressions_yaml=request.suppressions_yaml,
+            format=request.format.value,
+        )
+        return ExportResponse(format=request.format, content=content)
 
     @app.post("/v1/summary", response_model=SummaryResponse)
     def summary_endpoint(request: SummaryRequest) -> SummaryResponse:

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -26,6 +26,10 @@ class ApiReportFormat(StrEnum):
     html = "html"
 
 
+class ApiExportFormat(StrEnum):
+    sarif = "sarif"
+
+
 class ApiJobStatus(StrEnum):
     pending = "pending"
     running = "running"
@@ -204,6 +208,18 @@ class ReportRequest(BaseModel):
 class ReportResponse(BaseModel):
     format: ApiReportFormat
     content: str
+
+
+class ExportRequest(BaseModel):
+    results: AttackResults
+    baseline: AttackResults | None = None
+    suppressions_yaml: str | None = None
+    format: ApiExportFormat = ApiExportFormat.sarif
+
+
+class ExportResponse(BaseModel):
+    format: ApiExportFormat
+    content: dict[str, Any]
 
 
 class SummaryResponse(ResultsSummary):

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -19,6 +19,7 @@ from knives_out.services import (
     DEFAULT_SUPPRESSIONS_PATH,
     SuppressionRule,
     discover_model_paths,
+    export_results_from_paths,
     generate_suite_from_path,
     inspect_source_path,
     load_attack_results_or_raise,
@@ -57,6 +58,10 @@ class ConfidenceThresholdOption(StrEnum):
 class ReportFormatOption(StrEnum):
     markdown = "markdown"
     html = "html"
+
+
+class ExportFormatOption(StrEnum):
+    sarif = "sarif"
 
 
 class InspectFormatOption(StrEnum):
@@ -614,6 +619,49 @@ def run(
             f"Recorded {auth_failures} auth failure(s)."
         )
     console.print(f"Wrote results to [bold]{out}[/bold].")
+
+
+@app.command()
+def export(
+    results: Path,
+    baseline: Annotated[
+        Path | None,
+        typer.Option(help="Optional baseline results file for regression comparison."),
+    ] = None,
+    suppressions: Annotated[
+        Path | None,
+        typer.Option(
+            help="Optional suppressions file. Defaults to .knives-out-ignore.yml if present."
+        ),
+    ] = None,
+    out: Annotated[
+        Path | None,
+        typer.Option(help="Optional export output file."),
+    ] = None,
+    format: Annotated[
+        ExportFormatOption,
+        typer.Option(help="Machine-readable export format."),
+    ] = ExportFormatOption.sarif,
+) -> None:
+    """Render a machine-readable CI export from a results file."""
+    try:
+        export_result = export_results_from_paths(
+            results,
+            baseline_path=baseline,
+            suppressions_path=suppressions,
+            format=format.value,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    rendered = json.dumps(export_result.content, indent=2)
+    if out is None:
+        typer.echo(rendered)
+        return
+
+    out.write_text(rendered + "\n", encoding="utf-8")
+    _print_suppression_summary(export_result.suppressions_path, export_result.suppressions)
+    console.print(f"Wrote {format.value} export to [bold]{out}[/bold].")
 
 
 @app.command()

--- a/src/knives_out/exporting.py
+++ b/src/knives_out/exporting.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import Any
+
+from knives_out import __version__
+from knives_out.models import AttackResults, ProfileAttackResult, WorkflowStepResult
+from knives_out.reporting import _protocol_label, _schema_summary, summarize_results
+from knives_out.suppressions import SuppressionRule
+from knives_out.verification import (
+    ComparedFinding,
+    compare_attack_results,
+    compared_finding_sort_key,
+)
+
+_SARIF_SCHEMA_URL = "https://json.schemastore.org/sarif-2.1.0.json"
+
+
+def _sarif_level(severity: str) -> str:
+    if severity in {"critical", "high"}:
+        return "error"
+    if severity == "medium":
+        return "warning"
+    return "note"
+
+
+def _issue_name(issue: str | None) -> str:
+    return issue or "flagged_finding"
+
+
+def _sarif_rule_id(issue: str | None) -> str:
+    return f"knives-out/{_issue_name(issue)}"
+
+
+def _issue_label(issue: str | None) -> str:
+    return _issue_name(issue).replace("_", " ").capitalize()
+
+
+def _workflow_step_properties(step: WorkflowStepResult) -> dict[str, Any]:
+    return {
+        "name": step.name,
+        "operation_id": step.operation_id,
+        "method": step.method,
+        "url": step.url,
+        "status_code": step.status_code,
+        "error": step.error,
+        "duration_ms": step.duration_ms,
+        "response_excerpt": step.response_excerpt,
+    }
+
+
+def _profile_result_properties(result: ProfileAttackResult) -> dict[str, Any]:
+    return {
+        "profile": result.profile,
+        "protocol": _protocol_label(result.protocol),
+        "level": result.level,
+        "anonymous": result.anonymous,
+        "url": result.url,
+        "status_code": result.status_code,
+        "error": result.error,
+        "issue": result.issue,
+        "severity": result.severity,
+        "confidence": result.confidence,
+        "schema_status": _schema_summary(result),
+        "workflow_step_count": len(result.workflow_steps or []),
+    }
+
+
+def _message_text(finding: ComparedFinding | Any, *, baseline_used: bool) -> str:
+    result = finding.result if isinstance(finding, ComparedFinding) else finding
+    target = f"{result.method} {result.path}" if result.path else result.url
+    status = f"status {result.status_code}" if result.status_code is not None else "no status"
+    prefix = ""
+    if baseline_used and isinstance(finding, ComparedFinding):
+        prefix = f"[{finding.change}] "
+    return f"{prefix}{result.name}: {_issue_label(result.issue)} on {target} ({status})."
+
+
+def _finding_properties(finding: ComparedFinding | Any, *, baseline_used: bool) -> dict[str, Any]:
+    result = finding.result if isinstance(finding, ComparedFinding) else finding
+    properties: dict[str, Any] = {
+        "attack_id": result.attack_id,
+        "name": result.name,
+        "type": result.type,
+        "protocol": _protocol_label(result.protocol),
+        "kind": result.kind,
+        "method": result.method,
+        "path": result.path,
+        "tags": list(result.tags),
+        "url": result.url,
+        "status_code": result.status_code,
+        "severity": result.severity,
+        "confidence": result.confidence,
+        "issue": result.issue,
+        "schema_status": _schema_summary(result),
+        "duration_ms": result.duration_ms,
+        "error": result.error,
+        "response_excerpt": result.response_excerpt,
+    }
+    if result.response_schema_status is not None:
+        properties["response_schema_status"] = result.response_schema_status
+    if result.response_schema_valid is not None:
+        properties["response_schema_valid"] = result.response_schema_valid
+    if result.response_schema_error is not None:
+        properties["response_schema_error"] = result.response_schema_error
+    if result.graphql_response_valid is not None:
+        properties["graphql_response_valid"] = result.graphql_response_valid
+    if result.graphql_response_error is not None:
+        properties["graphql_response_error"] = result.graphql_response_error
+    if result.graphql_response_hint is not None:
+        properties["graphql_response_hint"] = result.graphql_response_hint
+    if result.workflow_steps:
+        properties["workflow_step_count"] = len(result.workflow_steps)
+        properties["workflow_steps"] = [
+            _workflow_step_properties(step) for step in result.workflow_steps
+        ]
+    if result.profile_results:
+        properties["profile_result_count"] = len(result.profile_results)
+        properties["profile_results"] = [
+            _profile_result_properties(profile_result) for profile_result in result.profile_results
+        ]
+    if baseline_used and isinstance(finding, ComparedFinding):
+        properties["change"] = finding.change
+        if finding.delta is not None and finding.delta.changed:
+            properties["delta_changes"] = [
+                {
+                    "field": change.field,
+                    "baseline": change.baseline,
+                    "current": change.current,
+                }
+                for change in finding.delta.changes
+            ]
+    return properties
+
+
+def _rule_payload(issue: str | None) -> dict[str, Any]:
+    issue_name = _issue_name(issue)
+    return {
+        "id": _sarif_rule_id(issue),
+        "name": issue_name,
+        "shortDescription": {"text": _issue_label(issue)},
+        "fullDescription": {"text": f"knives-out finding class `{issue_name}`."},
+        "properties": {"issue": issue_name},
+    }
+
+
+def render_sarif_export(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+) -> dict[str, Any]:
+    comparison = compare_attack_results(results, baseline, suppressions=suppressions)
+    summary = summarize_results(results, baseline=baseline, suppressions=suppressions, top_limit=0)
+    exported_findings: list[ComparedFinding | Any]
+    if baseline is None:
+        exported_findings = comparison.current_findings
+    else:
+        exported_findings = sorted(
+            [*comparison.new_findings, *comparison.persisting_findings],
+            key=compared_finding_sort_key,
+        )
+
+    exported_issues = sorted(
+        {
+            _issue_name(
+                finding.result.issue if isinstance(finding, ComparedFinding) else finding.issue
+            )
+            for finding in exported_findings
+        }
+    )
+    rules = [_rule_payload(issue) for issue in exported_issues]
+    sarif_results: list[dict[str, Any]] = []
+    baseline_used = baseline is not None
+    for finding in exported_findings:
+        result = finding.result if isinstance(finding, ComparedFinding) else finding
+        issue = result.issue
+        sarif_results.append(
+            {
+                "ruleId": _sarif_rule_id(issue),
+                "level": _sarif_level(result.severity),
+                "message": {"text": _message_text(finding, baseline_used=baseline_used)},
+                "partialFingerprints": {
+                    "attackIssue": f"{result.attack_id}:{_issue_name(issue)}",
+                },
+                "properties": _finding_properties(finding, baseline_used=baseline_used),
+            }
+        )
+
+    return {
+        "$schema": _SARIF_SCHEMA_URL,
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "knives-out",
+                        "version": __version__,
+                        "informationUri": "https://github.com/keithwegner/knives-out",
+                        "rules": rules,
+                    }
+                },
+                "properties": summary.model_dump(
+                    mode="json",
+                    exclude_none=True,
+                    exclude={"top_findings"},
+                ),
+                "results": sarif_results,
+            }
+        ],
+    }

--- a/src/knives_out/services.py
+++ b/src/knives_out/services.py
@@ -17,6 +17,7 @@ from knives_out.auth_config import (
     select_auth_configs,
 )
 from knives_out.auth_plugins import LoadedAuthPlugin, load_auth_plugins
+from knives_out.exporting import render_sarif_export
 from knives_out.filtering import filter_attack_suite, filter_operations
 from knives_out.generator import generate_attack_suite
 from knives_out.learned_discovery import discover_learned_model
@@ -98,6 +99,13 @@ class VerifyServiceResult:
 @dataclass(frozen=True)
 class SummaryServiceResult:
     summary: ResultsSummary
+    suppressions_path: Path | None
+    suppressions: list[SuppressionRule]
+
+
+@dataclass(frozen=True)
+class ExportServiceResult:
+    content: dict[str, Any]
     suppressions_path: Path | None
     suppressions: list[SuppressionRule]
 
@@ -677,6 +685,63 @@ def summarize_results_from_models(
         baseline=baseline,
         suppressions=suppression_rules,
         top_limit=top_limit,
+    )
+
+
+def export_results(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions: list[SuppressionRule] | None = None,
+    format: str = "sarif",
+) -> dict[str, Any]:
+    if format == "sarif":
+        return render_sarif_export(
+            results,
+            baseline=baseline,
+            suppressions=suppressions,
+        )
+    raise ValueError(f"Unsupported export format: {format!r}")
+
+
+def export_results_from_paths(
+    results_path: Path,
+    *,
+    baseline_path: Path | None = None,
+    suppressions_path: Path | None = None,
+    format: str = "sarif",
+) -> ExportServiceResult:
+    attack_results = load_attack_results_or_raise(results_path, label="current")
+    baseline_results = (
+        load_attack_results_or_raise(baseline_path, label="baseline")
+        if baseline_path is not None
+        else None
+    )
+    resolved_suppressions_path, suppression_rules = load_suppressions_or_default(suppressions_path)
+    return ExportServiceResult(
+        content=export_results(
+            attack_results,
+            baseline=baseline_results,
+            suppressions=suppression_rules,
+            format=format,
+        ),
+        suppressions_path=resolved_suppressions_path,
+        suppressions=suppression_rules,
+    )
+
+
+def export_results_from_models(
+    results: AttackResults,
+    *,
+    baseline: AttackResults | None = None,
+    suppressions_yaml: str | None = None,
+    format: str = "sarif",
+) -> dict[str, Any]:
+    return export_results(
+        results,
+        baseline=baseline,
+        suppressions=_load_suppressions_from_text(suppressions_yaml),
+        format=format,
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1132,6 +1132,19 @@ def test_report_verify_promote_and_triage_endpoints(tmp_path) -> None:
     results = _flagged_results()
     suite = _attack_suite()
 
+    export_response = client.post(
+        "/v1/export",
+        json={
+            "results": results.model_dump(mode="json"),
+            "format": "sarif",
+        },
+    )
+    assert export_response.status_code == 200
+    export_payload = export_response.json()
+    assert export_payload["format"] == "sarif"
+    assert export_payload["content"]["version"] == "2.1.0"
+    assert export_payload["content"]["runs"][0]["results"][0]["ruleId"] == "knives-out/server_error"
+
     summary_response = client.post(
         "/v1/summary",
         json={"results": results.model_dump(mode="json"), "top_limit": 5},
@@ -1218,3 +1231,88 @@ def test_verify_endpoint_reports_delta_changes_and_report_supports_html(tmp_path
     report_payload = report_response.json()
     assert report_payload["format"] == "html"
     assert "<!DOCTYPE html>" in report_payload["content"]
+
+
+def test_export_endpoint_reports_baseline_changes_and_applies_suppressions(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_api",
+                operation_id="getSecret",
+                kind="missing_auth",
+                name="Server failure",
+                method="GET",
+                path="/secrets",
+                url="https://example.com/secrets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="medium",
+            ),
+            AttackResult(
+                attack_id="atk_suppressed",
+                operation_id="listPets",
+                kind="wrong_type_param",
+                name="Suppressed failure",
+                method="GET",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+        ],
+    )
+    baseline = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_api",
+                operation_id="getSecret",
+                kind="missing_auth",
+                name="Server failure",
+                method="GET",
+                path="/secrets",
+                url="https://example.com/secrets",
+                status_code=401,
+                flagged=True,
+                issue="server_error",
+                severity="medium",
+                confidence="high",
+            )
+        ],
+    )
+
+    export_response = client.post(
+        "/v1/export",
+        json={
+            "results": current.model_dump(mode="json"),
+            "baseline": baseline.model_dump(mode="json"),
+            "format": "sarif",
+            "suppressions_yaml": (
+                "suppressions:\n"
+                "  - attack_id: atk_suppressed\n"
+                "    reason: Known issue\n"
+                "    owner: api-team\n"
+            ),
+        },
+    )
+
+    assert export_response.status_code == 200
+    export_payload = export_response.json()
+    sarif_results = export_payload["content"]["runs"][0]["results"]
+    assert len(sarif_results) == 1
+    assert sarif_results[0]["properties"]["attack_id"] == "atk_api"
+    assert sarif_results[0]["properties"]["change"] == "persisting"
+    assert {change["field"] for change in sarif_results[0]["properties"]["delta_changes"]} == {
+        "confidence",
+        "severity",
+        "status",
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -538,6 +538,147 @@ def test_summary_command_prints_json_to_stdout(tmp_path: Path) -> None:
     assert summary["top_findings"][0]["schema_status"] == "graphql-mismatch"
 
 
+def test_export_command_writes_sarif_to_file(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    export_path = tmp_path / "results.sarif"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_server",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Server failure",
+                method="POST",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            str(results_path),
+            "--format",
+            "sarif",
+            "--out",
+            str(export_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    export_payload = json.loads(export_path.read_text(encoding="utf-8"))
+    assert export_payload["version"] == "2.1.0"
+    assert export_payload["runs"][0]["results"][0]["ruleId"] == "knives-out/server_error"
+
+
+def test_export_command_prints_sarif_with_baseline_changes_to_stdout(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_results(
+        current_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Persisting failure",
+                method="POST",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="critical",
+                confidence="medium",
+            )
+        ),
+    )
+    _write_results(
+        baseline_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_shared",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Persisting failure",
+                method="POST",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=401,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            str(current_path),
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    export_payload = json.loads(result.stdout)
+    sarif_result = export_payload["runs"][0]["results"][0]
+    assert sarif_result["properties"]["change"] == "persisting"
+    assert {change["field"] for change in sarif_result["properties"]["delta_changes"]} == {
+        "confidence",
+        "severity",
+        "status",
+    }
+
+
+def test_export_command_auto_loads_suppressions_and_excludes_suppressed_findings() -> None:
+    with runner.isolated_filesystem():
+        results_path = Path("results.json")
+        _write_results(
+            results_path,
+            _results_with_findings(
+                AttackResult(
+                    attack_id="atk_suppressed",
+                    operation_id="createPet",
+                    kind="missing_request_body",
+                    name="Suppressed failure",
+                    method="POST",
+                    path="/pets",
+                    url="https://example.com/pets",
+                    status_code=500,
+                    flagged=True,
+                    issue="server_error",
+                    severity="high",
+                    confidence="high",
+                )
+            ),
+        )
+        Path(".knives-out-ignore.yml").write_text(
+            "suppressions:\n"
+            "  - attack_id: atk_suppressed\n"
+            "    reason: Known issue\n"
+            "    owner: api-team\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["export", str(results_path)])
+
+        assert result.exit_code == 0
+        export_payload = json.loads(result.stdout)
+        assert export_payload["runs"][0]["results"] == []
+
+
 def test_report_command_supports_html_and_artifact_links(tmp_path: Path) -> None:
     results_path = tmp_path / "results.json"
     report_path = tmp_path / "report.html"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -24,6 +24,7 @@ def test_readme_includes_ci_guidance() -> None:
     assert "KNIVES_OUT_BASE_URL" in readme
     assert "`knives-out run` currently exits with status `0`" in readme
     assert "knives-out verify results.json" in readme
+    assert "knives-out export results.json --format sarif --out results.sarif" in readme
     assert "status, severity, confidence, or schema outcome drifted" in readme
     assert "knives-out promote results.json" in readme
     assert "knives-out triage results.json" in readme
@@ -35,6 +36,7 @@ def test_readme_includes_ci_guidance() -> None:
     assert "KNIVES_OUT_API_DATA_DIR" in readme
     assert "POST /v1/inspect" in readme
     assert "POST /v1/summary" in readme
+    assert "POST /v1/export" in readme
     assert "POST /v1/runs" in readme
     assert "DELETE /v1/jobs/{id}" in readme
     assert "POST /v1/jobs/prune" in readme
@@ -101,6 +103,9 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert "--profile anonymous" in workflow
     assert 'knives-out run attacks.json "${args[@]}"' in workflow
     assert "knives-out report results.json --out report.md" in workflow
+    assert "knives-out export results.json --format sarif --out results.sarif" in workflow
+    assert "github/codeql-action/upload-sarif@v4" in workflow
+    assert "sarif_file: results.sarif" in workflow
     assert (
         "knives-out report results.json --format html --artifact-root artifacts --out report.html"
         in workflow
@@ -111,6 +116,8 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     assert ".knives-out-ignore.yml" in workflow
     assert "knives-out promote results.json" in workflow
     assert "KNIVES_OUT_BASE_URL" in workflow
+    assert "security-events: write" in workflow
+    assert "results.sarif" in workflow
 
 
 def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
@@ -119,6 +126,7 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "results.json" in ci_doc
     assert "report.md" in ci_doc
     assert "report.html" in ci_doc
+    assert "results.sarif" in ci_doc
     assert "artifacts/" in ci_doc
     assert "Simple gating with no baseline" in ci_doc
     assert "Baseline-aware gating" in ci_doc
@@ -151,12 +159,15 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "knives-out serve --host 127.0.0.1 --port 8787" in ci_doc
     assert "POST /v1/inspect" in ci_doc
     assert "POST /v1/summary" in ci_doc
+    assert "POST /v1/export" in ci_doc
     assert "POST /v1/runs" in ci_doc
     assert "DELETE /v1/jobs/{id}" in ci_doc
     assert "POST /v1/jobs/prune" in ci_doc
     assert "GET /v1/jobs/{id}/findings/{attack_id}/evidence" in ci_doc
     assert "KNIVES_OUT_API_DATA_DIR" in ci_doc
     assert "knives-out summary results.json --out summary.json" in ci_doc
+    assert "knives-out export results.json --format sarif --out results.sarif" in ci_doc
+    assert "github/codeql-action/upload-sarif@v4" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
     assert "--tag orders" in ci_doc
     assert "--path /draft-orders/{draftId}" in ci_doc

--- a/tests/test_exporting.py
+++ b/tests/test_exporting.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from knives_out.exporting import render_sarif_export
+from knives_out.models import (
+    AttackResult,
+    AttackResults,
+    ProfileAttackResult,
+    WorkflowStepResult,
+)
+
+
+def test_render_sarif_export_emits_rest_metadata_without_fake_locations() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_rest",
+                operation_id="createPet",
+                kind="wrong_type_param",
+                name="REST schema mismatch",
+                method="POST",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=200,
+                flagged=True,
+                issue="response_schema_mismatch",
+                severity="medium",
+                confidence="high",
+                response_schema_valid=False,
+                response_schema_error="$.id: expected integer, got string",
+                workflow_steps=[
+                    WorkflowStepResult(
+                        name="Create cart",
+                        operation_id="createCart",
+                        method="POST",
+                        url="https://example.com/cart",
+                        status_code=201,
+                    )
+                ],
+                profile_results=[
+                    ProfileAttackResult(
+                        profile="anonymous",
+                        anonymous=True,
+                        url="https://example.com/pets",
+                        status_code=403,
+                        flagged=True,
+                        issue="anonymous_access",
+                        severity="high",
+                        confidence="medium",
+                    )
+                ],
+            )
+        ],
+    )
+
+    sarif = render_sarif_export(results)
+
+    assert sarif["version"] == "2.1.0"
+    run = sarif["runs"][0]
+    assert run["tool"]["driver"]["name"] == "knives-out"
+    assert run["tool"]["driver"]["rules"][0]["id"] == "knives-out/response_schema_mismatch"
+    result = run["results"][0]
+    assert result["level"] == "warning"
+    assert "locations" not in result
+    assert result["properties"]["protocol"] == "rest"
+    assert result["properties"]["schema_status"] == "mismatch"
+    assert result["properties"]["response_schema_error"] == "$.id: expected integer, got string"
+    assert result["properties"]["workflow_steps"][0]["name"] == "Create cart"
+    assert result["properties"]["profile_results"][0]["profile"] == "anonymous"
+
+
+def test_render_sarif_export_includes_graphql_metadata() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_graphql",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="GraphQL shape mismatch",
+                protocol="graphql",
+                method="POST",
+                path="/graphql",
+                url="https://example.com/graphql",
+                status_code=200,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="high",
+                confidence="high",
+                graphql_response_valid=False,
+                graphql_response_error="$.data.book.title: expected String, got integer",
+                graphql_response_hint="Schema appears federated.",
+            )
+        ],
+    )
+
+    sarif = render_sarif_export(results)
+
+    result = sarif["runs"][0]["results"][0]
+    assert result["ruleId"] == "knives-out/graphql_response_shape_mismatch"
+    assert result["level"] == "error"
+    assert result["properties"]["protocol"] == "graphql"
+    assert result["properties"]["schema_status"] == "graphql-mismatch"
+    assert (
+        result["properties"]["graphql_response_error"]
+        == "$.data.book.title: expected String, got integer"
+    )
+    assert result["properties"]["graphql_response_hint"] == "Schema appears federated."
+
+
+def test_render_sarif_export_includes_baseline_change_metadata_for_active_findings() -> None:
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_persisting",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Persisting failure",
+                method="POST",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="critical",
+                confidence="medium",
+                response_schema_valid=False,
+            ),
+            AttackResult(
+                attack_id="atk_new",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="New GraphQL issue",
+                protocol="graphql",
+                method="POST",
+                path="/graphql",
+                url="https://example.com/graphql",
+                status_code=200,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="high",
+                confidence="high",
+                graphql_response_valid=False,
+            ),
+        ],
+    )
+    baseline = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_persisting",
+                operation_id="createPet",
+                kind="missing_request_body",
+                name="Persisting failure",
+                method="POST",
+                path="/pets",
+                url="https://example.com/pets",
+                status_code=401,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+                response_schema_valid=True,
+            ),
+            AttackResult(
+                attack_id="atk_resolved",
+                operation_id="deletePet",
+                kind="missing_auth",
+                name="Resolved issue",
+                method="DELETE",
+                path="/pets/1",
+                url="https://example.com/pets/1",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            ),
+        ],
+    )
+
+    sarif = render_sarif_export(current, baseline=baseline)
+
+    exported = {result["properties"]["attack_id"]: result for result in sarif["runs"][0]["results"]}
+    assert set(exported) == {"atk_new", "atk_persisting"}
+    assert exported["atk_new"]["properties"]["change"] == "new"
+    assert exported["atk_persisting"]["properties"]["change"] == "persisting"
+    assert {
+        change["field"] for change in exported["atk_persisting"]["properties"]["delta_changes"]
+    } == {"confidence", "schema", "severity", "status"}


### PR DESCRIPTION
## Summary
- add a dedicated `knives-out export` surface and `POST /v1/export` API parity for SARIF 2.1.0 output
- export active unsuppressed findings with optional baseline change metadata on top of the existing comparison and summary model
- document and demonstrate GitHub Actions SARIF upload in the README, CI guide, and example workflow

## Testing
- `.venv312/bin/python -m pytest -q`
- `.venv312/bin/python -m ruff check src/knives_out/exporting.py src/knives_out/services.py src/knives_out/api_models.py src/knives_out/api.py src/knives_out/cli.py tests/test_exporting.py tests/test_cli.py tests/test_api.py tests/test_docs.py`
- `.venv312/bin/python -m ruff format --check src/knives_out/exporting.py src/knives_out/services.py src/knives_out/api_models.py src/knives_out/api.py src/knives_out/cli.py tests/test_exporting.py tests/test_cli.py tests/test_api.py tests/test_docs.py`
- `python3.12 -m compileall src tests`

Closes #87