### PR TITLE
[codex] Configure Dependabot and frontend CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,28 @@
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: pip
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:15"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,22 @@ jobs:
           ruff format --check .
       - name: Pytest
         run: pytest --cov=src/knives_out --cov-report=term-missing
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+      - name: Test frontend
+        working-directory: frontend
+        run: npm test -- --run

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -774,6 +774,10 @@ describe("ProjectWorkbenchPage", () => {
   it("loads and clears a saved run baseline from the review workspace", async () => {
     let projectState = structuredClone(baseProjectPayload);
     projectState.artifacts.last_run_job_id = "job-current";
+    const latestVerification = projectState.artifacts.latest_verification;
+    if (!latestVerification) {
+      throw new Error("Expected latest verification fixture to be present");
+    }
 
     const baselineResults = {
       source: "unit",
@@ -785,20 +789,20 @@ describe("ProjectWorkbenchPage", () => {
     };
 
     const comparisonVerification = {
-      ...projectState.artifacts.latest_verification,
+      ...latestVerification,
       baseline_used: true,
       new_findings_count: 1,
       resolved_findings_count: 1,
       persisting_findings_count: 1,
       current_findings: [
-        projectState.artifacts.latest_verification.current_findings[0],
+        latestVerification.current_findings[0],
         {
-          ...projectState.artifacts.latest_verification.current_findings[1],
+          ...latestVerification.current_findings[1],
           change: "persisting",
           delta_changes: [{ field: "status", baseline: "500", current: "200" }],
         },
       ],
-      new_findings: [projectState.artifacts.latest_verification.current_findings[0]],
+      new_findings: [latestVerification.current_findings[0]],
       resolved_findings: [
         {
           change: "resolved",
@@ -819,7 +823,7 @@ describe("ProjectWorkbenchPage", () => {
       ],
       persisting_findings: [
         {
-          ...projectState.artifacts.latest_verification.current_findings[1],
+          ...latestVerification.current_findings[1],
           change: "persisting",
           delta_changes: [{ field: "status", baseline: "500", current: "200" }],
         },


### PR DESCRIPTION
## Summary
- configure Dependabot for the repo's real dependency ecosystems: `pip`, frontend `npm`, and `github-actions`
- extend CI with a dedicated frontend job while preserving the existing `test` backend job for branch protection compatibility
- fix the existing strict TypeScript nullability error in `ProjectWorkbenchPage.test.tsx` so the new frontend build check passes

Closes #90.

## Validation
- `npm ci`
- `npm run build`
- `npm test -- --run`
