### PR TITLE
[codex] Recover maintenance coverage gate

### DIFF
--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -33,6 +33,22 @@ def test_load_auth_profiles_reads_named_profiles(tmp_path: Path) -> None:
     assert profiles_file.profiles[1].headers["Authorization"] == "Bearer admin"
 
 
+def test_load_auth_profiles_rejects_top_level_sequences(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profiles.yml"
+    profile_path.write_text("- name: user\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="top-level mapping"):
+        load_auth_profiles(profile_path)
+
+
+def test_load_auth_profiles_reports_schema_errors(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profiles.yml"
+    profile_path.write_text("profiles:\n  - {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Field required"):
+        load_auth_profiles(profile_path)
+
+
 def test_select_auth_profiles_filters_named_profiles(tmp_path: Path) -> None:
     profile_path = tmp_path / "profiles.yml"
     profile_path.write_text(

--- a/tests/test_spec_loader.py
+++ b/tests/test_spec_loader.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from knives_out.spec_loader import is_graphql_schema_path, is_learned_model_path
+
+
+def test_is_learned_model_path_returns_false_for_invalid_json(tmp_path: Path) -> None:
+    model_path = tmp_path / "model.json"
+    model_path.write_text("{", encoding="utf-8")
+
+    assert is_learned_model_path(model_path) is False
+
+
+def test_is_graphql_schema_path_detects_top_level_introspection_json(tmp_path: Path) -> None:
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text('{"__schema": {}}', encoding="utf-8")
+
+    assert is_graphql_schema_path(schema_path) is True
+
+
+def test_is_graphql_schema_path_rejects_non_mapping_json(tmp_path: Path) -> None:
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("[]", encoding="utf-8")
+
+    assert is_graphql_schema_path(schema_path) is False


### PR DESCRIPTION
## Summary

- add focused profile loader validation coverage for malformed YAML and schema errors
- add spec router coverage for invalid JSON and top-level GraphQL introspection JSON
- keep the main-maintenance coverage-drop gate intact after PR #127 lowered coverage from 91.88% to 91.85%

## Validation

- `python3.12 -m compileall -q src tests scripts examples`
- `npm ci --prefer-offline`
- `npm run build`
- `npm test -- --run`
- `git diff --check HEAD~1..HEAD`

## Notes

Local Python dependency installation is blocked by PyPI DNS in this sandbox, so full pytest/coverage validation is left to hosted CI. Local Docker build also hung after a Docker Desktop credential log-permission warning; the hosted container job on the current main commit had already passed.