### PR TITLE
[codex] add project snapshot portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,9 @@ When you need to hand CI evidence to the local review UX, export a portable revi
 CLI and import the zip on the home page. v1 imports are intentionally review-only: the workbench
 recomputes summary, verification, and reports from bundled `results.json`, optional baseline JSON,
 optional suppressions YAML, and optional request/response artifacts.
+For full local project moves, the API can also export and import project snapshots that include
+the saved source, drafts, cached generated suite, project-scoped job history, stored results, and
+artifacts.
 
 ## Local API
 
@@ -404,6 +407,8 @@ The web workbench also uses project resources for saved drafts and project-scope
 - `PATCH /v1/projects/{id}`
 - `DELETE /v1/projects/{id}`
 - `POST /v1/projects/import-review-bundle`
+- `POST /v1/projects/import-snapshot`
+- `GET /v1/projects/{id}/snapshot`
 - `GET /v1/projects/{id}/jobs`
 - `POST /v1/projects/{id}/review`
 - `DELETE /v1/projects/{id}/jobs/{job_id}`
@@ -413,6 +418,10 @@ The web workbench also uses project resources for saved drafts and project-scope
 workbench uses. It always reviews the latest completed run with stored results in that project as
 the current run, accepts an optional `baseline_job_id` from the same project, and only falls back
 to external baseline JSON when the review draft switches to external baseline mode.
+`GET /v1/projects/{id}/snapshot` returns a portable zip for the saved project and its
+project-scoped run history. `POST /v1/projects/import-snapshot` imports that archive as a new
+project and remaps project/job IDs so the snapshot can be restored into the same data directory or
+another local workbench without collisions.
 
 The API accepts uploaded source content and JSON artifacts in the request body. It does not expose
 arbitrary server-side file reads. FastAPI also publishes the schema at `/openapi.json` and the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,7 @@ src/knives_out/
   api.py             # FastAPI entrypoint and route wiring
   api_models.py      # HTTP request/response models
   api_store.py       # Filesystem-backed API job/artifact persistence
+  project_snapshots.py  # Portable saved-project snapshot archives
   capture.py         # Reverse-proxy capture and NDJSON helpers
   learned_discovery.py  # Capture/HAR inference into learned models
   learned_loader.py  # Learned-model loading

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,6 +49,7 @@ The next portability step is to move beyond review-only handoff and allow rerunn
 snapshots:
 
 - export and import full saved-project snapshots instead of only review evidence
+- ship the first local API snapshot round trip with project/job ID remapping
 - preserve source documents, learned inputs, inspect/generate/run drafts, and reusable suites
 - keep imported snapshots runnable after they land in the workbench
 - support safe duplication and promotion on imported snapshots because the suite is present

--- a/src/knives_out/api.py
+++ b/src/knives_out/api.py
@@ -12,7 +12,7 @@ from secrets import compare_digest
 from typing import Annotated
 
 import yaml
-from fastapi import FastAPI, File, HTTPException, Query, Request, UploadFile
+from fastapi import FastAPI, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, RedirectResponse
 
@@ -70,6 +70,13 @@ from knives_out.api_models import (
 from knives_out.api_store import ActiveJobDeletionError, DeletedJob, JobNotFoundError, JobStore
 from knives_out.extensions import edition_status_for_extensions, register_api_extensions
 from knives_out.models import AttackResult, AttackResults, ResultsSummary
+from knives_out.project_snapshots import (
+    import_project_snapshot as import_project_snapshot_archive,
+)
+from knives_out.project_snapshots import (
+    load_project_snapshot,
+    render_project_snapshot,
+)
 from knives_out.project_store import ProjectNotFoundError, ProjectStore
 from knives_out.review_bundles import load_review_bundle, write_review_bundle_artifacts
 from knives_out.services import (
@@ -807,6 +814,37 @@ def create_app(
         return project_store.update_project(
             _project_with_review_refresh(project, review, review_draft=review_draft)
         )
+
+    @app.get("/v1/projects/{project_id}/snapshot")
+    def export_project_snapshot(project_id: str) -> Response:
+        project_store: ProjectStore = app.state.project_store
+        job_store: JobStore = app.state.job_store
+        try:
+            content = render_project_snapshot(project_store, job_store, project_id)
+        except ProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+        return Response(
+            content=content,
+            media_type="application/zip",
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="knives-out-project-{project_id}.zip"'
+                ),
+            },
+        )
+
+    @app.post("/v1/projects/import-snapshot", response_model=ProjectRecord)
+    async def import_project_snapshot(
+        snapshot: Annotated[UploadFile, File(description="Portable project snapshot zip.")],
+    ) -> ProjectRecord:
+        project_store: ProjectStore = app.state.project_store
+        job_store: JobStore = app.state.job_store
+        try:
+            loaded = load_project_snapshot(await snapshot.read())
+            return import_project_snapshot_archive(project_store, job_store, loaded)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @app.post("/v1/projects/{project_id}/duplicate", response_model=ProjectRecord)
     def duplicate_project(

--- a/src/knives_out/project_snapshots.py
+++ b/src/knives_out/project_snapshots.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from io import BytesIO
+from pathlib import PurePosixPath
+from uuid import uuid4
+from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile
+
+from pydantic import BaseModel, Field, ValidationError
+
+from knives_out.api_models import JobRecord, ProjectRecord
+from knives_out.api_store import JobStore
+from knives_out.models import AttackResults
+from knives_out.project_store import ProjectStore
+
+PROJECT_SNAPSHOT_KIND = "project_snapshot"
+PROJECT_SNAPSHOT_VERSION = 1
+MANIFEST_PATH = "manifest.json"
+PROJECT_PATH = "project/project.json"
+JOBS_PREFIX = "jobs"
+JOB_RECORD_NAME = "job.json"
+JOB_RESULT_NAME = "result.json"
+JOB_ARTIFACTS_SEGMENT = "artifacts"
+
+
+class ProjectSnapshotManifest(BaseModel):
+    snapshot_kind: str = PROJECT_SNAPSHOT_KIND
+    snapshot_version: int = PROJECT_SNAPSHOT_VERSION
+    name: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    project_id: str
+    source_mode: str
+    job_count: int = 0
+    result_count: int = 0
+    artifact_count: int = 0
+
+
+@dataclass(frozen=True)
+class ProjectSnapshotJob:
+    record: JobRecord
+    result: AttackResults | None
+    artifacts: dict[str, bytes]
+
+
+@dataclass(frozen=True)
+class ProjectSnapshot:
+    manifest: ProjectSnapshotManifest
+    project: ProjectRecord
+    jobs: list[ProjectSnapshotJob]
+
+
+def _safe_member_name(name: str) -> str:
+    if not name:
+        raise ValueError("Project snapshot contains an empty member path.")
+    path = PurePosixPath(name)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"Project snapshot contains unsafe path {name!r}.")
+    return path.as_posix()
+
+
+def _validate_manifest(manifest: ProjectSnapshotManifest) -> None:
+    if manifest.snapshot_kind != PROJECT_SNAPSHOT_KIND:
+        raise ValueError(f"Unsupported project snapshot kind {manifest.snapshot_kind!r}.")
+    if manifest.snapshot_version != PROJECT_SNAPSHOT_VERSION:
+        raise ValueError(
+            f"Unsupported project snapshot version {manifest.snapshot_version}; "
+            f"expected {PROJECT_SNAPSHOT_VERSION}."
+        )
+
+
+def _job_member_parts(name: str) -> tuple[str, ...]:
+    return PurePosixPath(name).parts
+
+
+def _job_record_path(job_id: str) -> str:
+    return f"{JOBS_PREFIX}/{job_id}/{JOB_RECORD_NAME}"
+
+
+def _job_result_path(job_id: str) -> str:
+    return f"{JOBS_PREFIX}/{job_id}/{JOB_RESULT_NAME}"
+
+
+def _job_artifact_path(job_id: str, artifact_name: str) -> str:
+    return f"{JOBS_PREFIX}/{job_id}/{JOB_ARTIFACTS_SEGMENT}/{_safe_member_name(artifact_name)}"
+
+
+def render_project_snapshot(
+    project_store: ProjectStore,
+    job_store: JobStore,
+    project_id: str,
+) -> bytes:
+    project = project_store.load_project(project_id)
+    jobs = [record for record in job_store.list_job_records() if record.project_id == project.id]
+    result_count = sum(1 for record in jobs if job_store.result_exists(record.id))
+    artifact_count = sum(len(job_store.list_artifacts(record.id)) for record in jobs)
+    manifest = ProjectSnapshotManifest(
+        name=project.name,
+        project_id=project.id,
+        source_mode=project.source_mode.value,
+        job_count=len(jobs),
+        result_count=result_count,
+        artifact_count=artifact_count,
+    )
+
+    stream = BytesIO()
+    with ZipFile(stream, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr(MANIFEST_PATH, manifest.model_dump_json(indent=2, exclude_none=True))
+        archive.writestr(PROJECT_PATH, project.model_dump_json(indent=2, exclude_none=True))
+        for record in jobs:
+            archive.writestr(
+                _job_record_path(record.id),
+                record.model_dump_json(indent=2, exclude_none=True),
+            )
+            if job_store.result_exists(record.id):
+                archive.writestr(
+                    _job_result_path(record.id),
+                    job_store.load_result(record.id).model_dump_json(
+                        indent=2,
+                        exclude_none=True,
+                    ),
+                )
+            for artifact_name in job_store.list_artifacts(record.id):
+                archive.writestr(
+                    _job_artifact_path(record.id, artifact_name),
+                    job_store.artifact_path_for_name(record.id, artifact_name).read_bytes(),
+                )
+    return stream.getvalue()
+
+
+def _load_members(raw: bytes) -> dict[str, bytes]:
+    if not raw:
+        raise ValueError("Project snapshot is empty.")
+    try:
+        with ZipFile(BytesIO(raw)) as archive:
+            return {
+                _safe_member_name(member.filename): archive.read(member)
+                for member in archive.infolist()
+                if not member.is_dir()
+            }
+    except BadZipFile as exc:
+        raise ValueError("Project snapshot must be a zip archive.") from exc
+
+
+def _load_json_model(members: dict[str, bytes], path: str, model, label: str):
+    raw = members.get(path)
+    if raw is None:
+        raise ValueError(f"Project snapshot is missing {path}.")
+    try:
+        return model.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ValueError(f"Project snapshot {label} is invalid: {exc}") from exc
+
+
+def _group_job_payloads(
+    members: dict[str, bytes],
+) -> tuple[dict[str, bytes], dict[str, bytes], dict[str, dict[str, bytes]]]:
+    job_records: dict[str, bytes] = {}
+    job_results: dict[str, bytes] = {}
+    artifacts: dict[str, dict[str, bytes]] = defaultdict(dict)
+
+    for name, content in members.items():
+        parts = _job_member_parts(name)
+        if len(parts) < 3 or parts[0] != JOBS_PREFIX:
+            continue
+        job_id = parts[1]
+        if len(parts) == 3 and parts[2] == JOB_RECORD_NAME:
+            job_records[job_id] = content
+            continue
+        if len(parts) == 3 and parts[2] == JOB_RESULT_NAME:
+            job_results[job_id] = content
+            continue
+        if len(parts) >= 4 and parts[2] == JOB_ARTIFACTS_SEGMENT:
+            artifact_name = _safe_member_name(PurePosixPath(*parts[3:]).as_posix())
+            artifacts[job_id][artifact_name] = content
+            continue
+        raise ValueError(f"Project snapshot contains unsupported job member {name!r}.")
+
+    return job_records, job_results, dict(artifacts)
+
+
+def load_project_snapshot(raw: bytes) -> ProjectSnapshot:
+    members = _load_members(raw)
+    manifest = _load_json_model(
+        members,
+        MANIFEST_PATH,
+        ProjectSnapshotManifest,
+        "manifest",
+    )
+    _validate_manifest(manifest)
+    project = _load_json_model(members, PROJECT_PATH, ProjectRecord, "project record")
+    if project.id != manifest.project_id:
+        raise ValueError("Project snapshot manifest project_id does not match project record.")
+
+    job_record_payloads, result_payloads, artifact_payloads = _group_job_payloads(members)
+    unknown_result_jobs = sorted(set(result_payloads) - set(job_record_payloads))
+    if unknown_result_jobs:
+        raise ValueError("Project snapshot contains results for an unknown job.")
+    unknown_artifact_jobs = sorted(set(artifact_payloads) - set(job_record_payloads))
+    if unknown_artifact_jobs:
+        raise ValueError("Project snapshot contains artifacts for an unknown job.")
+
+    jobs: list[ProjectSnapshotJob] = []
+    for job_id, payload in sorted(job_record_payloads.items()):
+        try:
+            record = JobRecord.model_validate_json(payload)
+        except ValidationError as exc:
+            raise ValueError(f"Project snapshot job {job_id} is invalid: {exc}") from exc
+        if record.id != job_id:
+            raise ValueError("Project snapshot job path does not match job record id.")
+        if record.project_id != project.id:
+            raise ValueError("Project snapshot job does not belong to the bundled project.")
+
+        result = None
+        result_payload = result_payloads.get(job_id)
+        if result_payload is not None:
+            try:
+                result = AttackResults.model_validate_json(result_payload)
+            except ValidationError as exc:
+                raise ValueError(f"Project snapshot job {job_id} result is invalid: {exc}") from exc
+        jobs.append(
+            ProjectSnapshotJob(
+                record=record,
+                result=result,
+                artifacts=artifact_payloads.get(job_id, {}),
+            )
+        )
+
+    result_count = sum(1 for job in jobs if job.result is not None)
+    artifact_count = sum(len(job.artifacts) for job in jobs)
+    if len(jobs) != manifest.job_count:
+        raise ValueError(f"Project snapshot manifest expects {manifest.job_count} job record(s).")
+    if result_count != manifest.result_count:
+        raise ValueError(f"Project snapshot manifest expects {manifest.result_count} result(s).")
+    if artifact_count != manifest.artifact_count:
+        raise ValueError(
+            f"Project snapshot manifest expects {manifest.artifact_count} artifact(s)."
+        )
+
+    return ProjectSnapshot(manifest=manifest, project=project, jobs=jobs)
+
+
+def _write_snapshot_artifacts(
+    job_store: JobStore,
+    *,
+    job_id: str,
+    artifacts: dict[str, bytes],
+) -> None:
+    root = job_store.artifact_dir(job_id).resolve()
+    for artifact_name, content in artifacts.items():
+        safe_name = _safe_member_name(artifact_name)
+        target = (job_store.artifact_dir(job_id) / safe_name).resolve()
+        if root not in target.parents and target != root:
+            raise ValueError(f"Project snapshot contains unsafe artifact path {artifact_name!r}.")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+
+def import_project_snapshot(
+    project_store: ProjectStore,
+    job_store: JobStore,
+    snapshot: ProjectSnapshot,
+    *,
+    name: str | None = None,
+) -> ProjectRecord:
+    now = datetime.now(UTC)
+    project_id = uuid4().hex
+    job_id_map = {job.record.id: uuid4().hex for job in snapshot.jobs}
+    imported_name = name.strip() if name and name.strip() else snapshot.project.name
+
+    artifacts = snapshot.project.artifacts.model_copy(
+        deep=True,
+        update={
+            "last_run_job_id": job_id_map.get(snapshot.project.artifacts.last_run_job_id)
+            if snapshot.project.artifacts.last_run_job_id is not None
+            else None,
+        },
+    )
+    review_draft = snapshot.project.review_draft.model_copy(
+        deep=True,
+        update={
+            "baseline_job_id": job_id_map.get(snapshot.project.review_draft.baseline_job_id)
+            if snapshot.project.review_draft.baseline_job_id is not None
+            else None,
+        },
+    )
+    imported_project = snapshot.project.model_copy(
+        deep=True,
+        update={
+            "id": project_id,
+            "name": imported_name,
+            "created_at": now,
+            "updated_at": now,
+            "review_draft": review_draft,
+            "artifacts": artifacts,
+        },
+    )
+    project_store.create_project(imported_project)
+
+    for job in snapshot.jobs:
+        imported_job_id = job_id_map[job.record.id]
+        imported_record = job.record.model_copy(
+            update={
+                "id": imported_job_id,
+                "project_id": project_id,
+            }
+        )
+        job_store.create_job(imported_record)
+        if job.result is not None:
+            job_store.write_result(imported_job_id, job.result)
+        _write_snapshot_artifacts(
+            job_store,
+            job_id=imported_job_id,
+            artifacts=job.artifacts,
+        )
+
+    return imported_project

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1126,6 +1126,107 @@ def test_project_update_persists_review_baseline_selection(tmp_path) -> None:
     assert payload["review_draft"]["min_confidence"] == "low"
 
 
+def test_project_snapshot_export_import_round_trips_project_state_jobs_and_artifacts(
+    tmp_path,
+) -> None:
+    app = create_app(data_dir=tmp_path)
+    client = TestClient(app)
+    job_store = app.state.job_store
+    project_store = app.state.project_store
+    create_response = client.post(
+        "/v1/projects",
+        json={
+            "name": "Snapshot demo",
+            "source_mode": "openapi",
+            "active_step": "review",
+            "source": {"name": "demo.yaml", "content": OPENAPI_SPEC},
+            "run_draft": {"base_url": "https://api.example"},
+            "artifacts": {"generated_suite": _attack_suite().model_dump(mode="json")},
+        },
+    )
+    assert create_response.status_code == 200
+    project_id = create_response.json()["id"]
+    completed_at = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+    record = _stored_job(
+        job_store,
+        status=ApiJobStatus.completed,
+        created_at=completed_at - timedelta(minutes=1),
+        completed_at=completed_at,
+        base_url="https://api.example",
+        project_id=project_id,
+        with_result=True,
+        with_artifact=True,
+    )
+    project = project_store.load_project(project_id)
+    project_store.update_project(
+        project.model_copy(
+            update={
+                "review_draft": project.review_draft.model_copy(
+                    update={"baseline_job_id": record.id}
+                ),
+                "artifacts": project.artifacts.model_copy(update={"last_run_job_id": record.id}),
+            }
+        )
+    )
+
+    export_response = client.get(f"/v1/projects/{project_id}/snapshot")
+
+    assert export_response.status_code == 200
+    assert export_response.headers["content-type"] == "application/zip"
+    assert (
+        export_response.headers["content-disposition"]
+        == f'attachment; filename="knives-out-project-{project_id}.zip"'
+    )
+
+    import_response = client.post(
+        "/v1/projects/import-snapshot",
+        files={"snapshot": ("snapshot.zip", export_response.content, "application/zip")},
+    )
+
+    assert import_response.status_code == 200
+    imported = import_response.json()
+    assert imported["id"] != project_id
+    assert imported["name"] == "Snapshot demo"
+    assert imported["source"]["name"] == "demo.yaml"
+    assert imported["source"]["content"] == OPENAPI_SPEC
+    assert imported["run_draft"]["base_url"] == "https://api.example"
+    assert imported["artifacts"]["generated_suite"]["attacks"][0]["id"] == "atk_api"
+    imported_job_id = imported["artifacts"]["last_run_job_id"]
+    assert imported_job_id != record.id
+    assert imported["review_draft"]["baseline_job_id"] == imported_job_id
+
+    jobs_response = client.get(f"/v1/projects/{imported['id']}/jobs")
+    assert jobs_response.status_code == 200
+    jobs_payload = jobs_response.json()
+    assert [job["id"] for job in jobs_payload["jobs"]] == [imported_job_id]
+    assert jobs_payload["jobs"][0]["status"] == "completed"
+    assert jobs_payload["jobs"][0]["result_available"] is True
+    assert jobs_payload["jobs"][0]["artifact_names"] == ["atk_api.json"]
+
+    result_response = client.get(f"/v1/jobs/{imported_job_id}/result")
+    assert result_response.status_code == 200
+    assert result_response.json()["results"][0]["attack_id"] == "atk_api"
+
+    artifact_response = client.get(f"/v1/jobs/{imported_job_id}/artifacts/atk_api.json")
+    assert artifact_response.status_code == 200
+    assert artifact_response.json()["attack"]["id"] == "atk_api"
+
+
+def test_project_snapshot_endpoints_report_missing_project_and_invalid_upload(tmp_path) -> None:
+    client = TestClient(create_app(data_dir=tmp_path))
+
+    missing_response = client.get("/v1/projects/missing/snapshot")
+    assert missing_response.status_code == 404
+    assert missing_response.json()["detail"] == "Project not found."
+
+    invalid_response = client.post(
+        "/v1/projects/import-snapshot",
+        files={"snapshot": ("empty.zip", b"", "application/zip")},
+    )
+    assert invalid_response.status_code == 400
+    assert invalid_response.json()["detail"] == "Project snapshot is empty."
+
+
 def test_job_store_lists_nested_artifacts_and_rejects_path_traversal(tmp_path) -> None:
     store = JobStore(tmp_path)
     record = store.create_job(JobRecord(base_url="https://example.com", attack_count=1))

--- a/tests/test_project_snapshots.py
+++ b/tests/test_project_snapshots.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+from knives_out.project_snapshots import load_project_snapshot
+
+
+def _zip_bytes(entries: dict[str, bytes | str]) -> bytes:
+    raw = BytesIO()
+    with ZipFile(raw, "w", compression=ZIP_DEFLATED) as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    return raw.getvalue()
+
+
+def test_project_snapshot_loader_rejects_unsupported_kind() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": json.dumps(
+                {
+                    "snapshot_kind": "review",
+                    "snapshot_version": 1,
+                    "name": "Wrong kind",
+                    "created_at": "2026-04-13T12:00:00Z",
+                    "project_id": "project-1",
+                    "source_mode": "openapi",
+                    "job_count": 0,
+                    "result_count": 0,
+                    "artifact_count": 0,
+                }
+            ),
+            "project/project.json": "{}",
+        }
+    )
+
+    with pytest.raises(ValueError, match="Unsupported project snapshot kind"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_unsafe_member_paths() -> None:
+    raw = _zip_bytes({"../escape.txt": "nope"})
+
+    with pytest.raises(ValueError, match="unsafe path"):
+        load_project_snapshot(raw)


### PR DESCRIPTION
## Summary
- Add portable full-project snapshot archives for saved workbench projects.
- Expose `GET /v1/projects/{project_id}/snapshot` and `POST /v1/projects/import-snapshot`.
- Import snapshots as new projects with remapped project/job IDs while preserving source, drafts, generated suites, results, artifacts, and project-scoped job history.
- Document the local API surface and architecture entry.

Closes #129.
Follow-up: #130 tracks workbench import/export controls.

## Validation
- `/opt/homebrew/bin/python3.12 -m compileall src/knives_out/project_snapshots.py src/knives_out/api.py tests/test_api.py tests/test_project_snapshots.py`
- `/opt/homebrew/bin/python3.12 -m compileall tests/test_api.py`
- `git diff --check`
- Hosted pull_request CI passed on `cc5b07f`: backend `test`, `frontend`, and `container`