### PR TITLE
[codex] Add GitHub community standards baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a defect, regression, or broken workflow in knives-out.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+        Please include enough detail for someone else to reproduce the problem.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A short description of the bug.
+      placeholder: HTML artifact preview fails to open raw response links
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Which part of the project is impacted?
+      options:
+        - CLI
+        - Local API
+        - Web workbench
+        - CI / GitHub Actions
+        - OpenAPI flow
+        - GraphQL flow
+        - Traffic capture / discovery
+        - Documentation / examples
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: What happened?
+      placeholder: Describe the failure, error output, or incorrect result.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction details
+      description: Share the steps, command, API call, or fixture needed to reproduce the issue.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include relevant versions, OS, browser, Python, Node, or deployment context.
+      placeholder: |
+        - OS:
+        - Python:
+        - Node:
+        - knives-out version / commit:
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Logs, screenshots, or artifacts
+      description: Optional. Paste any useful output, screenshots, SARIF excerpts, or report snippets.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question or get help
+    url: https://github.com/keithwegner/knives-out/discussions
+    about: Use GitHub Discussions for setup help, usage questions, and early design conversations.
+  - name: Report a security vulnerability
+    url: https://github.com/keithwegner/knives-out/security/policy
+    about: Please review the security policy and avoid filing public issues for vulnerabilities.

--- a/.github/ISSUE_TEMPLATE/docs_community.yml
+++ b/.github/ISSUE_TEMPLATE/docs_community.yml
@@ -1,0 +1,46 @@
+name: Docs or community improvement
+description: Suggest a documentation, onboarding, or contributor-process improvement.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for documentation gaps, onboarding pain points, and community-process improvements.
+  - type: textarea
+    id: gap
+    attributes:
+      label: Gap or friction
+      description: What is unclear, missing, or hard to navigate today?
+      placeholder: The review-bundle import flow is documented in README but not easy to find from CI docs.
+    validations:
+      required: true
+  - type: input
+    id: audience
+    attributes:
+      label: Intended audience
+      description: Who is affected by this gap?
+      placeholder: New contributors, CI maintainers, workbench users, API consumers
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_change
+    attributes:
+      label: Proposed change
+      description: What would improve the experience?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected docs or process area
+      options:
+        - README / landing docs
+        - CI docs / examples
+        - Contributor workflow
+        - Issue / PR process
+        - GitHub Discussions / community health
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Propose a new capability or improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the problem you are trying to solve before jumping to a solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user or workflow problem is this addressing?
+      placeholder: Teams need a portable way to review findings from CI in the local workbench.
+    validations:
+      required: true
+  - type: textarea
+    id: desired_outcome
+    attributes:
+      label: Desired outcome
+      description: What should the project be able to do after this change?
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: Who needs this and how would they use it?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Note other approaches or workarounds you have considered.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Which part of the project is most relevant?
+      options:
+        - CLI
+        - Local API
+        - Web workbench
+        - CI / GitHub Actions
+        - OpenAPI flow
+        - GraphQL flow
+        - Traffic capture / discovery
+        - Reporting / verification
+        - Documentation / examples
+        - Other
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+- Describe the change and the user or developer impact.
+
+## Linked issues
+
+- Closes #
+- Related to #
+
+## Validation
+
+- [ ] `pytest`
+- [ ] `ruff check .`
+- [ ] `ruff format --check .`
+- [ ] `cd frontend && npm test -- --run`
+- [ ] `cd frontend && npm run build`
+- [ ] Not run, with reason:
+
+## Evidence
+
+- Screenshots, GIFs, or CLI excerpts when relevant.
+
+## Checklist
+
+- [ ] Tests were added or updated when behavior changed.
+- [ ] Docs or examples were updated when the workflow changed.
+- [ ] Breaking changes are called out explicitly below.
+
+## Breaking changes
+
+- None.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the
+`knives-out` community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for this
+community include:
+
+- demonstrating empathy and kindness toward other people
+- being respectful of differing opinions, viewpoints, and experiences
+- giving and gracefully accepting constructive feedback
+- accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- the use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- trolling, insulting or derogatory comments, and personal or political attacks
+- public or private harassment
+- publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+`TODO: replace-with-private-conduct-report-email@example.com`.
+
+Replace that placeholder with a private maintainer contact before merging this
+file. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to knives-out
+
+Thanks for contributing to `knives-out`.
+
+This project is intentionally practical: small focused changes, reproducible
+validation, and clear GitHub history are preferred over broad speculative
+refactors.
+
+## Before you open a pull request
+
+- Open or link an issue first for net-new features, behavior changes, or larger
+  refactors.
+- Use [GitHub Discussions](https://github.com/keithwegner/knives-out/discussions)
+  for usage questions, setup help, or early design conversation.
+- Use [`SECURITY.md`](SECURITY.md) instead of a public issue for vulnerability
+  reports.
+
+If you want to send a small typo fix or other narrow docs correction directly as
+a pull request, that is fine.
+
+## Development setup
+
+Create a Python environment and install the project with development
+dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+The frontend lives in [`frontend/`](frontend):
+
+```bash
+cd frontend
+npm ci
+```
+
+## Validation
+
+Run the checks that match the surface you changed.
+
+Backend / docs:
+
+```bash
+pytest
+ruff check .
+ruff format --check .
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm test -- --run
+npm run build
+```
+
+If your change touches both Python and frontend code, run both sets.
+
+## Pull request expectations
+
+- Keep PRs scoped to one coherent change.
+- Link the relevant issue in the PR description.
+- Update docs, examples, or screenshots when the user-facing workflow changes.
+- Add or update tests when behavior changes.
+- Note any follow-up work explicitly instead of leaving it implicit in review.
+
+For workbench or other UI changes, include screenshots or a short video/GIF in
+the pull request so reviewers can verify the intended experience quickly.
+
+## Style and workflow
+
+- Prefer clear names and predictable behavior over clever abstractions.
+- Match the established repo structure and conventions instead of introducing a
+  new pattern unless the change clearly justifies it.
+- Keep commits intentional and reviewable.
+- Do not mix unrelated cleanup into feature PRs.
+
+## Issue intake
+
+The repository uses GitHub Issue Forms for bugs, feature requests, and
+documentation or community process improvements.
+
+Questions belong in
+[GitHub Discussions](https://github.com/keithwegner/knives-out/discussions)
+instead of Issues so bug and feature tracking stays focused.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 Project wiki: [GitHub Wiki](https://github.com/keithwegner/knives-out/wiki)
 
+Community: [Code of Conduct](CODE_OF_CONDUCT.md) · [Contributing](CONTRIBUTING.md) ·
+[Security Policy](SECURITY.md) ·
+[Discussions](https://github.com/keithwegner/knives-out/discussions)
+
 `knives-out` is a CLI for adversarial API testing from API specs and observed traffic.
 
 It helps developers break their APIs on purpose before someone else does.


### PR DESCRIPTION
## Summary
- add a Contributor Covenant-based `CODE_OF_CONDUCT.md` with an explicit private-contact placeholder
- add `CONTRIBUTING.md` aligned with the repo's Python and frontend workflow
- add GitHub Issue Forms, issue config, and a lightweight repo-wide PR template
- add a community entrypoint near the top of `README.md`

## Why
This closes the GitHub Community Standards gap for code of conduct, contributing guidance, issue templates, and pull request templating.

Closes #104.

## Validation
- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml", ".github/ISSUE_TEMPLATE/*.yaml"].sort.each { |path| YAML.load_file(path); puts "OK #{path}" }'`
- `python3 -m pytest -q tests/test_docs.py`

## Merge note
- Replace the placeholder conduct-report email in `CODE_OF_CONDUCT.md` with a real private maintainer contact before merge.
