### PR TITLE
[codex] Add Markdown summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Generate a machine-readable summary for dashboards or CI annotations:
 knives-out summary results.json --out summary.json
 ```
 
+Publish a compact Markdown summary in GitHub Actions:
+
+```bash
+knives-out summary results.json --format markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
 Export active findings as SARIF for CI-native code scanning:
 
 ```bash
@@ -488,7 +494,8 @@ With a baseline, both `verify` and baseline-aware `report` also summarize persis
 status, severity, confidence, or schema outcome drifted between runs.
 When you want a compact machine-readable artifact for dashboards, annotations, or follow-on
 automation, `knives-out summary results.json --out summary.json` emits the same counts and top
-findings as structured JSON.
+findings as structured JSON. For a smaller human-readable CI note, append
+`knives-out summary results.json --format markdown` output to `$GITHUB_STEP_SUMMARY`.
 When you want code-scanning or PR-native triage inside CI, `knives-out export results.json --format sarif --out results.sarif`
 emits SARIF 2.1.0 from the same active unsuppressed findings, with optional baseline change
 metadata when you also pass `--baseline previous-results.json`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -286,6 +286,14 @@ HTML, render a summary file after execution:
   run: knives-out summary results.json --out summary.json
 ```
 
+When GitHub Actions reviewers need a smaller human-readable note in the job UI, render the same
+summary as Markdown and append it to the step summary:
+
+```yaml
+- name: Publish knives-out job summary
+  run: knives-out summary results.json --format markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
 ## Optional: Shadow Twin learned models
 
 Shadow Twin adds a capture/discover front end for real-behavior API learning when the checked-in

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -15,6 +15,7 @@ from knives_out.auth_plugins import PluginRuntimeError
 from knives_out.capture import serve_capture_proxy
 from knives_out.models import AttackResults, PreflightWarning
 from knives_out.promotion import PromotionError
+from knives_out.reporting import render_markdown_summary
 from knives_out.services import (
     DEFAULT_SUPPRESSIONS_PATH,
     SuppressionRule,
@@ -62,6 +63,11 @@ class ReportFormatOption(StrEnum):
 
 class ExportFormatOption(StrEnum):
     sarif = "sarif"
+
+
+class SummaryFormatOption(StrEnum):
+    json = "json"
+    markdown = "markdown"
 
 
 class InspectFormatOption(StrEnum):
@@ -733,8 +739,12 @@ def summary(
         int,
         typer.Option(help="How many top active findings to include in the summary."),
     ] = 10,
+    format: Annotated[
+        SummaryFormatOption,
+        typer.Option(help="Summary output format."),
+    ] = SummaryFormatOption.json,
 ) -> None:
-    """Render a machine-readable JSON summary from a results file."""
+    """Render a compact summary from a results file."""
     try:
         summary_result = summarize_results_from_paths(
             results,
@@ -745,17 +755,23 @@ def summary(
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
-    rendered = json.dumps(
-        summary_result.summary.model_dump(mode="json", exclude_none=True),
-        indent=2,
-    )
+    if format == SummaryFormatOption.markdown:
+        rendered = render_markdown_summary(summary_result.summary)
+        format_label = "Markdown"
+    else:
+        rendered = json.dumps(
+            summary_result.summary.model_dump(mode="json", exclude_none=True),
+            indent=2,
+        )
+        format_label = "JSON"
+
     if out is None:
-        typer.echo(rendered)
+        typer.echo(rendered, nl=not rendered.endswith("\n"))
         return
 
-    out.write_text(rendered + "\n", encoding="utf-8")
+    out.write_text(rendered if rendered.endswith("\n") else rendered + "\n", encoding="utf-8")
     _print_suppression_summary(summary_result.suppressions_path, summary_result.suppressions)
-    console.print(f"Wrote summary JSON to [bold]{out}[/bold].")
+    console.print(f"Wrote summary {format_label} to [bold]{out}[/bold].")
 
 
 @app.command()

--- a/src/knives_out/reporting.py
+++ b/src/knives_out/reporting.py
@@ -279,6 +279,128 @@ def summarize_results(
     )
 
 
+def _markdown_cell(value: object | None) -> str:
+    text = "-" if value is None else str(value)
+    return text.replace("\n", " ").replace("|", r"\|").strip() or "-"
+
+
+def _append_counter_section(
+    lines: list[str],
+    *,
+    title: str,
+    counts: dict[str, int],
+    empty_message: str,
+) -> None:
+    lines.append(f"## {title}")
+    lines.append("")
+    if not counts:
+        lines.append(empty_message)
+        lines.append("")
+        return
+
+    lines.append("| Value | Count |")
+    lines.append("| --- | ---: |")
+    for value, count in sorted(counts.items()):
+        lines.append(f"| {_markdown_cell(value)} | {count} |")
+    lines.append("")
+
+
+def render_markdown_summary(summary: ResultsSummary) -> str:
+    """Render a compact Markdown summary for CI job summaries and chatops."""
+
+    lines: list[str] = [
+        "# knives-out summary",
+        "",
+        f"- Source: `{_markdown_cell(summary.source)}`",
+        f"- Base URL: `{_markdown_cell(summary.base_url)}`",
+        f"- Executed at: `{summary.executed_at.isoformat()}`",
+        f"- Baseline used: **{'yes' if summary.baseline_used else 'no'}**",
+    ]
+    if summary.baseline_executed_at is not None:
+        lines.append(f"- Baseline executed at: `{summary.baseline_executed_at.isoformat()}`")
+    if summary.profile_names:
+        lines.append(f"- Profiles: `{_markdown_cell(', '.join(summary.profile_names))}`")
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Key counts",
+            "",
+            "| Metric | Count |",
+            "| --- | ---: |",
+            f"| Total results | {summary.total_results} |",
+            f"| Active flagged | {summary.active_flagged_count} |",
+            f"| Suppressed flagged | {summary.suppressed_flagged_count} |",
+            f"| New findings | {summary.new_findings_count} |",
+            f"| Resolved findings | {summary.resolved_findings_count} |",
+            f"| Persisting findings | {summary.persisting_findings_count} |",
+            f"| Persisting with deltas | {summary.persisting_deltas_count} |",
+            f"| Profiles | {summary.profile_count} |",
+            f"| Auth failures | {summary.auth_failures} |",
+            f"| Refresh attempts | {summary.refresh_attempts} |",
+            f"| Response schema mismatches | {summary.response_schema_mismatches} |",
+            f"| GraphQL response-shape mismatches | {summary.graphql_shape_mismatches} |",
+            "",
+        ]
+    )
+
+    _append_counter_section(
+        lines,
+        title="Protocol counts",
+        counts=summary.protocol_counts,
+        empty_message="No protocol counts recorded.",
+    )
+    _append_counter_section(
+        lines,
+        title="Issue counts",
+        counts=summary.issue_counts,
+        empty_message="No issue counts recorded.",
+    )
+    _append_counter_section(
+        lines,
+        title="Finding severity counts",
+        counts=summary.finding_severity_counts,
+        empty_message="No active finding severities recorded.",
+    )
+
+    lines.append("## Top active findings")
+    lines.append("")
+    if summary.top_findings:
+        lines.append(
+            "| Attack | Protocol | Kind | Issue | Severity | Confidence | Status | Schema | URL |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | --- | ---: | --- | --- |")
+        for finding in summary.top_findings:
+            status = finding.status_code if finding.status_code is not None else "-"
+            lines.append(
+                f"| {_markdown_cell(finding.name)} | {_markdown_cell(finding.protocol)} | "
+                f"{_markdown_cell(finding.kind)} | {_markdown_cell(finding.issue or '-')} | "
+                f"{finding.severity} | {finding.confidence} | {status} | "
+                f"{_markdown_cell(finding.schema_status)} | `{_markdown_cell(finding.url)}` |"
+            )
+    else:
+        lines.append("No active findings in the current summary.")
+    lines.append("")
+
+    lines.append("## Auth summary")
+    lines.append("")
+    if summary.auth_summary:
+        lines.append("| Profile | Name | Strategy | Acquire | Refresh | Failures | Triggers |")
+        lines.append("| --- | --- | --- | ---: | ---: | ---: | --- |")
+        for entry in summary.auth_summary:
+            triggers = ", ".join(entry.triggers) or "-"
+            lines.append(
+                f"| {_markdown_cell(entry.profile)} | {_markdown_cell(entry.name)} | "
+                f"{_markdown_cell(entry.strategy)} | {entry.acquire} | {entry.refresh} | "
+                f"{entry.failures} | {_markdown_cell(triggers)} |"
+            )
+    else:
+        lines.append("No auth diagnostics recorded.")
+    lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def render_markdown_report(
     results: AttackResults,
     *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from knives_out.models import (
     AttackResult,
     AttackResults,
     AttackSuite,
+    AuthEvent,
     LoadedOperations,
     PreflightWarning,
 )
@@ -536,6 +537,69 @@ def test_summary_command_prints_json_to_stdout(tmp_path: Path) -> None:
     assert summary["protocol_counts"]["graphql"] == 1
     assert summary["graphql_shape_mismatches"] == 1
     assert summary["top_findings"][0]["schema_status"] == "graphql-mismatch"
+
+
+def test_summary_command_writes_markdown_summary(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    summary_path = tmp_path / "summary.md"
+    _write_results(
+        results_path,
+        AttackResults(
+            source="unit",
+            base_url="https://example.com",
+            auth_events=[
+                AuthEvent(
+                    profile="user",
+                    name="token",
+                    strategy="client_credentials",
+                    phase="acquire",
+                    trigger="suite",
+                    status_code=401,
+                    success=False,
+                    error="bad credentials",
+                )
+            ],
+            results=[
+                AttackResult(
+                    attack_id="atk_server",
+                    operation_id="createPet",
+                    kind="missing_request_body",
+                    name="Server failure",
+                    method="POST",
+                    url="https://example.com/pets",
+                    status_code=500,
+                    flagged=True,
+                    issue="server_error",
+                    severity="high",
+                    confidence="high",
+                )
+            ],
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "summary",
+            str(results_path),
+            "--format",
+            "markdown",
+            "--out",
+            str(summary_path),
+            "--top",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "# knives-out summary" in summary
+    assert "| Active flagged | 1 |" in summary
+    assert "## Top active findings" in summary
+    assert "Server failure" in summary
+    assert "| server_error | 1 |" in summary
+    assert "## Auth summary" in summary
+    assert "| user | token | client_credentials | 1 | 0 | 1 | suite |" in summary
 
 
 def test_export_command_writes_sarif_to_file(tmp_path: Path) -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -29,6 +29,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert "knives-out promote results.json" in readme
     assert "knives-out triage results.json" in readme
     assert "knives-out summary results.json --out summary.json" in readme
+    assert "knives-out summary results.json --format markdown" in readme
+    assert "GITHUB_STEP_SUMMARY" in readme
     assert "summary.json" in readme
     assert ".knives-out-ignore.yml" in readme
     assert "## Local API" in readme
@@ -180,6 +182,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "KNIVES_OUT_BASIC_AUTH_USERNAME" in ci_doc
     assert "KNIVES_OUT_BASIC_AUTH_PASSWORD" in ci_doc
     assert "knives-out summary results.json --out summary.json" in ci_doc
+    assert "knives-out summary results.json --format markdown" in ci_doc
+    assert "GITHUB_STEP_SUMMARY" in ci_doc
     assert "knives-out export results.json --format sarif --out results.sarif" in ci_doc
     assert "github/codeql-action/upload-sarif@v4" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc


### PR DESCRIPTION
Summary: adds summary --format markdown while keeping JSON default. Covers compact counts, top active findings, auth summary rows, and GitHub Actions step summary docs. Closes #112. Validation: ruff check, ruff format check, compileall, docs pytest passed. CLI pytest coverage added but local interpreters miss FastAPI/pytest/Pydantic.