### PR TITLE
[codex] Add Pro edition extension surface

### DIFF
--- a/Dockerfile.pro.example
+++ b/Dockerfile.pro.example
@@ -1,0 +1,12 @@
+# Example only: the private Pro image is built from the public image plus a private wheel.
+# Build the public image first:
+#   docker build -t knives-out:base .
+# Then place the private wheel at dist/knives_out_pro-*.whl and adapt this file for release.
+
+FROM knives-out:base
+
+COPY dist/knives_out_pro-*.whl /tmp/
+RUN python -m pip install --no-cache-dir /tmp/knives_out_pro-*.whl \
+    && rm -f /tmp/knives_out_pro-*.whl
+
+ENV KNIVES_OUT_LICENSE_PATH=/run/secrets/knives_out_license.json

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ It helps developers break their APIs on purpose before someone else does.
   - [GitHub Pages](#github-pages)
 - [Local API](#local-api)
 - [Container deployment](#container-deployment)
+- [Pro and commercial packaging](#pro-and-commercial-packaging)
 - [CI usage](#ci-usage)
 - [CLI](#cli)
+  - [`edition`](#edition)
   - [`inspect`](#inspect)
   - [`generate`](#generate)
   - [`run`](#run)
@@ -265,6 +267,8 @@ knives-out triage results.json --out .knives-out-ignore.yml
 
 `knives-out` also includes a local-first web workbench for saved projects, guided attack
 generation, background runs, and native review panels.
+The workbench shows the active Free or Pro edition reported by the API, so self-hosted installs can
+surface licensed capabilities without changing the MIT core behavior.
 
 The review step is now baseline-first: it treats the latest completed run in a saved project as the
 current comparison target, lets you pin an older completed project run as the baseline, and keeps
@@ -359,6 +363,11 @@ The synchronous endpoints mirror the short CLI flows:
 - `POST /v1/verify`
 - `POST /v1/promote`
 - `POST /v1/triage`
+- `GET /v1/edition`
+
+`GET /v1/edition` reports the active Free or Pro edition, license state, enabled capabilities,
+locked capabilities, and upgrade URL. Without an extension installed, the API reports the MIT Free
+edition with Pro CI ReviewOps locked.
 
 Longer execution runs use a job resource instead:
 
@@ -458,6 +467,19 @@ The same-origin container deployment is the recommended exposed setup in v1. It 
 single-user and not a multi-tenant service, and TLS is expected to be terminated outside the app
 when you move beyond localhost.
 
+## Pro and commercial packaging
+
+The MIT package exposes a small open-core extension surface for a private self-hosted Pro add-on.
+The free core remains the CLI, local API, workbench, Docker image, reports, SARIF export,
+verification, promotion, and suppressions. A private `knives-out-pro` package can register extra
+FastAPI routes and Typer commands through the `knives_out.extensions` entry point group.
+
+The first planned paid bundle is CI ReviewOps for developer teams: imported CI runs, GitHub pull
+request comments, branch/main baselines, shared evidence links, and repository-level run history.
+`docs/pro.md` describes the Free vs Pro split, offline license model, suggested launch pricing,
+and private package contract. `Dockerfile.pro.example` shows how a private Pro image can layer the
+proprietary wheel on top of the public image.
+
 ## CI usage
 
 `knives-out` works well in CI when you follow the same generate/run/report flow and add a final
@@ -529,6 +551,15 @@ you can also run one suite across `anonymous`, `user`, and `admin` profiles with
 `--profile-file examples/auth_profiles/anonymous-user-admin.yml`.
 
 ## CLI
+
+### `edition`
+
+Shows whether the running package is the MIT Free edition or a Pro extension has registered
+licensed capabilities.
+
+```bash
+knives-out edition --format json
+```
 
 ### `inspect`
 

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -1,0 +1,85 @@
+# Knives-Out Pro
+
+Knives-Out Pro is the planned self-hosted commercial add-on for developer teams that want
+CI ReviewOps on top of the MIT core.
+
+The open-source core remains useful on its own: CLI generation and execution, the local API,
+the single-user workbench, Docker deployment, reports, SARIF export, verification, promotion,
+and suppressions all stay in the MIT package.
+
+## Pro positioning
+
+The first paid bundle is CI ReviewOps:
+
+- import CI runs, reports, SARIF, and artifacts into a shared self-hosted workbench
+- compare pull request runs against branch or main baselines
+- post one stable GitHub pull request comment per run context
+- preserve linked request/response evidence for team review
+- manage repository-level run history without sending customer APIs or traffic to a hosted service
+
+Pro is packaged as a private `knives-out-pro` Python distribution and a private Pro Docker image
+layered on the public image. Customers receive an offline signed license file; the product does
+not call home for v1 subscription checks.
+
+## Editions
+
+| Edition | Package | Intended use |
+| --- | --- | --- |
+| Free | MIT `knives-out` | Local-first CLI/API/workbench, CI artifacts, and individual project review |
+| Pro Team | Private `knives-out-pro` add-on | CI ReviewOps for up to 5 repositories |
+| Pro Business | Private `knives-out-pro` add-on | CI ReviewOps for up to 25 repositories plus priority support |
+
+Suggested launch pricing:
+
+- Pro Team: `$299/month`
+- Pro Business: `$999/month`
+
+Billing and license issuance are manual for v1. A Stripe Payment Link or invoice can collect
+payment, then a signed license is issued out of band.
+
+## Extension contract
+
+The MIT package exposes a small extension surface for Pro without depending on proprietary code:
+
+- `GET /v1/edition` returns the active edition, license state, enabled capabilities, expiry
+  metadata, and locked capabilities.
+- Python entry points in the `knives_out.extensions` group can register additional FastAPI routes
+  and Typer CLI commands.
+- The default edition is Free with `ci_reviewops` locked when no Pro extension is installed.
+
+A private Pro package should expose an entry point similar to:
+
+```toml
+[project.entry-points."knives_out.extensions"]
+pro = "knives_out_pro.extension:Extension"
+```
+
+The extension object may implement:
+
+- `edition_status() -> dict | EditionStatus`
+- `register_api(app: fastapi.FastAPI) -> None`
+- `register_cli(app: typer.Typer) -> None`
+
+## License model
+
+The Pro package owns license validation. The intended v1 behavior is:
+
+- read a signed JSON license from `KNIVES_OUT_LICENSE` or `KNIVES_OUT_LICENSE_PATH`
+- validate an Ed25519 signature offline
+- support license fields for customer, plan, expiry, max repositories, and capabilities
+- enable `ci_reviewops` only for valid licenses or licenses inside a 14-day grace window
+- expose missing, invalid, expired, and grace-period states through `/v1/edition`
+
+## Private Pro feature shape
+
+The first private implementation should add:
+
+- `knives-out-pro publish` for GitHub Actions
+- a CI import endpoint accepting results, report, SARIF, artifacts, repo, branch, commit SHA,
+  workflow URL, and pull request number
+- repository and pull request views in the workbench
+- baseline-aware comparisons across imported CI runs
+- stable GitHub pull request comments with summary counts, policy outcome, deltas, and evidence links
+
+GitLab, Bitbucket, hosted SaaS, SSO, RBAC, call-home subscription checks, and advanced paid attack
+packs are deferred until CI ReviewOps has paying users.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,7 @@ import type {
   AttackSuite,
   DeleteJobResponse,
   DiscoverResponse,
+  EditionStatus,
   GenerateResponse,
   InspectResponse,
   JobArtifactDocument,
@@ -117,6 +118,10 @@ async function requestText(path: string, init?: RequestInit): Promise<string> {
 
 export function getHealthStatus() {
   return request<{ status: string }>("/healthz");
+}
+
+export function getEditionStatus() {
+  return request<EditionStatus>("/v1/edition");
 }
 
 export function listProjects() {

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -30,6 +30,21 @@ describe("HomePage", () => {
         if (url.endsWith("/healthz")) {
           return Response.json({ status: "ok" });
         }
+        if (url.endsWith("/v1/edition")) {
+          return Response.json({
+            edition: "free",
+            plan: "Free",
+            license_state: "missing",
+            enabled_capabilities: [],
+            locked_capabilities: ["ci_reviewops"],
+            customer: null,
+            expires_at: null,
+            grace_expires_at: null,
+            upgrade_url: "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md",
+            message: "Running the MIT Free edition.",
+            extension_errors: [],
+          });
+        }
         if (url.endsWith("/v1/projects")) {
           return Response.json({
             projects: [
@@ -65,6 +80,8 @@ describe("HomePage", () => {
 
     expect(await screen.findByText("Storefront triage")).toBeInTheDocument();
     expect(screen.getByText("connected")).toBeInTheDocument();
+    expect(screen.getByText("Free edition")).toBeInTheDocument();
+    expect(screen.getByText("Get Pro")).toBeInTheDocument();
     expect(screen.getByText("storefront.yaml")).toBeInTheDocument();
     expect(screen.getByText("Resume at")).toBeInTheDocument();
     expect(screen.getByText("review")).toBeInTheDocument();
@@ -182,6 +199,21 @@ describe("HomePage", () => {
         const method = init?.method ?? "GET";
         if (url.endsWith("/healthz")) {
           return Response.json({ status: "ok" });
+        }
+        if (url.endsWith("/v1/edition")) {
+          return Response.json({
+            edition: "free",
+            plan: "Free",
+            license_state: "missing",
+            enabled_capabilities: [],
+            locked_capabilities: ["ci_reviewops"],
+            customer: null,
+            expires_at: null,
+            grace_expires_at: null,
+            upgrade_url: "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md",
+            message: "Running the MIT Free edition.",
+            extension_errors: [],
+          });
         }
         if (url.endsWith("/v1/projects") && method === "GET") {
           return Response.json({

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import {
   createProject,
   deleteProject,
   duplicateProject,
+  getEditionStatus,
   getHealthStatus,
   listProjects,
 } from "../api";
@@ -49,6 +50,13 @@ export default function HomePage() {
   const healthQuery = useQuery({
     queryKey: ["health", apiBaseUrl],
     queryFn: getHealthStatus,
+    enabled: !requiresApiBase,
+    retry: false,
+  });
+
+  const editionQuery = useQuery({
+    queryKey: ["edition", apiBaseUrl],
+    queryFn: getEditionStatus,
     enabled: !requiresApiBase,
     retry: false,
   });
@@ -114,6 +122,9 @@ export default function HomePage() {
       : apiBaseUrl
         ? "The configured API endpoint is not responding yet. Make sure the deployed backend is reachable and allows cross-origin requests."
         : "This static frontend needs a reachable knives-out API when it is not served by `knives-out serve` on the same origin.";
+  const edition = editionQuery.data;
+  const editionLabel = edition ? `${edition.plan} edition` : "Free edition";
+  const licenseLabel = edition?.edition === "pro" ? edition.license_state : "upgrade available";
 
   return (
     <main className="shell">
@@ -125,6 +136,15 @@ export default function HomePage() {
             Inspect specs, generate attacks, run suites, and triage findings without leaving the
             flow. Everything stays local-first and project-scoped.
           </p>
+          <div className={`edition-badge edition-badge-${edition?.edition ?? "free"}`}>
+            <span>{editionLabel}</span>
+            <strong>{licenseLabel}</strong>
+            {edition?.edition === "pro" ? null : (
+              <a href={edition?.upgrade_url ?? "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md"}>
+                Get Pro
+              </a>
+            )}
+          </div>
         </div>
         <form
           className="hero-create"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -128,6 +128,27 @@ pre {
   color: var(--muted);
 }
 
+.edition-badge {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 18px;
+  padding: 9px 12px;
+  border: 1px solid rgba(13, 108, 99, 0.22);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.edition-badge strong {
+  color: var(--accent-strong);
+}
+
+.edition-badge a {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
 .hero-create,
 .stack,
 .editor-field,
@@ -166,6 +187,7 @@ pre {
 .meta-pill span,
 .field-hint,
 .summary-card span,
+.edition-badge span,
 .status-chip,
 .label {
   text-transform: uppercase;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,6 +3,8 @@ export type ProjectStep = "source" | "inspect" | "generate" | "run" | "review";
 export type ApiJobStatus = "pending" | "running" | "completed" | "failed";
 export type ApiReportFormat = "markdown" | "html";
 export type ProjectReviewBaselineMode = "job" | "external";
+export type EditionKind = "free" | "pro";
+export type LicenseState = "missing" | "valid" | "grace" | "expired" | "invalid";
 export type ArtifactReferenceKind =
   | "request"
   | "workflow_terminal"
@@ -13,6 +15,20 @@ export type ArtifactReferenceKind =
 export interface SourcePayload {
   name: string;
   content: string;
+}
+
+export interface EditionStatus {
+  edition: EditionKind;
+  plan: string;
+  license_state: LicenseState;
+  enabled_capabilities: string[];
+  locked_capabilities: string[];
+  customer?: string | null;
+  expires_at?: string | null;
+  grace_expires_at?: string | null;
+  upgrade_url: string;
+  message: string;
+  extension_errors: string[];
 }
 
 export interface PreflightWarning {

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -26,6 +26,7 @@ from knives_out.api_models import (
     DeltaChangeResponse,
     DiscoverRequest,
     DiscoverResponse,
+    EditionStatus,
     ExportRequest,
     ExportResponse,
     FindingSummaryResponse,
@@ -66,6 +67,7 @@ from knives_out.api_models import (
     VerifyResponse,
 )
 from knives_out.api_store import ActiveJobDeletionError, DeletedJob, JobNotFoundError, JobStore
+from knives_out.extensions import edition_status_for_extensions, register_api_extensions
 from knives_out.models import AttackResult, AttackResults, ResultsSummary
 from knives_out.project_store import ProjectNotFoundError, ProjectStore
 from knives_out.services import (
@@ -582,6 +584,7 @@ def create_app(
     app.state.job_store = JobStore(root)
     app.state.project_store = ProjectStore(root)
     app.state.frontend_dir = frontend_dir or _default_frontend_dir()
+    register_api_extensions(app)
 
     if basic_auth is not None:
         expected_username, expected_password = basic_auth
@@ -601,6 +604,13 @@ def create_app(
     @app.get("/healthz")
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/v1/edition", response_model=EditionStatus)
+    def edition() -> EditionStatus:
+        return edition_status_for_extensions(
+            app.state.knives_out_extensions,
+            extension_errors=app.state.knives_out_extension_errors,
+        )
 
     @app.get("/", include_in_schema=False)
     def root():

--- a/src/knives_out/api_models.py
+++ b/src/knives_out/api_models.py
@@ -37,6 +37,33 @@ class ApiJobStatus(StrEnum):
     failed = "failed"
 
 
+class EditionKind(StrEnum):
+    free = "free"
+    pro = "pro"
+
+
+class LicenseState(StrEnum):
+    missing = "missing"
+    valid = "valid"
+    grace = "grace"
+    expired = "expired"
+    invalid = "invalid"
+
+
+class EditionStatus(BaseModel):
+    edition: EditionKind = EditionKind.free
+    plan: str = "Free"
+    license_state: LicenseState = LicenseState.missing
+    enabled_capabilities: list[str] = Field(default_factory=list)
+    locked_capabilities: list[str] = Field(default_factory=lambda: ["ci_reviewops"])
+    customer: str | None = None
+    expires_at: datetime | None = None
+    grace_expires_at: datetime | None = None
+    upgrade_url: str = "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md"
+    message: str = "Running the MIT Free edition."
+    extension_errors: list[str] = Field(default_factory=list)
+
+
 class ProjectSourceMode(StrEnum):
     openapi = "openapi"
     graphql = "graphql"

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -13,6 +13,11 @@ from rich.table import Table
 from knives_out.api import create_app
 from knives_out.auth_plugins import PluginRuntimeError
 from knives_out.capture import serve_capture_proxy
+from knives_out.extensions import (
+    ExtensionLoadResult,
+    edition_status_for_extensions,
+    register_cli_extensions,
+)
 from knives_out.models import AttackResults, PreflightWarning
 from knives_out.promotion import PromotionError
 from knives_out.reporting import render_markdown_summary
@@ -75,6 +80,9 @@ class InspectFormatOption(StrEnum):
     json = "json"
 
 
+CLI_EXTENSIONS = ExtensionLoadResult(extensions=[], errors=[])
+
+
 def _warning_target(warning: PreflightWarning) -> str:
     if warning.operation_id:
         return f"{warning.operation_id} ({warning.method} {warning.path})"
@@ -117,6 +125,13 @@ def _inspect_payload(
         "warnings": [warning.model_dump(mode="json") for warning in warnings],
         "learned_workflow_count": learned_workflow_count,
     }
+
+
+def _current_edition_status():
+    return edition_status_for_extensions(
+        CLI_EXTENSIONS.extensions,
+        extension_errors=CLI_EXTENSIONS.errors,
+    )
 
 
 def _load_attack_results_or_error(path: Path, *, label: str) -> AttackResults:
@@ -200,6 +215,37 @@ def _print_persisting_delta_findings(findings: list[ComparedFinding]) -> None:
     console.print(table)
     for finding in delta_findings:
         console.print(f"- {finding.result.name}: {finding.delta_summary}")
+
+
+@app.command()
+def edition(
+    format: Annotated[
+        InspectFormatOption,
+        typer.Option(help="Output format for edition status."),
+    ] = InspectFormatOption.text,
+) -> None:
+    """Show the active knives-out edition and enabled capabilities."""
+    status = _current_edition_status()
+    if format == InspectFormatOption.json:
+        typer.echo(json.dumps(status.model_dump(mode="json", exclude_none=True), indent=2))
+        return
+
+    table = Table(title="knives-out edition")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("Edition", status.edition.value)
+    table.add_row("Plan", status.plan)
+    table.add_row("License", status.license_state.value)
+    table.add_row("Enabled capabilities", ", ".join(status.enabled_capabilities) or "-")
+    table.add_row("Locked capabilities", ", ".join(status.locked_capabilities) or "-")
+    if status.customer:
+        table.add_row("Customer", status.customer)
+    if status.expires_at:
+        table.add_row("Expires", status.expires_at.isoformat())
+    if status.grace_expires_at:
+        table.add_row("Grace expires", status.grace_expires_at.isoformat())
+    console.print(table)
+    console.print(status.message)
 
 
 @app.command()
@@ -970,6 +1016,9 @@ def serve(
 
 def main() -> None:
     app()
+
+
+CLI_EXTENSIONS = register_cli_extensions(app)
 
 
 if __name__ == "__main__":

--- a/src/knives_out/extensions.py
+++ b/src/knives_out/extensions.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.metadata import EntryPoint, entry_points
+from inspect import isclass
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from knives_out.api_models import EditionStatus
+
+if TYPE_CHECKING:
+    import typer
+    from fastapi import FastAPI
+
+EXTENSION_ENTRY_POINT_GROUP = "knives_out.extensions"
+
+
+@dataclass(frozen=True)
+class LoadedExtension:
+    name: str
+    plugin: Any
+
+
+@dataclass(frozen=True)
+class ExtensionLoadResult:
+    extensions: list[LoadedExtension]
+    errors: list[str]
+
+
+def _iter_extension_entry_points() -> list[EntryPoint]:
+    discovered = entry_points()
+    if hasattr(discovered, "select"):
+        return list(discovered.select(group=EXTENSION_ENTRY_POINT_GROUP))
+    return list(discovered.get(EXTENSION_ENTRY_POINT_GROUP, []))
+
+
+def _load_extension(entry_point: EntryPoint) -> LoadedExtension:
+    plugin = entry_point.load()
+    has_extension_methods = (
+        hasattr(plugin, "register_api")
+        or hasattr(plugin, "register_cli")
+        or hasattr(plugin, "edition_status")
+    )
+    if isclass(plugin) or (callable(plugin) and not has_extension_methods):
+        plugin = plugin()
+    return LoadedExtension(name=getattr(plugin, "name", entry_point.name), plugin=plugin)
+
+
+def load_extensions() -> ExtensionLoadResult:
+    extensions: list[LoadedExtension] = []
+    errors: list[str] = []
+    for entry_point in _iter_extension_entry_points():
+        try:
+            extensions.append(_load_extension(entry_point))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{entry_point.name}: {exc}")
+    return ExtensionLoadResult(extensions=extensions, errors=errors)
+
+
+def free_edition_status(*, extension_errors: list[str] | None = None) -> EditionStatus:
+    message = "Running the MIT Free edition."
+    if extension_errors:
+        message = "Running the MIT Free edition; one or more extensions failed to load."
+    return EditionStatus(extension_errors=extension_errors or [], message=message)
+
+
+def edition_status_for_extensions(
+    extensions: list[LoadedExtension],
+    *,
+    extension_errors: list[str] | None = None,
+) -> EditionStatus:
+    for extension in extensions:
+        provider = getattr(extension.plugin, "edition_status", None)
+        if not callable(provider):
+            continue
+        try:
+            status = provider()
+        except Exception as exc:  # noqa: BLE001
+            errors = [*(extension_errors or []), f"{extension.name}: {exc}"]
+            return free_edition_status(extension_errors=errors)
+        if status is None:
+            continue
+        try:
+            parsed = EditionStatus.model_validate(status)
+        except ValidationError as exc:
+            errors = [*(extension_errors or []), f"{extension.name}: {exc}"]
+            return free_edition_status(extension_errors=errors)
+        if extension_errors:
+            return parsed.model_copy(
+                update={"extension_errors": [*parsed.extension_errors, *extension_errors]}
+            )
+        return parsed
+    return free_edition_status(extension_errors=extension_errors)
+
+
+def register_api_extensions(app: FastAPI) -> ExtensionLoadResult:
+    loaded = load_extensions()
+    app.state.knives_out_extensions = loaded.extensions
+    app.state.knives_out_extension_errors = loaded.errors
+    for extension in loaded.extensions:
+        register = getattr(extension.plugin, "register_api", None)
+        if not callable(register):
+            continue
+        try:
+            register(app)
+        except Exception as exc:  # noqa: BLE001
+            loaded.errors.append(f"{extension.name}: {exc}")
+    return loaded
+
+
+def register_cli_extensions(app: typer.Typer) -> ExtensionLoadResult:
+    loaded = load_extensions()
+    for extension in loaded.extensions:
+        register = getattr(extension.plugin, "register_cli", None)
+        if not callable(register):
+            continue
+        try:
+            register(app)
+        except Exception as exc:  # noqa: BLE001
+            loaded.errors.append(f"{extension.name}: {exc}")
+    return loaded

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -292,6 +292,62 @@ def test_create_app_uses_env_data_dir_and_healthz_endpoint(tmp_path, monkeypatch
     assert app.state.job_store.root == configured
 
 
+def test_edition_endpoint_defaults_to_free_without_extensions(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    response = client.get("/v1/edition")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["edition"] == "free"
+    assert payload["plan"] == "Free"
+    assert payload["license_state"] == "missing"
+    assert payload["enabled_capabilities"] == []
+    assert "ci_reviewops" in payload["locked_capabilities"]
+
+
+def test_api_extension_can_register_routes_and_edition_status(tmp_path, monkeypatch) -> None:
+    class FakeExtension:
+        name = "fake-pro"
+
+        def edition_status(self):
+            return {
+                "edition": "pro",
+                "plan": "Team",
+                "license_state": "valid",
+                "enabled_capabilities": ["ci_reviewops"],
+                "locked_capabilities": [],
+                "customer": "Example Co",
+                "message": "Pro enabled.",
+            }
+
+        def register_api(self, app):
+            @app.get("/v1/pro/ping")
+            def ping():
+                return {"status": "pro"}
+
+    class FakeEntryPoint:
+        name = "fake-pro"
+
+        def load(self):
+            return FakeExtension
+
+    monkeypatch.setattr(
+        "knives_out.extensions._iter_extension_entry_points",
+        lambda: [FakeEntryPoint()],
+    )
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    edition_response = client.get("/v1/edition")
+    pro_response = client.get("/v1/pro/ping")
+
+    assert edition_response.status_code == 200
+    assert edition_response.json()["edition"] == "pro"
+    assert edition_response.json()["enabled_capabilities"] == ["ci_reviewops"]
+    assert pro_response.status_code == 200
+    assert pro_response.json() == {"status": "pro"}
+
+
 def test_create_app_requires_complete_basic_auth_configuration(monkeypatch) -> None:
     monkeypatch.setenv("KNIVES_OUT_BASIC_AUTH_USERNAME", "demo")
     monkeypatch.delenv("KNIVES_OUT_BASIC_AUTH_PASSWORD", raising=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,17 @@ def _normalized_output(output: str) -> str:
     return re.sub(r"\s+", " ", output).strip()
 
 
+def test_edition_command_prints_free_status() -> None:
+    result = runner.invoke(app, ["edition", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["edition"] == "free"
+    assert payload["license_state"] == "missing"
+    assert payload["enabled_capabilities"] == []
+    assert "ci_reviewops" in payload["locked_capabilities"]
+
+
 def test_inspect_command_runs() -> None:
     result = runner.invoke(app, ["inspect", str(EXAMPLE_SPEC)])
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -5,6 +5,7 @@ README = ROOT / "README.md"
 CI_DOC = ROOT / "docs" / "ci.md"
 ARCHITECTURE_DOC = ROOT / "docs" / "architecture.md"
 ROADMAP_DOC = ROOT / "docs" / "roadmap.md"
+PRO_DOC = ROOT / "docs" / "pro.md"
 DEV_WORKFLOW = ROOT / ".github" / "workflows" / "dev-environment-example.yml"
 SYNC_WIKI_WORKFLOW = ROOT / ".github" / "workflows" / "sync-wiki.yml"
 MAIN_MAINTENANCE_WORKFLOW = ROOT / ".github" / "workflows" / "main-maintenance.yml"
@@ -31,6 +32,7 @@ def test_readme_includes_ci_guidance() -> None:
     assert "knives-out summary results.json --out summary.json" in readme
     assert "knives-out summary results.json --format markdown" in readme
     assert "GITHUB_STEP_SUMMARY" in readme
+    assert "knives-out edition --format json" in readme
     assert "summary.json" in readme
     assert ".knives-out-ignore.yml" in readme
     assert "## Local API" in readme
@@ -43,7 +45,11 @@ def test_readme_includes_ci_guidance() -> None:
     assert "KNIVES_OUT_BASIC_AUTH_USERNAME" in readme
     assert "KNIVES_OUT_BASIC_AUTH_PASSWORD" in readme
     assert "same-origin self-hosted deployment" in readme
+    assert "## Pro and commercial packaging" in readme
+    assert "docs/pro.md" in readme
+    assert "Dockerfile.pro.example" in readme
     assert "POST /v1/inspect" in readme
+    assert "GET /v1/edition" in readme
     assert "POST /v1/summary" in readme
     assert "POST /v1/export" in readme
     assert "POST /v1/runs" in readme
@@ -89,6 +95,26 @@ def test_readme_includes_ci_guidance() -> None:
     assert "**v0.11:** deeper GraphQL coverage" in readme
     assert "Shadow Twin learned-model capture is now" in readme
     assert "available." in readme
+
+
+def test_pro_doc_describes_self_hosted_commercial_surface() -> None:
+    pro_doc = PRO_DOC.read_text(encoding="utf-8")
+    dockerfile = (ROOT / "Dockerfile.pro.example").read_text(encoding="utf-8")
+
+    assert "Knives-Out Pro" in pro_doc
+    assert "CI ReviewOps" in pro_doc
+    assert "knives-out-pro" in pro_doc
+    assert "offline signed license" in pro_doc
+    assert "KNIVES_OUT_LICENSE" in pro_doc
+    assert "KNIVES_OUT_LICENSE_PATH" in pro_doc
+    assert "Ed25519" in pro_doc
+    assert "knives_out.extensions" in pro_doc
+    assert "GET /v1/edition" in pro_doc
+    assert "Pro Team" in pro_doc
+    assert "$299/month" in pro_doc
+    assert "Pro Business" in pro_doc
+    assert "$999/month" in pro_doc
+    assert "knives_out_pro" in dockerfile
 
 
 def test_dev_environment_workflow_matches_current_cli_surface() -> None:


### PR DESCRIPTION
## Summary

- add a Free/Pro edition status model, `/v1/edition`, and `knives-out edition` CLI output
- add a `knives_out.extensions` entry-point loader so a private Pro package can register API routes and CLI commands without changing free behavior
- show the active edition in the workbench and document the self-hosted Pro CI ReviewOps packaging/license contract

## Validation

- `/tmp/knives-out-pro-test-venv/bin/python -m ruff check src tests README.md docs/pro.md`
- `/tmp/knives-out-pro-test-venv/bin/python -m ruff format --check src tests`
- `/tmp/knives-out-pro-test-venv/bin/python -m pytest -q`
- `npm test -- --run`
- `npm run build`
- `git diff --check`

## Notes

- This intentionally adds the public-core extension surface and docs, not proprietary Pro license-validation source inside the MIT repo.
- The private `knives-out-pro` package can now own offline Ed25519 license validation, CI import routes, and GitHub PR publishing.