### PR TITLE
[codex] Update workflow pins and coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,14 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -26,7 +29,7 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -45,7 +48,7 @@ jobs:
   container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Build image
         run: docker build -t knives-out:test .
       - name: Smoke test container

--- a/.github/workflows/dev-environment-example.yml
+++ b/.github/workflows/dev-environment-example.yml
@@ -14,7 +14,7 @@ jobs:
   knives-out-dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -147,7 +147,7 @@ jobs:
           sarif_file: results.sarif
       - name: Upload run artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: knives-out-dev-results
           if-no-files-found: ignore

--- a/.github/workflows/main-maintenance.yml
+++ b/.github/workflows/main-maintenance.yml
@@ -18,7 +18,7 @@ jobs:
   maintain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -48,7 +48,7 @@ jobs:
         run: pytest --cov=src/knives_out --cov-report=term-missing --cov-report=json:coverage.json
 
       - name: Upload coverage baseline artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: main-maintenance-coverage
           path: coverage.json
@@ -65,7 +65,7 @@ jobs:
 
       - name: Find previous successful coverage baseline
         id: previous-baseline
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -37,7 +37,7 @@ jobs:
         run: npm run build
       - name: Add SPA fallback
         run: cp frontend/dist/index.html frontend/dist/404.html
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: frontend/dist
 
@@ -49,4 +49,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -18,7 +18,7 @@ jobs:
   sync-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-python@v6

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -95,9 +95,9 @@ def test_dev_environment_workflow_matches_current_cli_surface() -> None:
     workflow = DEV_WORKFLOW.read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in workflow
-    assert "actions/checkout@v5" in workflow
+    assert "actions/checkout@v6" in workflow
     assert "actions/setup-python@v6" in workflow
-    assert "actions/upload-artifact@v6" in workflow
+    assert "actions/upload-artifact@v7" in workflow
     assert "SPEC_PATH: examples/openapi/storefront.yaml" in workflow
     assert 'knives-out generate "$SPEC_PATH" --tag orders --out attacks.json' in workflow
     assert "--path /draft-orders/{draftId}" in workflow
@@ -218,8 +218,8 @@ def test_main_maintenance_workflow_checks_docs_links_and_coverage_regressions() 
     assert "workflow_dispatch:" in workflow
     assert "branches:" in workflow
     assert "- main" in workflow
-    assert "actions/upload-artifact@v6" in workflow
-    assert "actions/github-script@v7" in workflow
+    assert "actions/upload-artifact@v7" in workflow
+    assert "actions/github-script@v9" in workflow
     assert "contents: write" in workflow
     assert "ruff check ." in workflow
     assert "ruff format --check ." in workflow

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,7 @@ import json
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import date
 from pathlib import Path
 
 import httpx
@@ -25,7 +26,12 @@ from knives_out.models import (
     WorkflowStep,
     WorkflowStepResult,
 )
-from knives_out.reporting import render_html_report, render_markdown_report, summarize_results
+from knives_out.reporting import (
+    render_html_report,
+    render_markdown_report,
+    render_markdown_summary,
+    summarize_results,
+)
 from knives_out.runner import (
     _graphql_subscription_payload,
     _graphql_subscription_url,
@@ -2505,6 +2511,29 @@ def test_render_markdown_report_shows_workflow_sections() -> None:
     assert "List pets" in report
 
 
+def test_render_markdown_summary_shows_empty_baseline_and_profiles() -> None:
+    current = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        profiles=["user|team"],
+        results=[],
+    )
+    baseline = AttackResults(
+        source="baseline",
+        base_url="https://example.com",
+        results=[],
+    )
+
+    report = render_markdown_summary(summarize_results(current, baseline=baseline))
+
+    assert "- Baseline used: **yes**" in report
+    assert "- Baseline executed at:" in report
+    assert "- Profiles: `user\\|team`" in report
+    assert "No protocol counts recorded." in report
+    assert "No active findings in the current summary." in report
+    assert "No auth diagnostics recorded." in report
+
+
 def test_render_html_report_shows_artifact_index_and_profile_outcomes(tmp_path: Path) -> None:
     artifact_root = tmp_path / "artifacts"
     artifact_root.mkdir()
@@ -2513,6 +2542,7 @@ def test_render_html_report_shows_artifact_index_and_profile_outcomes(tmp_path: 
     profile_root = artifact_root / "anonymous"
     profile_root.mkdir()
     (profile_root / "wf_lookup.json").write_text("{}", encoding="utf-8")
+    (profile_root / "wf_lookup-step-01.json").write_text("{}", encoding="utf-8")
 
     results = AttackResults(
         source="unit",
@@ -2543,6 +2573,15 @@ def test_render_html_report_shows_artifact_index_and_profile_outcomes(tmp_path: 
                         issue="server_error",
                         severity="high",
                         confidence="high",
+                        workflow_steps=[
+                            WorkflowStepResult(
+                                name="List pets",
+                                operation_id="listPets",
+                                method="GET",
+                                url="https://example.com/pets",
+                                status_code=200,
+                            )
+                        ],
                     )
                 ],
                 workflow_steps=[
@@ -2565,6 +2604,90 @@ def test_render_html_report_shows_artifact_index_and_profile_outcomes(tmp_path: 
     assert "wf_lookup-step-01.json" in report
     assert "<h4>Profile outcomes</h4>" in report
     assert "anonymous (anonymous)" in report
+    assert "anonymous step 1" in report
+
+
+def test_render_html_report_links_workflow_step_artifacts_without_profiles(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    (artifact_root / "wf_lookup-step-01.json").write_text("{}", encoding="utf-8")
+
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                type="workflow",
+                attack_id="wf_lookup",
+                operation_id="getPet",
+                kind="wrong_type_param",
+                name="Workflow lookup",
+                method="GET",
+                url="https://example.com/pets/42",
+                workflow_steps=[
+                    WorkflowStepResult(
+                        name="List pets",
+                        operation_id="listPets",
+                        method="GET",
+                        url="https://example.com/pets",
+                        status_code=200,
+                    )
+                ],
+            )
+        ],
+    )
+
+    report = render_html_report(results, artifact_root=artifact_root)
+
+    assert "step 1" in report
+    assert "wf_lookup-step-01.json" in report
+
+
+def test_render_html_report_shows_error_graphql_details_and_suppression_expiry() -> None:
+    results = AttackResults(
+        source="unit",
+        base_url="https://example.com",
+        results=[
+            AttackResult(
+                attack_id="atk_graphql",
+                operation_id="book",
+                kind="wrong_type_variable",
+                name="GraphQL mismatch",
+                protocol="graphql",
+                method="POST",
+                path="/graphql",
+                url="https://example.com/graphql",
+                status_code=200,
+                flagged=True,
+                issue="graphql_response_shape_mismatch",
+                severity="medium",
+                confidence="high",
+                error="GraphQL response validation failed.",
+                graphql_response_error="$.data.book.title: expected String, got integer",
+                graphql_response_hint="Schema appears federated.",
+            )
+        ],
+    )
+
+    report = render_html_report(
+        results,
+        suppressions=[
+            SuppressionRule(
+                attack_id="atk_graphql",
+                issue="graphql_response_shape_mismatch",
+                reason="known schema drift",
+                owner="api-team",
+                expires_on=date(2099, 1, 1),
+            )
+        ],
+    )
+
+    assert "GraphQL response validation failed." in report
+    assert "<h4>GraphQL validation</h4>" in report
+    assert "$.data.book.title: expected String, got integer" in report
+    assert "Schema appears federated." in report
+    assert "known schema drift" in report
+    assert "2099-01-01" in report
 
 
 def test_render_html_report_shows_persisting_deltas() -> None:


### PR DESCRIPTION
Summary:
- update GitHub workflow action major pins to the current release lines for checkout, artifact upload, Pages deploy/upload, and github-script
- add explicit read-only permissions to ci.yml
- add focused reporting coverage tests to recover the main-maintenance coverage gate after PR #113

Root cause:
- main-maintenance failed after PR #113 because total coverage dropped from 91.48% to 91.44%; the missing coverage was in new reporting branches.

Validation:
- python3 -m ruff check .
- python3 -m ruff format --check .
- /opt/homebrew/bin/python3.12 -m compileall -q src tests scripts examples
- ruby YAML parse of workflows, Dependabot, and issue templates
- python3 -m pytest tests/test_docs.py tests/test_maintenance_scripts.py tests/test_sync_wiki.py
- python3 scripts/check_markdown_links.py README.md docs
- python3 scripts/sync_wiki.py render --out-dir /tmp/knives-out-wiki-render-post-patch
- git diff --check

Local blockers:
- full backend pytest could not run locally because PyPI DNS failed while fetching Hatchling
- frontend npm ci/build/test could not run locally because registry.npmjs.org DNS failed and npm exited with its own exit-handler error
