### PR TITLE
[codex] Start Pro CI ReviewOps views

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Route, Routes } from "react-router-dom";
+import CiReviewOpsPage from "./pages/CiReviewOpsPage";
 import HomePage from "./pages/HomePage";
 import ProjectWorkbenchPage from "./pages/ProjectWorkbenchPage";
 
@@ -6,6 +7,7 @@ export default function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/reviewops" element={<CiReviewOpsPage />} />
       <Route path="/projects/:projectId" element={<ProjectWorkbenchPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/pages/CiReviewOpsPage.test.tsx
+++ b/frontend/src/pages/CiReviewOpsPage.test.tsx
@@ -1,0 +1,381 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CiReviewOpsPage from "./CiReviewOpsPage";
+import type {
+  EditionStatus,
+  ProjectJobsResponse,
+  ProjectListResponse,
+  ProjectRecord,
+} from "../types";
+
+function ProjectRoute() {
+  const { projectId } = useParams();
+  return <div>{`Opened ${projectId}`}</div>;
+}
+
+function renderReviewOpsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/reviewops"]}>
+        <Routes>
+          <Route path="/reviewops" element={<CiReviewOpsPage />} />
+          <Route path="/projects/:projectId" element={<ProjectRoute />} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const freeEdition: EditionStatus = {
+  edition: "free",
+  plan: "Free",
+  license_state: "missing",
+  enabled_capabilities: [],
+  locked_capabilities: ["ci_reviewops"],
+  customer: null,
+  expires_at: null,
+  grace_expires_at: null,
+  upgrade_url: "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md",
+  message: "Running the MIT Free edition.",
+  extension_errors: [],
+};
+
+const proEdition: EditionStatus = {
+  edition: "pro",
+  plan: "Pro Team",
+  license_state: "valid",
+  enabled_capabilities: ["ci_reviewops"],
+  locked_capabilities: [],
+  customer: "Demo Co",
+  expires_at: "2026-12-31T00:00:00Z",
+  grace_expires_at: null,
+  upgrade_url: "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md",
+  message: "CI ReviewOps enabled.",
+  extension_errors: [],
+};
+
+const projectListPayload: ProjectListResponse = {
+  projects: [
+    {
+      id: "repo-1",
+      name: "Storefront service",
+      source_mode: "review_bundle",
+      active_step: "review",
+      created_at: "2026-04-20T18:00:00Z",
+      updated_at: "2026-04-20T19:00:00Z",
+      source_name: null,
+      job_count: 2,
+      last_run_job_id: "job-pr-123456",
+      last_run_status: "completed",
+      last_run_at: "2026-04-20T19:00:00Z",
+      active_flagged_count: 3,
+    },
+  ],
+};
+
+const projectPayload: ProjectRecord = {
+  id: "repo-1",
+  name: "Storefront service",
+  source_mode: "review_bundle",
+  active_step: "review",
+  created_at: "2026-04-20T18:00:00Z",
+  updated_at: "2026-04-20T19:00:00Z",
+  graphql_endpoint: "/graphql",
+  source: null,
+  discover_inputs: [],
+  inspect_draft: { tag: [], exclude_tag: [], path: [], exclude_path: [] },
+  generate_draft: {
+    operation: [],
+    exclude_operation: [],
+    method: [],
+    exclude_method: [],
+    kind: [],
+    exclude_kind: [],
+    tag: [],
+    exclude_tag: [],
+    path: [],
+    exclude_path: [],
+    pack_names: [],
+    auto_workflows: false,
+    workflow_pack_names: [],
+  },
+  run_draft: {
+    base_url: "",
+    headers: {},
+    query: {},
+    timeout: 10,
+    store_artifacts: true,
+    auth_plugin_names: [],
+    auth_config_yaml: null,
+    auth_profile_names: [],
+    profile_file_yaml: null,
+    profile_names: [],
+    operation: [],
+    exclude_operation: [],
+    method: [],
+    exclude_method: [],
+    kind: [],
+    exclude_kind: [],
+    tag: [],
+    exclude_tag: [],
+    path: [],
+    exclude_path: [],
+  },
+  review_draft: {
+    baseline_mode: "external",
+    baseline_job_id: null,
+    baseline: {
+      source: "ci",
+      base_url: "https://storefront.example.com",
+      executed_at: "2026-04-20T18:00:00Z",
+      profiles: [],
+      auth_events: [],
+      results: [],
+    },
+    suppressions_yaml: null,
+    min_severity: "high",
+    min_confidence: "medium",
+  },
+  artifacts: {
+    latest_summary: {
+      source: "ci",
+      base_url: "https://storefront.example.com",
+      executed_at: "2026-04-20T19:00:00Z",
+      baseline_used: true,
+      baseline_executed_at: "2026-04-20T18:00:00Z",
+      total_results: 4,
+      profile_count: 0,
+      profile_names: [],
+      active_flagged_count: 3,
+      suppressed_flagged_count: 0,
+      new_findings_count: 1,
+      resolved_findings_count: 1,
+      persisting_findings_count: 2,
+      persisting_deltas_count: 1,
+      auth_failures: 0,
+      refresh_attempts: 0,
+      response_schema_mismatches: 1,
+      graphql_shape_mismatches: 0,
+      protocol_counts: { rest: 4 },
+      issue_counts: { server_error: 2, response_schema_mismatch: 1 },
+      finding_severity_counts: { high: 2, medium: 1 },
+      finding_confidence_counts: { high: 3 },
+      auth_summary: [],
+      top_findings: [],
+    },
+    latest_verification: {
+      passed: false,
+      baseline_used: true,
+      min_severity: "high",
+      min_confidence: "medium",
+      current_findings_count: 3,
+      new_findings_count: 1,
+      resolved_findings_count: 1,
+      persisting_findings_count: 2,
+      suppressed_current_findings_count: 0,
+      current_findings: [],
+      failing_findings: [],
+      new_findings: [
+        {
+          change: "new",
+          attack_id: "atk-login",
+          name: "Login regression",
+          protocol: "rest",
+          kind: "missing_auth",
+          method: "POST",
+          path: "/login",
+          tags: ["auth"],
+          issue: "server_error",
+          severity: "high",
+          confidence: "high",
+          status_code: 500,
+          url: "https://storefront.example.com/login",
+          delta_changes: [],
+        },
+      ],
+      resolved_findings: [
+        {
+          change: "resolved",
+          attack_id: "atk-legacy",
+          name: "Legacy endpoint retired",
+          protocol: "rest",
+          kind: "missing_auth",
+          method: "GET",
+          path: "/legacy",
+          tags: ["legacy"],
+          issue: "server_error",
+          severity: "medium",
+          confidence: "medium",
+          status_code: 404,
+          url: "https://storefront.example.com/legacy",
+          delta_changes: [],
+        },
+      ],
+      persisting_findings: [
+        {
+          change: "persisting",
+          attack_id: "atk-cart",
+          name: "Cart still errors",
+          protocol: "rest",
+          kind: "wrong_type_param",
+          method: "GET",
+          path: "/cart",
+          tags: ["cart"],
+          issue: "server_error",
+          severity: "high",
+          confidence: "high",
+          status_code: 500,
+          url: "https://storefront.example.com/cart",
+          delta_changes: [{ field: "status", baseline: "401", current: "500" }],
+        },
+      ],
+    },
+    latest_results: null,
+    latest_markdown_report: "# report",
+    latest_html_report: "<!doctype html>",
+    last_run_job_id: "job-pr-123456",
+  },
+};
+
+const jobsPayload: ProjectJobsResponse = {
+  project_id: "repo-1",
+  jobs: [
+    {
+      id: "job-pr-123456",
+      kind: "import",
+      status: "completed",
+      created_at: "2026-04-20T19:00:00Z",
+      started_at: "2026-04-20T19:00:01Z",
+      completed_at: "2026-04-20T19:00:05Z",
+      base_url: "https://storefront.example.com",
+      attack_count: 4,
+      project_id: "repo-1",
+      error: null,
+      result_available: true,
+      artifact_names: ["atk-login.json", "atk-cart.json"],
+      result_summary: projectPayload.artifacts.latest_summary,
+    },
+    {
+      id: "job-main-999999",
+      kind: "import",
+      status: "completed",
+      created_at: "2026-04-20T18:00:00Z",
+      started_at: "2026-04-20T18:00:01Z",
+      completed_at: "2026-04-20T18:00:05Z",
+      base_url: "https://storefront.example.com",
+      attack_count: 4,
+      project_id: "repo-1",
+      error: null,
+      result_available: true,
+      artifact_names: ["atk-legacy.json"],
+      result_summary: {
+        ...projectPayload.artifacts.latest_summary!,
+        active_flagged_count: 2,
+        new_findings_count: 0,
+        resolved_findings_count: 0,
+        persisting_findings_count: 0,
+        persisting_deltas_count: 0,
+      },
+    },
+  ],
+};
+
+describe("CiReviewOpsPage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows a locked Pro state without requesting project data in Free edition", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/v1/edition")) {
+        return Response.json(freeEdition);
+      }
+      throw new Error(`Unhandled fetch for ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderReviewOpsPage();
+
+    expect(
+      await screen.findByRole("heading", { name: "Repository and PR comparison views are locked" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Running the MIT Free edition.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open free workbench" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View Pro options" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([input]) => String(input).endsWith("/v1/projects")),
+      ).toBe(false),
+    );
+  });
+
+  it("renders imported repository runs, baseline deltas, and evidence links for Pro", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/v1/edition")) {
+          return Response.json(proEdition);
+        }
+        if (url.endsWith("/v1/projects")) {
+          return Response.json(projectListPayload);
+        }
+        if (url.endsWith("/v1/projects/repo-1")) {
+          return Response.json(projectPayload);
+        }
+        if (url.endsWith("/v1/projects/repo-1/jobs")) {
+          return Response.json(jobsPayload);
+        }
+        throw new Error(`Unhandled fetch for ${url}`);
+      }),
+    );
+
+    renderReviewOpsPage();
+
+    expect(
+      await screen.findByRole("heading", { name: "Repository runs and PR comparisons" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Storefront service/ })).toBeInTheDocument();
+    expect(screen.getByText("Imported CI review bundle")).toBeInTheDocument();
+    expect(await screen.findByText(/External baseline from/)).toBeInTheDocument();
+    expect(screen.getByText("Login regression")).toBeInTheDocument();
+    expect(screen.getByText("Legacy endpoint retired")).toBeInTheDocument();
+    expect(screen.getByText("Cart still errors")).toBeInTheDocument();
+    expect(screen.getByText("status: 401 -> 500")).toBeInTheDocument();
+
+    const comparisonTable = screen
+      .getAllByRole("table")
+      .find((table) => within(table).queryByText("Login regression"));
+    if (!comparisonTable) {
+      throw new Error("Expected comparison table to render.");
+    }
+    expect(within(comparisonTable).getByText("Baseline only")).toBeInTheDocument();
+    const artifactLinks = within(comparisonTable).getAllByRole("link", {
+      name: "Stored artifact",
+    });
+    expect(artifactLinks[0].getAttribute("href")).toContain(
+      "/v1/jobs/job-pr-123456/artifacts/atk-login.json",
+    );
+    const evidenceLinks = within(comparisonTable).getAllByRole("link", {
+      name: "Open evidence",
+    });
+    expect(evidenceLinks[0].getAttribute("href")).toBe(
+      "/projects/repo-1?review=evidence&finding=atk-login",
+    );
+  });
+});

--- a/frontend/src/pages/CiReviewOpsPage.tsx
+++ b/frontend/src/pages/CiReviewOpsPage.tsx
@@ -1,0 +1,617 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import {
+  buildJobArtifactUrl,
+  getEditionStatus,
+  getProject,
+  listProjectJobs,
+  listProjects,
+} from "../api";
+import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
+import ApiConnectionPanel from "../components/ApiConnectionPanel";
+import type {
+  EditionStatus,
+  FindingSummaryResponse,
+  JobStatusResponse,
+  ProjectRecord,
+  ProjectSummaryResponse,
+} from "../types";
+
+const REVIEWOPS_CAPABILITY = "ci_reviewops";
+
+type FindingBucket = "new" | "persisting" | "resolved" | "current";
+
+interface ComparisonFinding {
+  finding: FindingSummaryResponse;
+  bucket: FindingBucket;
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) {
+    return "-";
+  }
+  return new Date(value).toLocaleString();
+}
+
+function shortId(value: string | null | undefined): string {
+  return value ? value.slice(0, 8) : "-";
+}
+
+function jobMoment(job: JobStatusResponse): string {
+  return job.completed_at ?? job.started_at ?? job.created_at;
+}
+
+function jobSortValue(job: JobStatusResponse): number {
+  return new Date(jobMoment(job)).getTime();
+}
+
+function hasReviewOpsAccess(edition: EditionStatus | undefined): boolean {
+  if (!edition) {
+    return false;
+  }
+  return (
+    edition.enabled_capabilities.includes(REVIEWOPS_CAPABILITY) &&
+    !edition.locked_capabilities.includes(REVIEWOPS_CAPABILITY)
+  );
+}
+
+function repositorySubtitle(project: ProjectSummaryResponse): string {
+  if (project.source_mode === "review_bundle") {
+    return "Imported CI review bundle";
+  }
+  return project.source_name ?? `${project.source_mode.replace("_", " ")} project`;
+}
+
+function currentReviewJob(project: ProjectRecord | undefined, jobs: JobStatusResponse[]): JobStatusResponse | null {
+  if (!project) {
+    return null;
+  }
+  const completedJobs = jobs
+    .filter((job) => job.status === "completed" && job.result_available)
+    .sort((a, b) => jobSortValue(b) - jobSortValue(a));
+  return (
+    jobs.find((job) => job.id === project.artifacts.last_run_job_id) ??
+    completedJobs[0] ??
+    null
+  );
+}
+
+function baselineDescription(project: ProjectRecord | undefined, jobs: JobStatusResponse[]): string {
+  if (!project) {
+    return "No repository selected";
+  }
+
+  if (project.review_draft.baseline_mode === "external") {
+    return project.review_draft.baseline
+      ? `External baseline from ${formatDateTime(project.review_draft.baseline.executed_at)}`
+      : "External baseline mode without imported results";
+  }
+
+  if (!project.review_draft.baseline_job_id) {
+    return "No default-branch baseline pinned";
+  }
+
+  const baselineJob = jobs.find((job) => job.id === project.review_draft.baseline_job_id);
+  return baselineJob
+    ? `Run ${shortId(baselineJob.id)} from ${formatDateTime(jobMoment(baselineJob))}`
+    : `Pinned baseline ${shortId(project.review_draft.baseline_job_id)} is not in this repository history`;
+}
+
+function comparisonFindings(project: ProjectRecord | undefined): ComparisonFinding[] {
+  const verification = project?.artifacts.latest_verification;
+  if (!verification) {
+    return [];
+  }
+
+  const rows: ComparisonFinding[] = [];
+  const seen = new Set<string>();
+  const append = (bucket: FindingBucket, findings: FindingSummaryResponse[]) => {
+    for (const finding of findings) {
+      const key = `${bucket}:${finding.attack_id}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      rows.push({ bucket, finding });
+    }
+  };
+
+  append("new", verification.new_findings);
+  append("persisting", verification.persisting_findings);
+  append("resolved", verification.resolved_findings);
+  if (!rows.length) {
+    append("current", verification.current_findings);
+  }
+  return rows.slice(0, 8);
+}
+
+function artifactForFinding(job: JobStatusResponse | null, attackId: string): string | null {
+  if (!job) {
+    return null;
+  }
+  const exact = `${attackId}.json`;
+  return (
+    job.artifact_names.find((artifactName) => artifactName === exact) ??
+    job.artifact_names.find((artifactName) => artifactName.includes(attackId)) ??
+    null
+  );
+}
+
+function safeHttpHref(value: string): string {
+  try {
+    const url = new URL(value, window.location.origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return "#";
+    }
+    return url.href;
+  } catch {
+    return "#";
+  }
+}
+
+function ReviewOpsLockedState({
+  apiBaseUrl,
+  edition,
+  onApplyApiBase,
+}: {
+  apiBaseUrl: string;
+  edition: EditionStatus | undefined;
+  onApplyApiBase: (value: string) => void;
+}) {
+  return (
+    <main className="shell">
+      <section className="panel stack">
+        <div>
+          <p className="eyebrow">Pro CI ReviewOps</p>
+          <h1>Repository and PR comparison views are locked</h1>
+          <p className="hero-body">
+            {edition?.message ??
+              "The API did not report the CI ReviewOps capability. Free workbench projects still work normally."}
+          </p>
+        </div>
+        <div className="summary-card-grid">
+          <div className="summary-card">
+            <span>Edition</span>
+            <strong>{edition ? edition.plan : "Unknown"}</strong>
+          </div>
+          <div className="summary-card">
+            <span>License</span>
+            <strong>{edition?.license_state ?? "unavailable"}</strong>
+          </div>
+          <div className="summary-card">
+            <span>Locked capability</span>
+            <strong>{REVIEWOPS_CAPABILITY}</strong>
+          </div>
+        </div>
+        <div className="action-row">
+          <Link className="secondary-button" to="/">
+            Open free workbench
+          </Link>
+          <a
+            className="primary-button"
+            href={edition?.upgrade_url ?? "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md"}
+          >
+            View Pro options
+          </a>
+        </div>
+      </section>
+      <ApiConnectionPanel
+        apiBaseUrl={apiBaseUrl}
+        description="CI ReviewOps is enabled by the API edition status. Point this UI at a Pro-enabled backend to unlock repository and PR views."
+        onApply={onApplyApiBase}
+        statusLabel="locked"
+        statusTone="idle"
+        title="API edition source"
+      />
+    </main>
+  );
+}
+
+export default function CiReviewOpsPage() {
+  const queryClient = useQueryClient();
+  const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const requiresApiBase = needsConfiguredApiBase(apiBaseUrl);
+
+  const editionQuery = useQuery({
+    queryKey: ["edition", apiBaseUrl],
+    queryFn: getEditionStatus,
+    enabled: !requiresApiBase,
+    retry: false,
+  });
+  const reviewOpsEnabled = hasReviewOpsAccess(editionQuery.data);
+
+  const projectsQuery = useQuery({
+    queryKey: ["projects", apiBaseUrl, "reviewops"],
+    queryFn: listProjects,
+    enabled: reviewOpsEnabled,
+    retry: false,
+  });
+
+  const repositoryProjects = useMemo(
+    () =>
+      (projectsQuery.data?.projects ?? [])
+        .filter((project) => project.job_count > 0 || project.source_mode === "review_bundle")
+        .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()),
+    [projectsQuery.data],
+  );
+
+  useEffect(() => {
+    if (!repositoryProjects.length) {
+      return;
+    }
+    if (selectedProjectId && repositoryProjects.some((project) => project.id === selectedProjectId)) {
+      return;
+    }
+    setSelectedProjectId(repositoryProjects[0].id);
+  }, [repositoryProjects, selectedProjectId]);
+
+  const projectQuery = useQuery({
+    queryKey: ["project", selectedProjectId, apiBaseUrl, "reviewops"],
+    queryFn: () => getProject(selectedProjectId!),
+    enabled: reviewOpsEnabled && Boolean(selectedProjectId),
+    retry: false,
+  });
+
+  const jobsQuery = useQuery({
+    queryKey: ["projectJobs", selectedProjectId, apiBaseUrl, "reviewops"],
+    queryFn: () => listProjectJobs(selectedProjectId!),
+    enabled: reviewOpsEnabled && Boolean(selectedProjectId),
+    retry: false,
+  });
+
+  function applyApiBase(nextValue: string) {
+    const normalized = persistApiBaseUrl(nextValue);
+    setApiBaseUrl(normalized);
+    setSelectedProjectId(null);
+    void queryClient.invalidateQueries();
+  }
+
+  if (requiresApiBase) {
+    return (
+      <main className="shell">
+        <section className="panel stack">
+          <div>
+            <p className="eyebrow">Pro CI ReviewOps</p>
+            <h1>Connect a Pro-enabled API</h1>
+            <p className="hero-body">
+              The static workbench shell needs a reachable API before it can inspect edition status
+              or load repository run history.
+            </p>
+          </div>
+          <ApiConnectionPanel
+            apiBaseUrl={apiBaseUrl}
+            description="Repository views, branch baselines, and PR comparisons are served by the configured API backend."
+            onApply={applyApiBase}
+            statusLabel="configure API"
+            statusTone="idle"
+            title="ReviewOps API endpoint"
+          />
+          <Link className="ghost-button" to="/">
+            Back to projects
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
+  if (editionQuery.isLoading) {
+    return (
+      <main className="shell">
+        <section className="panel">
+          <p className="empty-copy">Checking CI ReviewOps access...</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (editionQuery.isError || !reviewOpsEnabled) {
+    return (
+      <ReviewOpsLockedState
+        apiBaseUrl={apiBaseUrl}
+        edition={editionQuery.data}
+        onApplyApiBase={applyApiBase}
+      />
+    );
+  }
+
+  const edition = editionQuery.data;
+  const selectedProject = projectQuery.data;
+  const jobs = jobsQuery.data?.jobs ?? [];
+  const currentJob = currentReviewJob(selectedProject, jobs);
+  const comparisonRows = comparisonFindings(selectedProject);
+  const summary = selectedProject?.artifacts.latest_summary;
+  const verification = selectedProject?.artifacts.latest_verification;
+  const latestRunLabel = currentJob
+    ? `Run ${shortId(currentJob.id)} from ${formatDateTime(jobMoment(currentJob))}`
+    : "No imported run selected";
+  const baselineLabel = baselineDescription(selectedProject, jobs);
+  const proError =
+    projectsQuery.error instanceof Error
+      ? projectsQuery.error.message
+      : projectQuery.error instanceof Error
+        ? projectQuery.error.message
+        : jobsQuery.error instanceof Error
+          ? jobsQuery.error.message
+          : null;
+
+  return (
+    <main className="shell">
+      <section className="hero-panel reviewops-hero">
+        <div className="hero-copy">
+          <p className="eyebrow">Pro CI ReviewOps</p>
+          <h1>Repository runs and PR comparisons</h1>
+          <p className="hero-body">
+            Review imported CI runs, pin branch baselines, and inspect pull request deltas with
+            links back to stored evidence.
+          </p>
+          <div className="edition-badge edition-badge-pro">
+            <span>{edition?.plan ?? "Pro"} edition</span>
+            <strong>{edition?.license_state ?? "valid"}</strong>
+          </div>
+        </div>
+        <div className="reviewops-snapshot" aria-label="CI ReviewOps snapshot">
+          <div>
+            <span>Repositories</span>
+            <strong>{repositoryProjects.length}</strong>
+          </div>
+          <div>
+            <span>Imported runs</span>
+            <strong>
+              {repositoryProjects.reduce((total, project) => total + project.job_count, 0)}
+            </strong>
+          </div>
+          <div>
+            <span>Active findings</span>
+            <strong>
+              {repositoryProjects.reduce(
+                (total, project) => total + (project.active_flagged_count ?? 0),
+                0,
+              )}
+            </strong>
+          </div>
+        </div>
+      </section>
+
+      {proError ? <div className="error-banner">{proError}</div> : null}
+
+      <section className="reviewops-layout">
+        <aside className="sidebar-panel stack" aria-label="Repositories">
+          <div>
+            <p className="eyebrow">Repository view</p>
+            <h2>Imported CI runs</h2>
+          </div>
+          {projectsQuery.isLoading ? <p className="empty-copy">Loading repositories...</p> : null}
+          {!projectsQuery.isLoading && !repositoryProjects.length ? (
+            <div className="empty-state">
+              <p>No imported CI runs are available yet.</p>
+              <p>Publish or import a review bundle to populate the Pro workbench.</p>
+            </div>
+          ) : null}
+          <div className="reviewops-repository-list">
+            {repositoryProjects.map((project) => (
+              <button
+                className={`reviewops-repository-button${
+                  project.id === selectedProjectId ? " reviewops-repository-button-active" : ""
+                }`}
+                key={project.id}
+                onClick={() => setSelectedProjectId(project.id)}
+                type="button"
+              >
+                <strong>{project.name}</strong>
+                <span>{repositorySubtitle(project)}</span>
+                <small>
+                  {project.job_count} run{project.job_count === 1 ? "" : "s"} /{" "}
+                  {project.active_flagged_count ?? 0} active
+                </small>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <div className="stack">
+          <section className="panel stack">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Branch baseline state</p>
+                <h2>{selectedProject?.name ?? "Select a repository"}</h2>
+              </div>
+              {selectedProject ? (
+                <Link className="secondary-button" to={`/projects/${selectedProject.id}`}>
+                  Open workbench
+                </Link>
+              ) : null}
+            </div>
+
+            {projectQuery.isLoading || jobsQuery.isLoading ? (
+              <p className="empty-copy">Loading repository details...</p>
+            ) : null}
+
+            {selectedProject ? (
+              <>
+                <div className="summary-card-grid">
+                  <div className="summary-card">
+                    <span>Latest imported run</span>
+                    <strong>{latestRunLabel}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>Default branch baseline</span>
+                    <strong>{baselineLabel}</strong>
+                  </div>
+                  <div className="summary-card">
+                    <span>Baseline deltas</span>
+                    <strong>{summary?.persisting_deltas_count ?? 0}</strong>
+                  </div>
+                </div>
+
+                <ReviewOpsRunTable jobs={jobs} />
+              </>
+            ) : null}
+          </section>
+
+          <section className="panel stack">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Pull request comparison</p>
+                <h2>New, resolved, and persisting findings</h2>
+              </div>
+              <div className={`status-chip status-${verification?.passed ? "completed" : "failed"}`}>
+                {verification ? (verification.passed ? "policy passed" : "policy failed") : "no policy"}
+              </div>
+            </div>
+
+            <div className="compare-banner">
+              <div className="compare-card">
+                <span>New</span>
+                <strong>{summary?.new_findings_count ?? 0}</strong>
+              </div>
+              <div className="compare-card">
+                <span>Resolved</span>
+                <strong>{summary?.resolved_findings_count ?? 0}</strong>
+              </div>
+              <div className="compare-card">
+                <span>Persisting</span>
+                <strong>{summary?.persisting_findings_count ?? 0}</strong>
+              </div>
+            </div>
+
+            <ReviewOpsFindingsTable
+              currentJob={currentJob}
+              findings={comparisonRows}
+              projectId={selectedProject?.id ?? null}
+            />
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function ReviewOpsRunTable({ jobs }: { jobs: JobStatusResponse[] }) {
+  const sortedJobs = [...jobs].sort((a, b) => jobSortValue(b) - jobSortValue(a));
+  return (
+    <div className="table-shell">
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>Run</th>
+            <th>Status</th>
+            <th>Target</th>
+            <th>Findings</th>
+            <th>Artifacts</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedJobs.length ? (
+            sortedJobs.map((job) => (
+              <tr key={job.id}>
+                <td>
+                  <strong>{shortId(job.id)}</strong>
+                  <br />
+                  <small>{formatDateTime(jobMoment(job))}</small>
+                </td>
+                <td>{job.status}</td>
+                <td>{job.base_url || "-"}</td>
+                <td>{job.result_summary?.active_flagged_count ?? "-"}</td>
+                <td>{job.artifact_names.length}</td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td className="table-empty" colSpan={5}>
+                No imported runs are stored for this repository.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ReviewOpsFindingsTable({
+  currentJob,
+  findings,
+  projectId,
+}: {
+  currentJob: JobStatusResponse | null;
+  findings: ComparisonFinding[];
+  projectId: string | null;
+}) {
+  return (
+    <div className="table-shell">
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>Change</th>
+            <th>Finding</th>
+            <th>Delta</th>
+            <th>Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {findings.length ? (
+            findings.map(({ bucket, finding }) => {
+              const artifactName = bucket === "resolved" ? null : artifactForFinding(currentJob, finding.attack_id);
+              const evidencePath = projectId
+                ? `/projects/${encodeURIComponent(projectId)}?review=evidence&finding=${encodeURIComponent(finding.attack_id)}`
+                : null;
+              const artifactHref =
+                artifactName && currentJob
+                  ? safeHttpHref(buildJobArtifactUrl(currentJob.id, artifactName))
+                  : null;
+              return (
+                <tr key={`${bucket}-${finding.attack_id}`}>
+                  <td>
+                    <span className={`status-chip reviewops-change-${bucket}`}>{bucket}</span>
+                  </td>
+                  <td>
+                    <strong>{finding.name}</strong>
+                    <br />
+                    <small>
+                      {finding.method} {finding.path ?? "-"} / {finding.issue ?? "finding"}
+                    </small>
+                  </td>
+                  <td>
+                    {finding.delta_changes.length ? (
+                      <ul className="reviewops-delta-list">
+                        {finding.delta_changes.map((delta) => (
+                          <li key={`${finding.attack_id}-${delta.field}`}>
+                            {`${delta.field}: ${delta.baseline} -> ${delta.current}`}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td>
+                    <div className="reviewops-evidence-links">
+                      {evidencePath ? (
+                        <Link to={evidencePath}>Open evidence</Link>
+                      ) : null}
+                      {artifactHref ? (
+                        <a href={artifactHref} rel="noreferrer" target="_blank">
+                          Stored artifact
+                        </a>
+                      ) : (
+                        <span>{bucket === "resolved" ? "Baseline only" : "No stored artifact"}</span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })
+          ) : (
+            <tr>
+              <td className="table-empty" colSpan={4}>
+                No PR comparison findings are available for this repository.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -240,6 +240,9 @@ export default function HomePage() {
             >
               {importReviewBundleMutation.isPending ? "Importing…" : "Import review bundle"}
             </button>
+            <Link className="secondary-button" to="/reviewops">
+              CI ReviewOps
+            </Link>
           </div>
         </form>
       </section>

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -505,7 +505,7 @@ function createEvidenceResponse(attackId: string) {
   };
 }
 
-function renderWorkbench() {
+function renderWorkbench(initialEntry = "/projects/project-1") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -514,7 +514,7 @@ function renderWorkbench() {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/projects/project-1"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route path="/projects/:projectId" element={<ProjectWorkbenchPage />} />
         </Routes>
@@ -1037,6 +1037,16 @@ describe("ProjectWorkbenchPage", () => {
     expect((await screen.findAllByText("member-login")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/https:\/\/example.com\/login/)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/server exploded/)).length).toBeGreaterThan(0);
+  });
+
+  it("opens the evidence drawer from ReviewOps deep links", async () => {
+    renderWorkbench("/projects/project-1?review=evidence&finding=atk-login");
+
+    expect(await screen.findByRole("heading", { name: "Workbench demo" })).toBeInTheDocument();
+    expect(await screen.findByText("Current-run evidence")).toBeInTheDocument();
+    expect(await screen.findByText("Workflow terminal artifact")).toBeInTheDocument();
+    expect((await screen.findAllByText("Login failure")).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Close evidence" })).toBeInTheDocument();
   });
 
   it("keeps resolved findings summary-only and reuses the artifact viewer in the artifacts tab", async () => {

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { getApiBaseUrl, needsConfiguredApiBase, persistApiBaseUrl } from "../apiConfig";
 import ApiConnectionPanel from "../components/ApiConnectionPanel";
 import CodeEditor from "../components/CodeEditor";
@@ -578,6 +578,7 @@ export default function ProjectWorkbenchPage() {
   const { projectId } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [draft, setDraft] = useState<ProjectRecord | null>(null);
   const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
   const [hasPendingSave, setHasPendingSave] = useState(false);
@@ -613,6 +614,8 @@ export default function ProjectWorkbenchPage() {
   const syncedJobIdRef = useRef<string | null>(null);
   const deferredReviewFilter = useDeferredValue(reviewFilter.trim().toLowerCase());
   const requiresApiBase = needsConfiguredApiBase(apiBaseUrl);
+  const deepLinkedReviewTask = searchParams.get("review");
+  const deepLinkedFindingId = searchParams.get("finding")?.trim() || null;
 
   const projectQuery = useQuery({
     queryKey: ["project", projectId, apiBaseUrl],
@@ -810,8 +813,7 @@ export default function ProjectWorkbenchPage() {
     if (currentFindingIds.has(selectedEvidenceAttackId)) {
       return;
     }
-    setSelectedEvidenceAttackId(null);
-    setSelectedDrawerArtifactName(null);
+    closeFindingEvidence();
     setEvidenceNotice("Evidence changed with the latest run. Reopen a finding from the refreshed comparison.");
   }, [draft?.artifacts.latest_verification, selectedEvidenceAttackId]);
 
@@ -859,6 +861,37 @@ export default function ProjectWorkbenchPage() {
       setReviewTab("overview");
     }
   }, [draft?.source_mode, reviewTab]);
+
+  useEffect(() => {
+    if (!draft || deepLinkedReviewTask !== "evidence") {
+      return;
+    }
+
+    if (draft.active_step !== "review") {
+      setDraft((current) => (current ? { ...current, active_step: "review" } : current));
+    }
+    setReviewTask("evidence");
+
+    if (!deepLinkedFindingId) {
+      return;
+    }
+
+    const currentFindingIds = new Set(
+      draft.artifacts.latest_verification?.current_findings.map((finding) => finding.attack_id) ?? [],
+    );
+    if (!currentFindingIds.has(deepLinkedFindingId)) {
+      setSelectedEvidenceAttackId(null);
+      setSelectedDrawerArtifactName(null);
+      setEvidenceNotice(
+        `Finding ${deepLinkedFindingId} is not available in the current compared run.`,
+      );
+      return;
+    }
+
+    setSelectedEvidenceAttackId(deepLinkedFindingId);
+    setSelectedDrawerArtifactName(null);
+    setEvidenceNotice(null);
+  }, [deepLinkedFindingId, deepLinkedReviewTask, draft]);
 
   if (!projectId) {
     return (
@@ -1205,6 +1238,23 @@ export default function ProjectWorkbenchPage() {
     setSelectedEvidenceAttackId(finding.attack_id);
     setSelectedDrawerArtifactName(null);
     setEvidenceNotice(null);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("finding");
+    if (nextParams.get("review") === "evidence") {
+      nextParams.delete("review");
+    }
+    setSearchParams(nextParams, { replace: true });
+  }
+
+  function closeFindingEvidence() {
+    setSelectedEvidenceAttackId(null);
+    setSelectedDrawerArtifactName(null);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("finding");
+    if (nextParams.get("review") === "evidence") {
+      nextParams.delete("review");
+    }
+    setSearchParams(nextParams, { replace: true });
   }
 
   function findingAction(label: string, finding: { attack_id: string }) {
@@ -2708,10 +2758,7 @@ export default function ProjectWorkbenchPage() {
                   </div>
                   <button
                     className="secondary-button"
-                    onClick={() => {
-                      setSelectedEvidenceAttackId(null);
-                      setSelectedDrawerArtifactName(null);
-                    }}
+                    onClick={closeFindingEvidence}
                     type="button"
                   >
                     Close evidence

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -617,6 +617,113 @@ pre {
   font-size: 1.05rem;
 }
 
+.reviewops-hero {
+  margin-bottom: 22px;
+}
+
+.reviewops-snapshot {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  align-self: end;
+}
+
+.reviewops-snapshot div {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid rgba(13, 108, 99, 0.18);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.reviewops-snapshot span,
+.reviewops-delta-list,
+.reviewops-evidence-links span {
+  color: var(--muted);
+}
+
+.reviewops-snapshot span {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.reviewops-snapshot strong {
+  font-size: 2rem;
+}
+
+.reviewops-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.reviewops-layout .summary-card strong {
+  font-size: 1rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.reviewops-repository-list {
+  display: grid;
+  gap: 10px;
+}
+
+.reviewops-repository-button {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  padding: 14px;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.64);
+  cursor: pointer;
+}
+
+.reviewops-repository-button span,
+.reviewops-repository-button small {
+  color: var(--muted);
+}
+
+.reviewops-repository-button-active {
+  border-color: rgba(0, 127, 109, 0.42);
+  background: rgba(0, 127, 109, 0.1);
+  color: var(--accent-strong);
+}
+
+.reviewops-delta-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.reviewops-evidence-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.reviewops-evidence-links a {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.reviewops-change-new {
+  color: var(--danger);
+}
+
+.reviewops-change-persisting {
+  color: var(--warning);
+}
+
+.reviewops-change-resolved,
+.reviewops-change-current {
+  color: var(--accent-strong);
+}
+
 .advanced-panel {
   margin: 18px 0;
   padding: 14px;
@@ -890,6 +997,8 @@ pre {
   .field-grid-3,
   .field-grid-2,
   .source-choice-grid,
+  .reviewops-layout,
+  .reviewops-snapshot,
   .artifact-viewer,
   .report-grid,
   .compare-banner {


### PR DESCRIPTION
## Summary

- add a guarded `/reviewops` React route for the Pro CI ReviewOps workbench
- render a locked Free-edition state when `ci_reviewops` is unavailable, without calling project/job APIs
- render Pro repository run history, branch baseline state, PR comparison counts, delta rows, and evidence/artifact links from existing imported project/job data
- hydrate workbench evidence drawers from ReviewOps evidence deep links so `Open evidence` lands on the matching current finding
- add frontend coverage for locked Free behavior, enabled Pro fixture runs, and evidence deep-link hydration

Refs #119.

## Validation

- `npm run build`
- `npm test -- --run ProjectWorkbenchPage.test.tsx CiReviewOpsPage.test.tsx`
- `npm test -- --run`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest --cov=src/knives_out --cov-report=term-missing` (92% total coverage)
- `git diff --check`

## Notes

This is the first public React-native slice for #119. It intentionally uses the existing project/job/review contracts so the view works against imported fixture runs now and can be wired to proprietary CI ReviewOps endpoints later.