### PR TITLE
[codex] Add review bundle inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It helps developers break their APIs on purpose before someone else does.
   - [`run`](#run)
   - [`report`](#report)
   - [`bundle`](#bundle)
+  - [`inspect-bundle`](#inspect-bundle)
   - [`export`](#export)
   - [`verify`](#verify)
   - [`promote`](#promote)
@@ -531,7 +532,8 @@ metadata when you also pass `--baseline previous-results.json`.
 When you want to move the exact review inputs into the local workbench, `knives-out bundle
 results.json --artifact-dir artifacts --out review-bundle.zip` packages the current results plus
 optional baseline JSON, suppressions, and artifacts into one zip that the home page can import as
-its own review-only project.
+its own review-only project. `knives-out inspect-bundle review-bundle.zip` validates that zip and
+prints the manifest, included evidence counts, and review defaults before import.
 When you want stateful coverage, generate with `--auto-workflows` first, then add
 `--workflow-pack-module examples/workflow_packs/listed_pet_lookup.py` or your own custom pack as
 you move from generic coverage to app-specific journeys. For protected APIs, keep simple static
@@ -773,6 +775,24 @@ The bundle zip always carries `manifest.json` plus `current/results.json`, and i
 `baseline/results.json`, `review/suppressions.yml`, and `artifacts/**` when you supply those
 inputs. Use **Import review bundle** on the home page to create a new review-only project in the
 workbench.
+
+### `inspect-bundle`
+
+Validates a portable review bundle zip and prints the import-ready manifest details.
+
+```bash
+knives-out inspect-bundle review-bundle.zip
+```
+
+Use JSON output when CI needs to gate or annotate the bundle handoff:
+
+```bash
+knives-out inspect-bundle review-bundle.zip --format json
+```
+
+The command reuses the same bundle validation as workbench import, including manifest version,
+required `current/results.json`, optional baseline and suppressions expectations, artifact path
+safety, and artifact counts.
 
 ### `export`
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -207,6 +207,7 @@ zip bundle after the run finishes:
     knives-out bundle results.json \
       --artifact-dir artifacts \
       --out review-bundle.zip
+    knives-out inspect-bundle review-bundle.zip
     # Optional review context:
     # knives-out bundle results.json \
     #   --baseline previous-results.json \
@@ -228,6 +229,8 @@ The resulting zip has a fixed layout:
 Import that file from the workbench home page with **Import review bundle**. v1 imports are
 review-only on purpose: they materialize one completed `import` job plus project review state so
 the existing review tabs, suppressions editor, run history, and artifact inspection keep working.
+Use `knives-out inspect-bundle review-bundle.zip --format json` when a CI job needs a
+machine-readable validation step before publishing the zip as an artifact.
 
 ## Optional: stateful workflow coverage
 

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -21,6 +21,7 @@ from knives_out.extensions import (
 from knives_out.models import AttackResults, PreflightWarning
 from knives_out.promotion import PromotionError
 from knives_out.reporting import render_markdown_summary
+from knives_out.review_bundles import ReviewBundleInspection, inspect_review_bundle
 from knives_out.services import (
     DEFAULT_SUPPRESSIONS_PATH,
     SuppressionRule,
@@ -216,6 +217,55 @@ def _print_persisting_delta_findings(findings: list[ComparedFinding]) -> None:
     console.print(table)
     for finding in delta_findings:
         console.print(f"- {finding.result.name}: {finding.delta_summary}")
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _print_review_bundle_inspection(inspection: ReviewBundleInspection) -> None:
+    manifest = inspection.manifest
+    table = Table(title="Review bundle")
+    table.add_column("Field")
+    table.add_column("Value", overflow="fold")
+    table.add_row("Name", manifest.name)
+    table.add_row("Base URL", manifest.base_url)
+    table.add_row("Created at", manifest.created_at.isoformat())
+    table.add_row("Executed at", manifest.executed_at.isoformat())
+    table.add_row("Current results", str(inspection.current_result_count))
+    table.add_row(
+        "Baseline results",
+        str(inspection.baseline_result_count)
+        if inspection.baseline_result_count is not None
+        else "none",
+    )
+    table.add_row(
+        "Suppressions",
+        f"yes ({inspection.suppressions_bytes} bytes)"
+        if inspection.suppressions_bytes is not None
+        else "no",
+    )
+    table.add_row("Artifacts", str(inspection.artifact_count))
+    table.add_row(
+        "Review defaults",
+        f"severity >= {manifest.min_severity}, confidence >= {manifest.min_confidence}",
+    )
+    table.add_row("Manifest baseline flag", _yes_no(manifest.includes_baseline))
+    table.add_row("Manifest suppressions flag", _yes_no(manifest.includes_suppressions))
+    table.add_row("Manifest artifacts flag", _yes_no(manifest.includes_artifacts))
+    console.print(table)
+
+    if not inspection.artifact_names:
+        return
+
+    artifacts_table = Table(title=f"Artifacts ({inspection.artifact_count})")
+    artifacts_table.add_column("Path", overflow="fold")
+    for artifact_name in inspection.artifact_names[:20]:
+        artifacts_table.add_row(artifact_name)
+    if inspection.artifact_count > 20:
+        artifacts_table.add_row(f"... {inspection.artifact_count - 20} more")
+    console.print("")
+    console.print(artifacts_table)
 
 
 @app.command()
@@ -725,6 +775,30 @@ def bundle(
     out.write_bytes(bundle_result.content)
     _print_suppression_summary(bundle_result.suppressions_path, bundle_result.suppressions)
     console.print(f"Wrote review bundle to [bold]{out}[/bold].")
+
+
+@app.command()
+def inspect_bundle(
+    bundle: Path,
+    format: Annotated[
+        InspectFormatOption,
+        typer.Option(help="Output format for review bundle inspection."),
+    ] = InspectFormatOption.text,
+) -> None:
+    """Validate and summarize a portable review bundle zip."""
+    try:
+        inspection = inspect_review_bundle(bundle.read_bytes())
+    except OSError as exc:
+        message = exc.strerror or str(exc)
+        raise typer.BadParameter(f"Could not read review bundle '{bundle}': {message}") from exc
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    if format == InspectFormatOption.json:
+        typer.echo(json.dumps(inspection.model_dump(mode="json", exclude_none=True), indent=2))
+        return
+
+    _print_review_bundle_inspection(inspection)
 
 
 @app.command()

--- a/src/knives_out/review_bundles.py
+++ b/src/knives_out/review_bundles.py
@@ -43,6 +43,15 @@ class ReviewBundle:
     artifacts: dict[str, bytes]
 
 
+class ReviewBundleInspection(BaseModel):
+    manifest: ReviewBundleManifest
+    current_result_count: int
+    baseline_result_count: int | None = None
+    suppressions_bytes: int | None = None
+    artifact_count: int = 0
+    artifact_names: list[str] = Field(default_factory=list)
+
+
 def _default_name(name: str | None) -> str:
     return name.strip() if name and name.strip() else "Imported review"
 
@@ -197,6 +206,24 @@ def load_review_bundle(raw: bytes) -> ReviewBundle:
         baseline_results=baseline_results,
         suppressions_yaml=suppressions_yaml,
         artifacts=artifacts,
+    )
+
+
+def inspect_review_bundle(raw: bytes) -> ReviewBundleInspection:
+    bundle = load_review_bundle(raw)
+    return ReviewBundleInspection(
+        manifest=bundle.manifest,
+        current_result_count=len(bundle.current_results.results),
+        baseline_result_count=(
+            len(bundle.baseline_results.results) if bundle.baseline_results is not None else None
+        ),
+        suppressions_bytes=(
+            len(bundle.suppressions_yaml.encode("utf-8"))
+            if bundle.suppressions_yaml is not None
+            else None
+        ),
+        artifact_count=len(bundle.artifacts),
+        artifact_names=sorted(bundle.artifacts),
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2590,3 +2590,131 @@ def test_bundle_command_includes_optional_review_inputs_and_artifacts(
         assert manifest["min_severity"] == "medium"
         assert manifest["min_confidence"] == "low"
         assert "accepted" in archive.read("review/suppressions.yml").decode("utf-8")
+
+
+def test_inspect_bundle_command_prints_review_bundle_summary(tmp_path: Path) -> None:
+    current_results_path = tmp_path / "results.json"
+    baseline_results_path = tmp_path / "baseline.json"
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    (artifact_dir / "atk_secret.json").write_text('{"request":"demo"}', encoding="utf-8")
+    suppressions_path = tmp_path / ".knives-out-ignore.yml"
+    suppressions_path.write_text(
+        dedent(
+            """
+            suppressions:
+              - attack_id: atk_secret
+                reason: accepted
+                owner: api-team
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    _write_results(
+        current_results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_secret",
+                operation_id="getSecret",
+                kind="missing_auth",
+                name="Missing auth",
+                protocol="openapi",
+                method="GET",
+                path="/secret",
+                url="https://example.com/secret",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+    _write_results(baseline_results_path, _results_with_findings())
+    out_path = tmp_path / "review-bundle.zip"
+    bundle_result = runner.invoke(
+        app,
+        [
+            "bundle",
+            str(current_results_path),
+            "--baseline",
+            str(baseline_results_path),
+            "--suppressions",
+            str(suppressions_path),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--name",
+            "Bundle demo",
+            "--min-severity",
+            "medium",
+            "--min-confidence",
+            "low",
+            "--out",
+            str(out_path),
+        ],
+    )
+    assert bundle_result.exit_code == 0
+
+    result = runner.invoke(app, ["inspect-bundle", str(out_path)])
+
+    assert result.exit_code == 0
+    assert "Review bundle" in result.stdout
+    assert "Bundle demo" in result.stdout
+    assert "Base URL" in result.stdout
+    assert "Current results" in result.stdout
+    assert "Baseline results" in result.stdout
+    assert "Review defaults" in result.stdout
+    assert "severity >= medium" in result.stdout
+    assert "confidence >= low" in result.stdout
+    assert "atk_secret.json" in result.stdout
+
+
+def test_inspect_bundle_command_prints_json_summary(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    out_path = tmp_path / "review-bundle.zip"
+    _write_results(
+        results_path,
+        _results_with_findings(
+            AttackResult(
+                attack_id="atk_secret",
+                operation_id="getSecret",
+                kind="missing_auth",
+                name="Missing auth",
+                protocol="openapi",
+                method="GET",
+                path="/secret",
+                url="https://example.com/secret",
+                status_code=500,
+                flagged=True,
+                issue="server_error",
+                severity="high",
+                confidence="high",
+            )
+        ),
+    )
+    bundle_result = runner.invoke(
+        app,
+        ["bundle", str(results_path), "--name", "Bundle demo", "--out", str(out_path)],
+    )
+    assert bundle_result.exit_code == 0
+
+    result = runner.invoke(app, ["inspect-bundle", str(out_path), "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["manifest"]["name"] == "Bundle demo"
+    assert payload["manifest"]["bundle_kind"] == "review"
+    assert payload["current_result_count"] == 1
+    assert payload["artifact_count"] == 0
+    assert payload["artifact_names"] == []
+    assert "baseline_result_count" not in payload
+
+
+def test_inspect_bundle_command_rejects_invalid_archives(tmp_path: Path) -> None:
+    bundle_path = tmp_path / "review-bundle.zip"
+    bundle_path.write_bytes(b"not a zip")
+
+    result = runner.invoke(app, ["inspect-bundle", str(bundle_path)])
+
+    assert result.exit_code == 2
+    assert "Review bundle must be a zip archive." in result.stderr

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -29,6 +29,8 @@ def test_readme_includes_ci_guidance() -> None:
     assert (
         "knives-out bundle results.json --artifact-dir artifacts --out review-bundle.zip" in readme
     )
+    assert "knives-out inspect-bundle review-bundle.zip" in readme
+    assert "knives-out inspect-bundle review-bundle.zip --format json" in readme
     assert "Import review bundle" in readme
     assert "review-only project" in readme
     assert "status, severity, confidence, or schema outcome drifted" in readme
@@ -219,6 +221,8 @@ def test_ci_doc_describes_artifacts_and_optional_gating() -> None:
     assert "GITHUB_STEP_SUMMARY" in ci_doc
     assert "knives-out export results.json --format sarif --out results.sarif" in ci_doc
     assert "knives-out bundle results.json" in ci_doc
+    assert "knives-out inspect-bundle review-bundle.zip" in ci_doc
+    assert "knives-out inspect-bundle review-bundle.zip --format json" in ci_doc
     assert "github/codeql-action/upload-sarif@v4" in ci_doc
     assert "Generate attacks with built-in workflows" in ci_doc
     assert "--tag orders" in ci_doc


### PR DESCRIPTION
## Summary
- add a ReviewBundleInspection helper and inspect-bundle CLI command for review bundle validation
- support text and JSON inspection output with manifest details, result counts, suppressions, and artifact names
- document the command in README and CI handoff guidance

## Issues
Closes #122
Closes #123

## Validation
- `.venv312/bin/python -m ruff check .`
- `.venv312/bin/python -m ruff format --check .`
- `/opt/homebrew/bin/python3.12 -m compileall -q src tests scripts examples`
- `.venv312/bin/python -m pytest tests/test_cli.py tests/test_docs.py tests/test_review_bundles.py`
- `.venv312/bin/python -m pytest --cov=src/knives_out --cov-report=term-missing` (371 passed, 2 warnings, 92% coverage)
- `.venv312/bin/python scripts/check_markdown_links.py README.md docs`
- `.venv312/bin/python scripts/sync_wiki.py render --out-dir /tmp/knives-out-wiki-render-issue-*`