### PR TITLE
Redesign guided workbench UI

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -17,6 +17,7 @@ import type {
   ProjectReviewResponse,
   ProjectRecord,
   ProjectReviewDraft,
+  ProjectSourceMode,
   PromoteResponse,
   ReportResponse,
   ResultsSummary,
@@ -122,10 +123,18 @@ export function listProjects() {
   return request<ProjectListResponse>("/v1/projects");
 }
 
-export function createProject(name: string) {
+export function createProject(
+  input:
+    | string
+    | {
+        name: string;
+        source_mode?: ProjectSourceMode;
+      },
+) {
+  const payload = typeof input === "string" ? { name: input } : input;
   return request<ProjectRecord>("/v1/projects", {
     method: "POST",
-    body: JSON.stringify({ name }),
+    body: JSON.stringify(payload),
   });
 }
 

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "./HomePage";
@@ -66,8 +66,111 @@ describe("HomePage", () => {
     expect(await screen.findByText("Storefront triage")).toBeInTheDocument();
     expect(screen.getByText("connected")).toBeInTheDocument();
     expect(screen.getByText("storefront.yaml")).toBeInTheDocument();
-    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getByText("Resume at")).toBeInTheDocument();
+    expect(screen.getByText("review")).toBeInTheDocument();
+    expect(screen.getByText("Latest run")).toBeInTheDocument();
+    expect(screen.getAllByText("completed").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Findings")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText(/2 saved runs/)).toBeInTheDocument();
     expect(screen.getByText("Open")).toBeInTheDocument();
+  });
+
+  it("creates a project with the selected source mode", async () => {
+    let createBody: unknown = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.endsWith("/healthz")) {
+          return Response.json({ status: "ok" });
+        }
+        if (url.endsWith("/v1/projects") && method === "GET") {
+          return Response.json({ projects: [] });
+        }
+        if (url.endsWith("/v1/projects") && method === "POST") {
+          createBody = JSON.parse(String(init?.body ?? "{}"));
+          return Response.json({
+            id: "project-new",
+            name: "GraphQL review",
+            source_mode: "graphql",
+            active_step: "source",
+            created_at: "2026-04-13T20:00:00Z",
+            updated_at: "2026-04-13T20:00:00Z",
+            graphql_endpoint: "/graphql",
+            source: null,
+            discover_inputs: [],
+            inspect_draft: { tag: [], exclude_tag: [], path: [], exclude_path: [] },
+            generate_draft: {
+              operation: [],
+              exclude_operation: [],
+              method: [],
+              exclude_method: [],
+              kind: [],
+              exclude_kind: [],
+              tag: [],
+              exclude_tag: [],
+              path: [],
+              exclude_path: [],
+              pack_names: [],
+              auto_workflows: false,
+              workflow_pack_names: [],
+            },
+            run_draft: {
+              base_url: "",
+              headers: {},
+              query: {},
+              timeout: 10,
+              store_artifacts: true,
+              auth_plugin_names: [],
+              auth_config_yaml: null,
+              auth_profile_names: [],
+              profile_file_yaml: null,
+              profile_names: [],
+              operation: [],
+              exclude_operation: [],
+              method: [],
+              exclude_method: [],
+              kind: [],
+              exclude_kind: [],
+              tag: [],
+              exclude_tag: [],
+              path: [],
+              exclude_path: [],
+            },
+            review_draft: {
+              baseline_mode: "job",
+              baseline_job_id: null,
+              baseline: null,
+              suppressions_yaml: null,
+              min_severity: "high",
+              min_confidence: "medium",
+            },
+            artifacts: {},
+          });
+        }
+        throw new Error(`Unhandled fetch for ${method} ${url}`);
+      }),
+    );
+
+    renderHomePage();
+
+    await screen.findByText("No saved projects yet.");
+    expect(screen.getByRole("radio", { name: /OpenAPI/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /GraphQL/ }));
+    fireEvent.change(screen.getByLabelText("New project"), {
+      target: { value: "GraphQL review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Open workbench" }));
+
+    await waitFor(() =>
+      expect(createBody).toEqual({ name: "GraphQL review", source_mode: "graphql" }),
+    );
   });
 
   it("duplicates a saved project from the dashboard", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,11 +10,32 @@ import {
 } from "../api";
 import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
 import ApiConnectionPanel from "../components/ApiConnectionPanel";
+import type { ProjectSourceMode } from "../types";
+
+const SOURCE_MODE_OPTIONS: Array<{ mode: ProjectSourceMode; label: string; description: string }> = [
+  {
+    mode: "openapi",
+    label: "OpenAPI",
+    description: "Start from a REST schema.",
+  },
+  {
+    mode: "graphql",
+    label: "GraphQL",
+    description: "Start from SDL or introspection.",
+  },
+  {
+    mode: "capture_upload",
+    label: "Captured traffic",
+    description: "Infer a learned model from HAR or NDJSON.",
+  },
+];
 
 export default function HomePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [newProjectName, setNewProjectName] = useState("Security workbench");
+  const [newProjectSourceMode, setNewProjectSourceMode] =
+    useState<ProjectSourceMode>("openapi");
   const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
   const requiresApiBase = needsConfiguredApiBase(apiBaseUrl);
 
@@ -112,7 +133,10 @@ export default function HomePage() {
             if (requiresApiBase || !newProjectName.trim()) {
               return;
             }
-            createProjectMutation.mutate(newProjectName.trim());
+            createProjectMutation.mutate({
+              name: newProjectName.trim(),
+              source_mode: newProjectSourceMode,
+            });
           }}
         >
           <label className="field">
@@ -124,6 +148,26 @@ export default function HomePage() {
               placeholder="Name the workbench"
             />
           </label>
+          <div className="field">
+            <span className="field-label">Source type</span>
+            <div className="source-choice-grid" role="radiogroup" aria-label="New project source type">
+              {SOURCE_MODE_OPTIONS.map((option) => (
+                <button
+                  aria-checked={newProjectSourceMode === option.mode}
+                  className={`source-choice-card${
+                    newProjectSourceMode === option.mode ? " source-choice-card-active" : ""
+                  }`}
+                  key={option.mode}
+                  onClick={() => setNewProjectSourceMode(option.mode)}
+                  role="radio"
+                  type="button"
+                >
+                  <strong>{option.label}</strong>
+                  <span>{option.description}</span>
+                </button>
+              ))}
+            </div>
+          </div>
           <button
             className="primary-button"
             type="submit"
@@ -189,7 +233,7 @@ export default function HomePage() {
           {projectListQuery.data?.projects.map((project) => (
             <article className="project-card" key={project.id}>
               <div className="project-card-top">
-                <p className="project-mode">{project.source_mode.replace('_', ' ')}</p>
+                <p className="project-mode">{project.source_mode.replace("_", " ")}</p>
                 <div className={`status-chip status-${project.last_run_status ?? "idle"}`}>
                   {project.last_run_status ?? "draft"}
                 </div>
@@ -200,18 +244,22 @@ export default function HomePage() {
               </Link>
               <dl className="project-metrics">
                 <div>
-                  <dt>Step</dt>
+                  <dt>Resume at</dt>
                   <dd>{project.active_step}</dd>
                 </div>
                 <div>
-                  <dt>Jobs</dt>
-                  <dd>{project.job_count}</dd>
+                  <dt>Latest run</dt>
+                  <dd>{project.last_run_status ?? "draft"}</dd>
                 </div>
                 <div>
                   <dt>Findings</dt>
                   <dd>{project.active_flagged_count ?? "—"}</dd>
                 </div>
               </dl>
+              <p className="project-card-summary">
+                {project.job_count} saved run{project.job_count === 1 ? "" : "s"}
+                {project.last_run_at ? ` • last activity ${new Date(project.last_run_at).toLocaleString()}` : ""}
+              </p>
               <div className="project-card-actions">
                 <Link className="secondary-button" to={`/projects/${project.id}`}>
                   Open

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -523,6 +523,22 @@ function renderWorkbench() {
   );
 }
 
+function getStepButton(stepName: string) {
+  return within(screen.getByRole("navigation", { name: "Workbench steps" })).getByRole("button", {
+    name: new RegExp(stepName, "i"),
+  });
+}
+
+function clickReviewTask(taskName: string | RegExp) {
+  const reviewTasks = screen.getByRole("tablist", { name: "Review task groups" });
+  fireEvent.click(within(reviewTasks).getByRole("tab", { name: taskName }));
+}
+
+function clickFindingsTab(tabName: string | RegExp) {
+  const findingsTabs = screen.getByRole("tablist", { name: "Findings panels" });
+  fireEvent.click(within(findingsTabs).getByRole("tab", { name: tabName }));
+}
+
 describe("ProjectWorkbenchPage", () => {
   beforeEach(() => {
     let projectPayload = clone(baseProjectPayload);
@@ -681,24 +697,43 @@ describe("ProjectWorkbenchPage", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders the fixed step rail and disables runs without a generated suite", async () => {
+  it("renders guided step status and keeps one active step panel visible", async () => {
     renderWorkbench();
 
     expect(await screen.findByRole("heading", { name: "Workbench demo" })).toBeInTheDocument();
     const stepRail = screen.getByRole("navigation", { name: "Workbench steps" });
-    for (const stepName of ["source", "inspect", "generate", "run", "review"]) {
+    for (const stepName of ["Source", "Inspect", "Generate", "Run", "Review"]) {
       expect(
         within(stepRail).getByRole("button", { name: new RegExp(stepName, "i") }),
       ).toBeInTheDocument();
     }
-    expect(screen.getByRole("button", { name: "Run suite" })).toBeDisabled();
+    expect(getStepButton("Review")).toHaveAttribute("aria-current", "step");
+    expect(within(stepRail).getByText("Review ready")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Baseline-aware review workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Choose how this project begins" })).not.toBeInTheDocument();
+
+    fireEvent.click(getStepButton("Source"));
+    expect(
+      await screen.findByRole("heading", { name: "Choose how this project begins" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Baseline-aware review workspace" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Inspect the source surface" })).toBeInTheDocument();
+
+    fireEvent.click(getStepButton("Run"));
+    expect(await screen.findByRole("heading", { name: "Execute against a live target" })).toBeInTheDocument();
+    const nextAction = screen.getByRole("region", { name: "Next action" });
+    expect(
+      within(nextAction).getByRole("heading", { name: "Run the suite against a target" }),
+    ).toBeInTheDocument();
+    expect(within(nextAction).getByRole("button", { name: "Run suite" })).toBeDisabled();
+    expect(screen.getByText("Generate an attack suite before running.")).toBeInTheDocument();
   });
 
   it("filters new findings inside the diff-first review tabs", async () => {
     renderWorkbench();
 
     await screen.findByRole("heading", { name: "Workbench demo" });
-    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    clickFindingsTab("New");
 
     const table = screen
       .getAllByRole("table")
@@ -938,18 +973,23 @@ describe("ProjectWorkbenchPage", () => {
     renderWorkbench();
 
     await screen.findByRole("heading", { name: "Workbench demo" });
-    fireEvent.change(screen.getByLabelText("Pinned baseline run"), {
+    clickReviewTask("Policy");
+    expect(
+      await screen.findByText("Set thresholds, baselines, suppressions, and promotion rules."),
+    ).toBeInTheDocument();
+    fireEvent.change(await screen.findByLabelText("Pinned baseline run"), {
       target: { value: "job-1" },
     });
 
     expect(await screen.findByText("Diffs ready")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByLabelText("Pinned baseline run")).toHaveValue("job-1"),
-    );
+    clickReviewTask("Policy");
+    const baselineSelect = await screen.findByLabelText("Pinned baseline run");
+    await waitFor(() => expect(baselineSelect).toHaveValue("job-1"));
 
     fireEvent.click(screen.getByRole("button", { name: "Pin latest run as baseline" }));
 
     expect(await screen.findByText("Waiting for next run")).toBeInTheDocument();
+    clickReviewTask("Policy");
     await waitFor(() =>
       expect(screen.getByLabelText("Pinned baseline run")).toHaveValue("job-2"),
     );
@@ -959,12 +999,24 @@ describe("ProjectWorkbenchPage", () => {
     renderWorkbench();
 
     await screen.findByRole("heading", { name: "Workbench demo" });
+    clickReviewTask("Policy");
+    expect(
+      await screen.findByText("Set thresholds, baselines, suppressions, and promotion rules."),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "External JSON" }));
+    expect(await screen.findByText(/Review workspace switched to external baseline mode/)).toBeInTheDocument();
+    clickReviewTask("Policy");
+    expect(
+      await screen.findByText("Set thresholds, baselines, suppressions, and promotion rules."),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByText("External baseline JSON"));
 
     const editors = screen.getAllByTestId("code-editor");
-    fireEvent.change(editors.at(-1)!, { target: { value: "{" } });
-    const refreshButton = await screen.findByRole("button", { name: /Refresh/ });
+    fireEvent.change(editors.at(0)!, { target: { value: "{" } });
+    const refreshButton = screen.getAllByRole("button", { name: /Refresh/ }).at(0);
+    if (!refreshButton) {
+      throw new Error("Expected the refresh button to render.");
+    }
     fireEvent.click(refreshButton);
 
     expect(
@@ -976,7 +1028,7 @@ describe("ProjectWorkbenchPage", () => {
     renderWorkbench();
 
     await screen.findByRole("heading", { name: "Workbench demo" });
-    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    clickFindingsTab("New");
     fireEvent.click(screen.getByRole("button", { name: "Login failure" }));
 
     expect(await screen.findByText("Current-run evidence")).toBeInTheDocument();
@@ -984,19 +1036,24 @@ describe("ProjectWorkbenchPage", () => {
     expect(await screen.findByText("Create session")).toBeInTheDocument();
     expect((await screen.findAllByText("member-login")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/https:\/\/example.com\/login/)).length).toBeGreaterThan(0);
-    expect(await screen.findByText(/server exploded/)).toBeInTheDocument();
+    expect((await screen.findAllByText(/server exploded/)).length).toBeGreaterThan(0);
   });
 
   it("keeps resolved findings summary-only and reuses the artifact viewer in the artifacts tab", async () => {
     renderWorkbench();
 
     await screen.findByRole("heading", { name: "Workbench demo" });
-    fireEvent.change(screen.getByLabelText("Pinned baseline run"), {
+    clickReviewTask("Policy");
+    expect(
+      await screen.findByText("Set thresholds, baselines, suppressions, and promotion rules."),
+    ).toBeInTheDocument();
+    fireEvent.change(await screen.findByLabelText("Pinned baseline run"), {
       target: { value: "job-1" },
     });
 
     expect(await screen.findByText("Diffs ready")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: "Resolved" }));
+    clickReviewTask("Findings");
+    clickFindingsTab("Resolved");
 
     expect(
       await screen.findByText(
@@ -1005,7 +1062,7 @@ describe("ProjectWorkbenchPage", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Order mismatch" })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Artifacts" }));
+    clickReviewTask("Evidence");
     expect(await screen.findByRole("button", { name: "atk-login.json" })).toBeInTheDocument();
     expect((await screen.findAllByText(/Authorization/)).length).toBeGreaterThan(0);
     expect(await screen.findByText(/server exploded/)).toBeInTheDocument();
@@ -1015,16 +1072,27 @@ describe("ProjectWorkbenchPage", () => {
     renderWorkbench();
 
     await screen.findByRole("heading", { name: "Workbench demo" });
-    fireEvent.change(screen.getByLabelText("Pinned baseline run"), {
+    clickReviewTask("Policy");
+    expect(
+      await screen.findByText("Set thresholds, baselines, suppressions, and promotion rules."),
+    ).toBeInTheDocument();
+    fireEvent.change(await screen.findByLabelText("Pinned baseline run"), {
       target: { value: "job-1" },
     });
     expect(await screen.findByText("Diffs ready")).toBeInTheDocument();
 
+    clickReviewTask("Findings");
     fireEvent.click(screen.getByRole("button", { name: "Login failure" }));
     expect(await screen.findByText("Current-run evidence")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh analysis" }));
+    const refreshButton = screen.getAllByRole("button", { name: "Refresh analysis" }).at(0);
+    if (!refreshButton) {
+      throw new Error("Expected refresh analysis to render.");
+    }
+    fireEvent.click(refreshButton);
 
+    expect(await screen.findByText(/Review workspace refreshed/)).toBeInTheDocument();
+    clickReviewTask("Evidence");
     expect(
       await screen.findByText(
         "Evidence changed with the latest run. Reopen a finding from the refreshed comparison.",
@@ -1065,13 +1133,23 @@ describe("ProjectWorkbenchPage", () => {
         return Response.json({ project_id: "project-1", jobs });
       }
       if (url.endsWith("/v1/projects/project-1/review") && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        const baselineJobId = body.baseline_job_id ?? null;
+        projectState = {
+          ...projectState,
+          review_draft: {
+            ...projectState.review_draft,
+            baseline_job_id: baselineJobId,
+            baseline: body.baseline ?? null,
+          },
+        };
         return Response.json({
           ...createReviewResponse({
-            baselineJobId: projectState.review_draft.baseline_job_id ?? null,
+            baselineJobId,
             waitingForNewRun: false,
-            baselineUsed: projectState.review_draft.baseline_job_id === "job-1",
+            baselineUsed: baselineJobId === "job-1",
           }),
-          baseline_job_id: projectState.review_draft.baseline_job_id,
+          baseline_job_id: baselineJobId,
         });
       }
       if (url.endsWith("/v1/projects/project-1/jobs/job-1") && method === "DELETE") {
@@ -1175,18 +1253,19 @@ describe("ProjectWorkbenchPage", () => {
     renderWorkbench();
 
     await screen.findAllByText("Workbench demo");
-    const reviewPanels = screen.getAllByRole("tablist", { name: "Review panels" }).at(-1);
-    if (!reviewPanels) {
-      throw new Error("Expected the review tab list to render.");
-    }
-    fireEvent.click(within(reviewPanels).getByRole("tab", { name: /Artifacts/ }));
+    clickReviewTask("Runs & Reports");
 
     fireEvent.click(screen.getByRole("button", { name: "Delete run job-1" }));
 
-    const baselineSelect = screen.getByLabelText("Pinned baseline run");
+    expect(await screen.findByText(/Deleted run job-1 from this project/)).toBeInTheDocument();
+    clickReviewTask("Policy");
+    expect(
+      await screen.findByText("Set thresholds, baselines, suppressions, and promotion rules."),
+    ).toBeInTheDocument();
+    const baselineSelect = await screen.findByLabelText("Pinned baseline run");
     await waitFor(() => expect(baselineSelect).toHaveValue(""));
 
-    fireEvent.click(screen.getByRole("tab", { name: /Artifacts/ }));
+    clickReviewTask("Runs & Reports");
     fireEvent.click(screen.getByRole("button", { name: "Preview matches" }));
 
     await waitFor(() =>
@@ -1203,6 +1282,7 @@ describe("ProjectWorkbenchPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete matched runs" }));
 
     expect(await screen.findByText("No jobs for this project yet.")).toBeInTheDocument();
+    clickReviewTask("Evidence");
     expect(
       screen.getByText("No current compared run is available for artifact inspection."),
     ).toBeInTheDocument();

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -54,10 +54,34 @@ type ReviewTab =
   | "suppressions"
   | "promote";
 
+type ReviewTask = "findings" | "evidence" | "runs" | "policy";
 type RunHistoryFilter = "all" | "active" | "completed" | "failed";
+type StepStatusTone = "blocked" | "ready" | "done" | "running";
+
+interface StepStatus {
+  label: string;
+  detail: string;
+  tone: StepStatusTone;
+}
+
+interface NextAction {
+  eyebrow: string;
+  title: string;
+  description: string;
+  actionLabel: string;
+  disabledReason: string | null;
+  isBusy: boolean;
+  onAction: () => void;
+}
 
 const STEP_ORDER: ProjectStep[] = ["source", "inspect", "generate", "run", "review"];
 const PRUNEABLE_JOB_STATUSES: ApiJobStatus[] = ["completed", "failed"];
+const REVIEW_TASKS: Array<[ReviewTask, string]> = [
+  ["findings", "Findings"],
+  ["evidence", "Evidence"],
+  ["runs", "Runs & Reports"],
+  ["policy", "Policy"],
+];
 
 function defaultSourceForMode(mode: ProjectSourceMode): SourcePayload | null {
   if (mode === "openapi") {
@@ -192,6 +216,22 @@ function matchesRunHistoryFilter(job: JobStatusResponse, filter: RunHistoryFilte
     return job.status === "pending" || job.status === "running";
   }
   return job.status === filter;
+}
+
+function stepLabel(step: ProjectStep): string {
+  if (step === "source") {
+    return "Source";
+  }
+  if (step === "inspect") {
+    return "Inspect";
+  }
+  if (step === "generate") {
+    return "Generate";
+  }
+  if (step === "run") {
+    return "Run";
+  }
+  return "Review";
 }
 
 function ReviewTable({
@@ -484,24 +524,52 @@ function ListField({
 function StepRail({
   activeStep,
   onChange,
+  statuses,
 }: {
   activeStep: ProjectStep;
   onChange: (step: ProjectStep) => void;
+  statuses: Record<ProjectStep, StepStatus>;
 }) {
   return (
     <nav className="step-rail" aria-label="Workbench steps">
       {STEP_ORDER.map((step, index) => (
         <button
-          className={`step-rail-button${step === activeStep ? " step-rail-button-active" : ""}`}
+          aria-current={step === activeStep ? "step" : undefined}
+          className={`step-rail-button step-rail-${statuses[step].tone}${
+            step === activeStep ? " step-rail-button-active" : ""
+          }`}
           key={step}
           onClick={() => onChange(step)}
           type="button"
         >
           <span className="step-rail-index">0{index + 1}</span>
-          <span className="step-rail-name">{step}</span>
+          <span className="step-rail-name">{stepLabel(step)}</span>
+          <span className="step-rail-status">{statuses[step].label}</span>
+          <span className="step-rail-detail">{statuses[step].detail}</span>
         </button>
       ))}
     </nav>
+  );
+}
+
+function NextActionCard({ action }: { action: NextAction }) {
+  return (
+    <section className="next-action-card" aria-label="Next action">
+      <div>
+        <p className="eyebrow">{action.eyebrow}</p>
+        <h2>{action.title}</h2>
+        <p>{action.description}</p>
+        {action.disabledReason ? <p className="next-action-blocker">{action.disabledReason}</p> : null}
+      </div>
+      <button
+        className="primary-button"
+        disabled={Boolean(action.disabledReason) || action.isBusy}
+        onClick={action.onAction}
+        type="button"
+      >
+        {action.isBusy ? "Working…" : action.actionLabel}
+      </button>
+    </section>
   );
 }
 
@@ -524,6 +592,7 @@ export default function ProjectWorkbenchPage() {
   const [baselineError, setBaselineError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [activityMessage, setActivityMessage] = useState<string | null>(null);
+  const [reviewTask, setReviewTask] = useState<ReviewTask>("findings");
   const [reviewTab, setReviewTab] = useState<ReviewTab>("overview");
   const [reviewFilter, setReviewFilter] = useState("");
   const [selectedEvidenceAttackId, setSelectedEvidenceAttackId] = useState<string | null>(null);
@@ -658,6 +727,7 @@ export default function ProjectWorkbenchPage() {
     try {
       const review = await refreshProjectReview(project.id, project.review_draft);
       commitDraft(withReviewBundle(project, review));
+      setReviewTask("findings");
       setReviewTab("overview");
       setActivityMessage(
         review.waiting_for_new_run
@@ -928,6 +998,179 @@ export default function ProjectWorkbenchPage() {
     drawerArtifactQuery.error instanceof Error ? drawerArtifactQuery.error.message : null;
   const artifactsTabArtifactError =
     artifactsTabArtifactQuery.error instanceof Error ? artifactsTabArtifactQuery.error.message : null;
+  const sourceDocumentReady = Boolean(draft.source?.content.trim());
+  const suiteReady = Boolean(draft.artifacts.generated_suite?.attacks.length);
+  const targetReady = Boolean(draft.run_draft.base_url.trim());
+  const activeRun = currentJobs.find((job) => job.status === "pending" || job.status === "running");
+  const stepStatuses: Record<ProjectStep, StepStatus> = {
+    source: sourceDocumentReady
+      ? {
+          label: "Done",
+          detail: `${draft.source_mode.replace("_", " ")} source saved`,
+          tone: "done",
+        }
+      : draft.source_mode === "capture_upload" && draft.discover_inputs.length
+        ? {
+            label: "Ready",
+            detail: `${draft.discover_inputs.length} capture file(s) loaded`,
+            tone: "ready",
+          }
+        : {
+            label: "Needs source",
+            detail: "Add schema or captures",
+            tone: "blocked",
+          },
+    inspect: draft.artifacts.inspect_result
+      ? {
+          label: "Done",
+          detail: `${draft.artifacts.inspect_result.operations.length} operation(s)`,
+          tone: "done",
+        }
+      : sourceDocumentReady
+        ? {
+            label: "Ready",
+            detail: "Preflight available",
+            tone: "ready",
+          }
+        : {
+            label: "Needs source",
+            detail: "Inspect waits for source",
+            tone: "blocked",
+          },
+    generate: suiteReady
+      ? {
+          label: "Done",
+          detail: `${draft.artifacts.generated_suite?.attacks.length ?? 0} attack(s)`,
+          tone: "done",
+        }
+      : sourceDocumentReady
+        ? {
+            label: "Ready",
+            detail: "Suite can be generated",
+            tone: "ready",
+          }
+        : {
+            label: "Needs source",
+            detail: "Generate waits for source",
+            tone: "blocked",
+          },
+    run: activeRun
+      ? {
+          label: "Running",
+          detail: shortJobId(activeRun.id),
+          tone: "running",
+        }
+      : currentReviewedJob
+        ? {
+            label: "Done",
+            detail: `${currentReviewedJob.artifact_names.length} artifact(s)`,
+            tone: "done",
+          }
+        : suiteReady
+          ? {
+              label: targetReady ? "Ready" : "Needs target",
+              detail: targetReady ? "Run can start" : "Add a base URL",
+              tone: targetReady ? "ready" : "blocked",
+            }
+          : {
+              label: "Needs suite",
+              detail: "Generate attacks first",
+              tone: "blocked",
+            },
+    review: currentReviewedJob
+      ? {
+          label: "Review ready",
+          detail: `${currentFindings.length} active finding(s)`,
+          tone: "done",
+        }
+      : activeRun
+        ? {
+            label: "Running",
+            detail: "Waiting for results",
+            tone: "running",
+          }
+        : {
+            label: "Needs run",
+            detail: "Run a suite first",
+            tone: "blocked",
+          },
+  };
+  const nextAction: NextAction =
+    draft.active_step === "source"
+      ? draft.source_mode === "capture_upload"
+        ? {
+            eyebrow: "Next action",
+            title: "Discover a source model from captured traffic",
+            description:
+              "Upload HAR or capture NDJSON files, then convert them into a learned model before inspection.",
+            actionLabel: "Discover learned model",
+            disabledReason: draft.discover_inputs.length
+              ? null
+              : "Upload at least one capture file to continue.",
+            isBusy: busyAction === "discover",
+            onAction: () => void handleDiscover(),
+          }
+        : {
+            eyebrow: "Next action",
+            title: "Inspect the source surface",
+            description:
+              "Load or paste the API source, then preflight the operations before choosing attacks.",
+            actionLabel: "Inspect source",
+            disabledReason: sourceDocumentReady ? null : "Paste or upload a source document first.",
+            isBusy: busyAction === "inspect",
+            onAction: () => void handleInspect(),
+          }
+      : draft.active_step === "inspect"
+        ? {
+            eyebrow: "Next action",
+            title: "Refresh operation discovery",
+            description:
+              "Apply the inspect filters and confirm which operations are available for attack generation.",
+            actionLabel: "Inspect source",
+            disabledReason: sourceDocumentReady ? null : "Add a source document before inspecting.",
+            isBusy: busyAction === "inspect",
+            onAction: () => void handleInspect(),
+          }
+        : draft.active_step === "generate"
+          ? {
+              eyebrow: "Next action",
+              title: "Generate an attack suite",
+              description:
+                "Use the selected filters and packs to build the suite that will run against your target.",
+              actionLabel: "Generate suite",
+              disabledReason: sourceDocumentReady ? null : "Add a source document before generating.",
+              isBusy: busyAction === "generate",
+              onAction: () => void handleGenerate(),
+            }
+          : draft.active_step === "run"
+            ? {
+                eyebrow: "Next action",
+                title: "Run the suite against a target",
+                description:
+                  "Set the base URL and optional auth context, then start a project-scoped background run.",
+                actionLabel: "Run suite",
+                disabledReason: !suiteReady
+                  ? "Generate an attack suite before running."
+                  : !targetReady
+                    ? "Add a base URL before starting a run."
+                    : headersError || queryError
+                      ? "Fix JSON errors in the run settings before starting."
+                      : null,
+                isBusy: busyAction === "run",
+                onAction: () => void handleRun(),
+              }
+            : {
+                eyebrow: "Next action",
+                title: "Review the latest completed run",
+                description:
+                  "Refresh analysis to update findings, evidence, reports, policy checks, and comparison state.",
+                actionLabel: "Refresh analysis",
+                disabledReason: completedReviewJobs.length
+                  ? null
+                  : "Complete at least one run before reviewing.",
+                isBusy: busyAction === "refresh-review",
+                onAction: () => void handleRefreshReview(),
+              };
 
   async function resolvePromotionReview(project: ProjectRecord) {
     if (project.review_draft.baseline_mode === "external") {
@@ -947,6 +1190,7 @@ export default function ProjectWorkbenchPage() {
   }
 
   function openFindingEvidence(finding: { attack_id: string }) {
+    setReviewTask("evidence");
     setSelectedEvidenceAttackId(finding.attack_id);
     setSelectedDrawerArtifactName(null);
     setEvidenceNotice(null);
@@ -1178,6 +1422,7 @@ export default function ProjectWorkbenchPage() {
         },
       }));
       setActivityMessage(`Generated ${triaged.added_count} suppression rule(s).`);
+      setReviewTask("policy");
       setReviewTab("suppressions");
     } catch (error) {
       setActionError(error instanceof Error ? error.message : "Could not generate suppressions.");
@@ -1209,6 +1454,7 @@ export default function ProjectWorkbenchPage() {
         },
       }));
       setActivityMessage(`Promoted ${promoted.promoted_attack_ids.length} attack(s).`);
+      setReviewTask("policy");
       setReviewTab("promote");
     } catch (error) {
       setActionError(error instanceof Error ? error.message : "Promotion failed.");
@@ -1551,10 +1797,14 @@ export default function ProjectWorkbenchPage() {
               active_step: step,
             }))
           }
+          statuses={stepStatuses}
         />
 
         <section className="workbench-main">
-          <div className="panel">
+          <NextActionCard action={nextAction} />
+
+          {draft.active_step === "source" ? (
+          <div className="panel step-panel">
             <div className="section-heading">
               <div>
                 <p className="eyebrow">Source</p>
@@ -1709,8 +1959,10 @@ export default function ProjectWorkbenchPage() {
               </div>
             )}
           </div>
+          ) : null}
 
-          <div className="panel">
+          {draft.active_step === "inspect" ? (
+          <div className="panel step-panel">
             <div className="section-heading">
               <div>
                 <p className="eyebrow">Inspect</p>
@@ -1780,8 +2032,10 @@ export default function ProjectWorkbenchPage() {
               ])}
             />
           </div>
+          ) : null}
 
-          <div className="panel">
+          {draft.active_step === "generate" ? (
+          <div className="panel step-panel">
             <div className="section-heading">
               <div>
                 <p className="eyebrow">Generate</p>
@@ -1900,8 +2154,10 @@ export default function ProjectWorkbenchPage() {
               </button>
             </div>
           </div>
+          ) : null}
 
-          <div className="panel">
+          {draft.active_step === "run" ? (
+          <div className="panel step-panel">
             <div className="section-heading">
               <div>
                 <p className="eyebrow">Run</p>
@@ -2099,8 +2355,10 @@ export default function ProjectWorkbenchPage() {
               </button>
             </div>
           </div>
+          ) : null}
 
-          <div className="panel">
+          {draft.active_step === "review" ? (
+          <div className="panel step-panel">
             <div className="section-heading">
               <div>
                 <p className="eyebrow">Review</p>
@@ -2176,6 +2434,30 @@ export default function ProjectWorkbenchPage() {
                 </small>
               </article>
             </div>
+
+            <div className="tab-row review-task-row" role="tablist" aria-label="Review task groups">
+              {REVIEW_TASKS.map(([task, label]) => (
+                <button
+                  aria-selected={reviewTask === task}
+                  className={`tab-button${reviewTask === task ? " tab-button-active" : ""}`}
+                  key={task}
+                  onClick={() => setReviewTask(task)}
+                  role="tab"
+                  type="button"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {reviewTask === "policy" ? (
+            <div className="stack review-task-panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Policy</p>
+                <h3>Set thresholds, baselines, suppressions, and promotion rules.</h3>
+              </div>
+            </div>
             <div className="field-grid field-grid-3">
               <label className="field">
                 <span className="field-label">Minimum severity</span>
@@ -2220,15 +2502,6 @@ export default function ProjectWorkbenchPage() {
                     </option>
                   ))}
                 </select>
-              </label>
-              <label className="field">
-                <span className="field-label">Findings filter</span>
-                <input
-                  className="text-input"
-                  value={reviewFilter}
-                  onChange={(event) => setReviewFilter(event.target.value)}
-                  placeholder="search by attack, kind, issue, path"
-                />
               </label>
             </div>
             <div className="field-grid field-grid-3">
@@ -2331,8 +2604,21 @@ export default function ProjectWorkbenchPage() {
                 value={baselineText}
               />
             </details>
+            </div>
+            ) : null}
 
-            <div className="tab-row" role="tablist" aria-label="Review panels">
+            {reviewTask === "findings" ? (
+            <div className="stack review-task-panel">
+            <label className="field">
+              <span className="field-label">Findings filter</span>
+              <input
+                className="text-input"
+                value={reviewFilter}
+                onChange={(event) => setReviewFilter(event.target.value)}
+                placeholder="search by attack, kind, issue, path"
+              />
+            </label>
+            <div className="tab-row" role="tablist" aria-label="Findings panels">
               {(
                 [
                   ["overview", "Overview"],
@@ -2340,9 +2626,6 @@ export default function ProjectWorkbenchPage() {
                   ["persisting", "Persisting"],
                   ["resolved", "Resolved"],
                   ["deltas", "Deltas"],
-                  ["artifacts", "Artifacts"],
-                  ["suppressions", "Suppressions"],
-                  ["promote", "Promote"],
                 ] as Array<[ReviewTab, string]>
               ).map(([tab, label]) => (
                 <button
@@ -2357,7 +2640,17 @@ export default function ProjectWorkbenchPage() {
                 </button>
               ))}
             </div>
+            </div>
+            ) : null}
 
+            {reviewTask === "evidence" ? (
+            <div className="stack review-task-panel">
+              <div className="section-heading">
+                <div>
+                  <p className="eyebrow">Evidence</p>
+                  <h3>Inspect artifacts, auth events, and finding-level request evidence.</h3>
+                </div>
+              </div>
             {selectedEvidenceAttackId && currentReviewedJob ? (
               <section className="evidence-drawer">
                 <div className="section-heading">
@@ -2489,8 +2782,38 @@ export default function ProjectWorkbenchPage() {
                 <p>{evidenceNotice}</p>
               </div>
             ) : null}
+              {currentReviewedJob ? (
+                <ArtifactViewer
+                  document={artifactsTabArtifactQuery.data}
+                  emptyCopy="No artifacts linked to the current compared run."
+                  error={artifactsTabArtifactError}
+                  isLoading={artifactsTabArtifactQuery.isLoading}
+                  jobId={currentReviewedJob.id}
+                  onSelect={setSelectedArtifactsTabArtifactName}
+                  references={artifactBrowserReferences}
+                  selectedArtifactName={selectedArtifactsTabArtifactName}
+                />
+              ) : (
+                <div className="empty-state">
+                  <p>No current compared run is available for artifact inspection.</p>
+                </div>
+              )}
+              <ReviewTable
+                emptyCopy="No auth events captured."
+                headings={["Profile", "Name", "Strategy", "Phase", "Status", "Error"]}
+                rows={(draft.artifacts.latest_results?.auth_events ?? []).map((event) => [
+                  event.profile ?? "—",
+                  event.name,
+                  event.strategy,
+                  event.phase,
+                  event.status_code ?? (event.success ? "ok" : "failed"),
+                  event.error ?? "—",
+                ])}
+              />
+            </div>
+            ) : null}
 
-            {reviewTab === "overview" ? (
+            {reviewTask === "findings" && reviewTab === "overview" ? (
               <div className="stack">
                 <div className="summary-card-grid">
                   <div className="summary-card">
@@ -2541,7 +2864,7 @@ export default function ProjectWorkbenchPage() {
               </div>
             ) : null}
 
-            {reviewTab === "new" ? (
+            {reviewTask === "findings" && reviewTab === "new" ? (
               <ReviewTable
                 emptyCopy="No new findings match the current filter."
                 headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "Status", "Path"]}
@@ -2557,7 +2880,7 @@ export default function ProjectWorkbenchPage() {
               />
             ) : null}
 
-            {reviewTab === "persisting" ? (
+            {reviewTask === "findings" && reviewTab === "persisting" ? (
               <ReviewTable
                 emptyCopy="No persisting findings match the current filter."
                 headings={["Attack", "Kind", "Issue", "Severity", "Confidence", "Status", "Path"]}
@@ -2573,7 +2896,7 @@ export default function ProjectWorkbenchPage() {
               />
             ) : null}
 
-            {reviewTab === "resolved" ? (
+            {reviewTask === "findings" && reviewTab === "resolved" ? (
               <div className="stack">
                 <p className="field-hint">
                   Resolved findings are baseline-only in this milestone, so current-run artifact evidence is not available.
@@ -2594,7 +2917,7 @@ export default function ProjectWorkbenchPage() {
               </div>
             ) : null}
 
-            {reviewTab === "deltas" ? (
+            {reviewTask === "findings" && reviewTab === "deltas" ? (
               <ReviewTable
                 emptyCopy="No persisting deltas are available for the current comparison."
                 headings={["Attack", "Issue", "Change summary", "Method", "Path"]}
@@ -2612,7 +2935,7 @@ export default function ProjectWorkbenchPage() {
               />
             ) : null}
 
-            {reviewTab === "artifacts" ? (
+            {reviewTask === "runs" ? (
               <div className="stack">
                 <div className="comparison-panel">
                   <div className="section-heading">
@@ -2771,39 +3094,17 @@ export default function ProjectWorkbenchPage() {
                     <pre>{draft.artifacts.latest_html_report ?? "No HTML report yet."}</pre>
                   </article>
                 </div>
-                <ReviewTable
-                  emptyCopy="No auth events captured."
-                  headings={["Profile", "Name", "Strategy", "Phase", "Status", "Error"]}
-                  rows={(draft.artifacts.latest_results?.auth_events ?? []).map((event) => [
-                    event.profile ?? "—",
-                    event.name,
-                    event.strategy,
-                    event.phase,
-                    event.status_code ?? (event.success ? "ok" : "failed"),
-                    event.error ?? "—",
-                  ])}
-                />
-                {currentReviewedJob ? (
-                  <ArtifactViewer
-                    document={artifactsTabArtifactQuery.data}
-                    emptyCopy="No artifacts linked to the current compared run."
-                    error={artifactsTabArtifactError}
-                    isLoading={artifactsTabArtifactQuery.isLoading}
-                    jobId={currentReviewedJob.id}
-                    onSelect={setSelectedArtifactsTabArtifactName}
-                    references={artifactBrowserReferences}
-                    selectedArtifactName={selectedArtifactsTabArtifactName}
-                  />
-                ) : (
-                  <div className="empty-state">
-                    <p>No current compared run is available for artifact inspection.</p>
-                  </div>
-                )}
               </div>
             ) : null}
 
-            {reviewTab === "suppressions" ? (
-              <div className="stack">
+            {reviewTask === "policy" ? (
+              <div className="stack review-task-panel">
+                <div className="section-heading">
+                  <div>
+                    <p className="eyebrow">Suppressions</p>
+                    <h3>Keep accepted findings out of active review noise.</h3>
+                  </div>
+                </div>
                 <CodeEditor
                   error={null}
                   height={260}
@@ -2825,8 +3126,14 @@ export default function ProjectWorkbenchPage() {
               </div>
             ) : null}
 
-            {reviewTab === "promote" ? (
-              <div className="stack">
+            {reviewTask === "policy" ? (
+              <div className="stack review-task-panel">
+                <div className="section-heading">
+                  <div>
+                    <p className="eyebrow">Promotion</p>
+                    <h3>Promote qualifying findings into a regression suite.</h3>
+                  </div>
+                </div>
                 <div className="summary-card-grid">
                   <div className="summary-card">
                     <span>Promoted attacks</span>
@@ -2845,6 +3152,7 @@ export default function ProjectWorkbenchPage() {
               </div>
             ) : null}
           </div>
+          ) : null}
         </section>
 
         <aside className="workbench-sidebar">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,17 +1,19 @@
 :root {
-  --bg: #f3ede2;
-  --panel: rgba(254, 251, 246, 0.9);
-  --panel-strong: rgba(255, 255, 255, 0.9);
-  --ink: #1f1b18;
-  --muted: #6e6359;
-  --border: rgba(76, 57, 39, 0.14);
-  --line: rgba(76, 57, 39, 0.08);
-  --accent: #0d6c63;
-  --accent-strong: #064e48;
-  --warning: #b26b00;
+  --bg: #111816;
+  --panel: rgba(247, 244, 235, 0.94);
+  --panel-strong: rgba(255, 252, 244, 0.98);
+  --ink: #161a17;
+  --muted: #657069;
+  --border: rgba(18, 31, 26, 0.16);
+  --line: rgba(18, 31, 26, 0.09);
+  --accent: #007f6d;
+  --accent-strong: #004b43;
+  --warning: #bb6a00;
   --danger: #b42318;
-  --pending: #8b5cf6;
-  --shadow: 0 20px 60px rgba(31, 23, 17, 0.09);
+  --pending: #455ed8;
+  --console: #13201c;
+  --console-soft: #1c2c27;
+  --shadow: 0 24px 70px rgba(5, 12, 9, 0.22);
   --radius-xl: 26px;
   --radius-lg: 20px;
   --radius-md: 14px;
@@ -34,9 +36,9 @@ body {
   color: var(--ink);
   font-family: var(--font-ui);
   background:
-    radial-gradient(circle at top left, rgba(13, 108, 99, 0.16), transparent 28%),
-    radial-gradient(circle at top right, rgba(178, 107, 0, 0.12), transparent 24%),
-    linear-gradient(180deg, #f9f4eb 0%, var(--bg) 100%);
+    linear-gradient(135deg, rgba(0, 127, 109, 0.18), transparent 34%),
+    radial-gradient(circle at top right, rgba(187, 106, 0, 0.18), transparent 25%),
+    linear-gradient(180deg, #17231f 0%, #f4efe4 34%, #eee5d5 100%);
 }
 
 a {
@@ -65,7 +67,8 @@ pre {
 .hero-panel,
 .panel,
 .project-card,
-.sidebar-panel {
+.sidebar-panel,
+.next-action-card {
   background: var(--panel);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
@@ -78,6 +81,38 @@ pre {
   gap: 28px;
   padding: 32px;
   border-radius: 32px;
+}
+
+.source-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.source-choice-card {
+  display: grid;
+  gap: 6px;
+  min-height: 92px;
+  padding: 14px;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.64);
+  cursor: pointer;
+}
+
+.source-choice-card span,
+.project-card-summary,
+.step-rail-detail {
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.source-choice-card-active {
+  color: var(--accent-strong);
+  border-color: rgba(0, 127, 109, 0.36);
+  background: rgba(0, 127, 109, 0.1);
 }
 
 .hero-copy h1,
@@ -290,6 +325,10 @@ pre {
   font-size: 1.35rem;
 }
 
+.project-card-summary {
+  margin: 0;
+}
+
 .project-metrics {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -345,7 +384,7 @@ pre {
 
 .workbench-layout {
   display: grid;
-  grid-template-columns: 170px minmax(0, 1fr) 290px;
+  grid-template-columns: 210px minmax(0, 1fr) 300px;
   gap: 22px;
   align-items: start;
 }
@@ -364,20 +403,96 @@ pre {
   align-items: flex-start;
   gap: 4px;
   width: 100%;
-  padding: 14px;
-  background: rgba(255, 255, 255, 0.68);
+  padding: 15px;
+  background: rgba(255, 255, 255, 0.72);
   cursor: pointer;
 }
 
 .step-rail-button-active {
-  background: rgba(13, 108, 99, 0.14);
-  border-color: rgba(13, 108, 99, 0.38);
+  color: var(--accent-strong);
+  background:
+    linear-gradient(135deg, rgba(0, 127, 109, 0.16), rgba(255, 255, 255, 0.82));
+  border-color: rgba(0, 127, 109, 0.42);
+  box-shadow: inset 4px 0 0 rgba(0, 127, 109, 0.72);
 }
 
 .step-rail-name {
   font-size: 1rem;
   font-weight: 700;
   text-transform: capitalize;
+}
+
+.step-rail-status {
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.step-rail-blocked .step-rail-status {
+  color: var(--danger);
+}
+
+.step-rail-ready .step-rail-status {
+  color: var(--warning);
+}
+
+.step-rail-done .step-rail-status {
+  color: var(--accent-strong);
+}
+
+.step-rail-running .step-rail-status {
+  color: var(--pending);
+}
+
+.next-action-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  padding: 22px;
+  border-radius: var(--radius-xl);
+  background:
+    linear-gradient(135deg, rgba(19, 32, 28, 0.96), rgba(28, 44, 39, 0.92));
+  color: #f7f4eb;
+}
+
+.next-action-card h2,
+.next-action-card p {
+  margin: 0;
+}
+
+.next-action-card .eyebrow,
+.next-action-card p {
+  color: rgba(247, 244, 235, 0.74);
+}
+
+.next-action-card .primary-button {
+  min-width: 180px;
+  background: #f7c65d;
+  color: #1e211c;
+}
+
+.next-action-blocker {
+  margin-top: 10px !important;
+  color: #ffd6c9 !important;
+  font-weight: 700;
+}
+
+.step-panel,
+.review-task-panel {
+  animation: panel-enter 180ms ease-out;
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .upload-box {
@@ -571,6 +686,10 @@ pre {
   font-weight: 700;
 }
 
+.review-task-row {
+  margin-bottom: 18px;
+}
+
 .report-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -748,6 +867,7 @@ pre {
   .field-grid-4,
   .field-grid-3,
   .field-grid-2,
+  .source-choice-grid,
   .artifact-viewer,
   .report-grid,
   .compare-banner {
@@ -768,8 +888,13 @@ pre {
   }
 
   .workbench-header,
-  .section-heading {
+  .section-heading,
+  .next-action-card {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .next-action-card .primary-button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the workbench into one active step workspace with a status/progress rail and persistent next-action guidance
- add first-time project source selection on the home page and refresh project cards around resume state, latest run, findings, and source type
- reorganize Review into Findings, Evidence, Runs & Reports, and Policy task groups while preserving artifact, evidence, baseline, suppression, promotion, duplicate, delete, and prune flows
- refresh the workbench styling toward a sharper security-console visual hierarchy

Closes #110.

## Validation
- `npm test -- --run`
- `npm run build`
