### PR TITLE
[codex] Add README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ Project wiki: [GitHub Wiki](https://github.com/keithwegner/knives-out/wiki)
 
 It helps developers break their APIs on purpose before someone else does.
 
+## Table of contents
+
+- [What it does](#what-it-does)
+- [Current attack types](#current-attack-types)
+- [Why this shape](#why-this-shape)
+- [Quick start](#quick-start)
+- [Web workbench](#web-workbench)
+  - [GitHub Pages](#github-pages)
+- [Local API](#local-api)
+- [CI usage](#ci-usage)
+- [CLI](#cli)
+  - [`inspect`](#inspect)
+  - [`generate`](#generate)
+  - [`run`](#run)
+  - [`report`](#report)
+  - [`export`](#export)
+  - [`verify`](#verify)
+  - [`promote`](#promote)
+  - [`triage`](#triage)
+- [Development](#development)
+  - [Dev Container](#dev-container)
+- [Custom attack packs](#custom-attack-packs)
+- [Custom workflow packs](#custom-workflow-packs)
+- [Built-in auth configs](#built-in-auth-configs)
+- [Auth/session plugins](#authsession-plugins)
+- [Roadmap](#roadmap)
+
 ## What it does
 
 Given an OpenAPI spec, GraphQL schema, or learned traffic model, `knives-out` can:


### PR DESCRIPTION
## Summary
- add a top-level table of contents to the README
- link the main product, workflow, and CLI sections for easier navigation

## Validation
- README content checked locally
- `python3.12 -m pytest -q tests/test_docs.py` could not run in this environment because `pytest` is not installed for the active Python 3.12 interpreter
