### PR TITLE
[codex] add workbench project snapshot controls

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { listProjects } from "./api";
+import { buildProjectSnapshotUrl, importProjectSnapshot, listProjects } from "./api";
 
 describe("api", () => {
   beforeEach(() => {
@@ -30,5 +30,29 @@ describe("api", () => {
       expect(message).toContain("returned HTML instead of the JSON API");
       expect(message).not.toContain("<!DOCTYPE html>");
     }
+  });
+
+  it("builds project snapshot URLs", () => {
+    expect(buildProjectSnapshotUrl("project 1")).toBe("/v1/projects/project%201/snapshot");
+  });
+
+  it("posts project snapshot imports as multipart form data", async () => {
+    const submission: { body?: BodyInit | null } = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        submission.body = init?.body;
+        return Response.json({ id: "project-imported" });
+      }),
+    );
+
+    await importProjectSnapshot(new File(["zip"], "snapshot.zip", { type: "application/zip" }));
+
+    const submittedBody = submission.body as unknown;
+    expect(submittedBody).toBeInstanceOf(FormData);
+    if (!(submittedBody instanceof FormData)) {
+      throw new Error("Expected snapshot import body to be FormData.");
+    }
+    expect(submittedBody.get("snapshot")).toBeInstanceOf(File);
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -174,6 +174,19 @@ export function importReviewBundle(bundle: File) {
   });
 }
 
+export function importProjectSnapshot(snapshot: File) {
+  const formData = new FormData();
+  formData.append("snapshot", snapshot);
+  return requestFormData<ProjectRecord>("/v1/projects/import-snapshot", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+export function buildProjectSnapshotUrl(projectId: string) {
+  return buildApiUrl(`/v1/projects/${encodeURIComponent(projectId)}/snapshot`);
+}
+
 export function getProject(projectId: string) {
   return request<ProjectRecord>(`/v1/projects/${projectId}`);
 }

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -99,6 +99,9 @@ describe("HomePage", () => {
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText(/2 saved runs/)).toBeInTheDocument();
     expect(screen.getByText("Open")).toBeInTheDocument();
+    const exportLink = screen.getByRole("link", { name: "Export snapshot" });
+    expect(exportLink).toHaveAttribute("download", "knives-out-project-project-1.zip");
+    expect(exportLink.getAttribute("href")).toContain("/v1/projects/project-1/snapshot");
   });
 
   it("creates a project with the selected source mode", async () => {
@@ -437,6 +440,107 @@ describe("HomePage", () => {
     });
 
     expect(await screen.findByText("Opened project-imported")).toBeInTheDocument();
+  });
+
+  it("imports a project snapshot and opens the imported project", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.endsWith("/healthz")) {
+          return Response.json({ status: "ok" });
+        }
+        if (url.endsWith("/v1/edition")) {
+          return Response.json({
+            edition: "free",
+            plan: "Free",
+            license_state: "missing",
+            enabled_capabilities: [],
+            locked_capabilities: ["ci_reviewops"],
+            customer: null,
+            expires_at: null,
+            grace_expires_at: null,
+            upgrade_url: "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md",
+            message: "Running the MIT Free edition.",
+            extension_errors: [],
+          });
+        }
+        if (url.endsWith("/v1/projects") && method === "GET") {
+          return Response.json({ projects: [] });
+        }
+        if (url.endsWith("/v1/projects/import-snapshot") && method === "POST") {
+          expect(init?.body).toBeInstanceOf(FormData);
+          return Response.json({ id: "project-snapshot", name: "Imported snapshot" });
+        }
+        throw new Error(`Unhandled fetch for ${method} ${url}`);
+      }),
+    );
+
+    const { container } = renderHomePage();
+
+    await screen.findByText("No saved projects yet.");
+    const snapshotInput = container.querySelector('input[aria-label="Project snapshot zip"]');
+    if (!(snapshotInput instanceof HTMLInputElement)) {
+      throw new Error("Expected the project snapshot input to render.");
+    }
+    fireEvent.change(snapshotInput, {
+      target: {
+        files: [new File(["zip"], "project-snapshot.zip", { type: "application/zip" })],
+      },
+    });
+
+    expect(await screen.findByText("Opened project-snapshot")).toBeInTheDocument();
+  });
+
+  it("surfaces project snapshot import validation errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.endsWith("/healthz")) {
+          return Response.json({ status: "ok" });
+        }
+        if (url.endsWith("/v1/edition")) {
+          return Response.json({
+            edition: "free",
+            plan: "Free",
+            license_state: "missing",
+            enabled_capabilities: [],
+            locked_capabilities: ["ci_reviewops"],
+            customer: null,
+            expires_at: null,
+            grace_expires_at: null,
+            upgrade_url: "https://github.com/keithwegner/knives-out/blob/main/docs/pro.md",
+            message: "Running the MIT Free edition.",
+            extension_errors: [],
+          });
+        }
+        if (url.endsWith("/v1/projects") && method === "GET") {
+          return Response.json({ projects: [] });
+        }
+        if (url.endsWith("/v1/projects/import-snapshot") && method === "POST") {
+          return Response.json({ detail: "Project snapshot is empty." }, { status: 400 });
+        }
+        throw new Error(`Unhandled fetch for ${method} ${url}`);
+      }),
+    );
+
+    const { container } = renderHomePage();
+
+    await screen.findByText("No saved projects yet.");
+    const snapshotInput = container.querySelector('input[aria-label="Project snapshot zip"]');
+    if (!(snapshotInput instanceof HTMLInputElement)) {
+      throw new Error("Expected the project snapshot input to render.");
+    }
+    fireEvent.change(snapshotInput, {
+      target: {
+        files: [new File([], "empty.zip", { type: "application/zip" })],
+      },
+    });
+
+    expect(await screen.findByText("Project snapshot is empty.")).toBeInTheDocument();
   });
 
   it("saves a custom API endpoint", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,11 +2,13 @@ import { startTransition, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
 import {
+  buildProjectSnapshotUrl,
   createProject,
   deleteProject,
   duplicateProject,
   getEditionStatus,
   getHealthStatus,
+  importProjectSnapshot,
   importReviewBundle,
   listProjects,
 } from "../api";
@@ -40,6 +42,7 @@ export default function HomePage() {
     useState<ProjectSourceMode>("openapi");
   const [apiBaseUrl, setApiBaseUrl] = useState(() => getApiBaseUrl());
   const bundleInputRef = useRef<HTMLInputElement | null>(null);
+  const snapshotInputRef = useRef<HTMLInputElement | null>(null);
   const requiresApiBase = needsConfiguredApiBase(apiBaseUrl);
 
   const projectListQuery = useQuery({
@@ -97,6 +100,16 @@ export default function HomePage() {
     },
   });
 
+  const importProjectSnapshotMutation = useMutation({
+    mutationFn: importProjectSnapshot,
+    onSuccess: async (project) => {
+      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+      startTransition(() => {
+        navigate(`/projects/${project.id}`);
+      });
+    },
+  });
+
   function applyApiBase(nextValue: string) {
     const normalized = persistApiBaseUrl(nextValue);
     setApiBaseUrl(normalized);
@@ -114,7 +127,9 @@ export default function HomePage() {
             ? duplicateProjectMutation.error.message
             : importReviewBundleMutation.error instanceof Error
               ? importReviewBundleMutation.error.message
-              : null;
+              : importProjectSnapshotMutation.error instanceof Error
+                ? importProjectSnapshotMutation.error.message
+                : null;
   const apiStatusTone = requiresApiBase
     ? "idle"
     : healthQuery.isLoading
@@ -196,6 +211,20 @@ export default function HomePage() {
             ref={bundleInputRef}
             type="file"
           />
+          <input
+            accept=".zip,application/zip"
+            aria-label="Project snapshot zip"
+            hidden
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                importProjectSnapshotMutation.mutate(file);
+              }
+              event.target.value = "";
+            }}
+            ref={snapshotInputRef}
+            type="file"
+          />
           <div className="field">
             <span className="field-label">Source type</span>
             <div className="source-choice-grid" role="radiogroup" aria-label="New project source type">
@@ -221,7 +250,10 @@ export default function HomePage() {
               className="primary-button"
               type="submit"
               disabled={
-                createProjectMutation.isPending || importReviewBundleMutation.isPending || requiresApiBase
+                createProjectMutation.isPending ||
+                importReviewBundleMutation.isPending ||
+                importProjectSnapshotMutation.isPending ||
+                requiresApiBase
               }
             >
               {createProjectMutation.isPending
@@ -233,12 +265,28 @@ export default function HomePage() {
             <button
               className="secondary-button"
               disabled={
-                createProjectMutation.isPending || importReviewBundleMutation.isPending || requiresApiBase
+                createProjectMutation.isPending ||
+                importReviewBundleMutation.isPending ||
+                importProjectSnapshotMutation.isPending ||
+                requiresApiBase
               }
               onClick={() => bundleInputRef.current?.click()}
               type="button"
             >
               {importReviewBundleMutation.isPending ? "Importing…" : "Import review bundle"}
+            </button>
+            <button
+              className="secondary-button"
+              disabled={
+                createProjectMutation.isPending ||
+                importReviewBundleMutation.isPending ||
+                importProjectSnapshotMutation.isPending ||
+                requiresApiBase
+              }
+              onClick={() => snapshotInputRef.current?.click()}
+              type="button"
+            >
+              {importProjectSnapshotMutation.isPending ? "Importing…" : "Import snapshot"}
             </button>
             <Link className="secondary-button" to="/reviewops">
               CI ReviewOps
@@ -290,7 +338,7 @@ export default function HomePage() {
         !projectListQuery.data?.projects.length ? (
           <div className="empty-state">
             <p>No saved projects yet.</p>
-            <p>Start with a spec-driven workbench or import a portable review bundle.</p>
+            <p>Start with a spec-driven workbench or import a portable project snapshot.</p>
           </div>
         ) : null}
 
@@ -333,6 +381,13 @@ export default function HomePage() {
                 <Link className="secondary-button" to={`/projects/${project.id}`}>
                   Open
                 </Link>
+                <a
+                  className="ghost-button"
+                  download={`knives-out-project-${project.id}.zip`}
+                  href={buildProjectSnapshotUrl(project.id)}
+                >
+                  Export snapshot
+                </a>
                 {project.source_mode !== "review_bundle" ? (
                   <button
                     className="ghost-button"

--- a/frontend/src/pages/ProjectWorkbenchPage.test.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.test.tsx
@@ -701,6 +701,9 @@ describe("ProjectWorkbenchPage", () => {
     renderWorkbench();
 
     expect(await screen.findByRole("heading", { name: "Workbench demo" })).toBeInTheDocument();
+    const exportLink = screen.getByRole("link", { name: "Export snapshot" });
+    expect(exportLink).toHaveAttribute("download", "knives-out-project-project-1.zip");
+    expect(exportLink.getAttribute("href")).toContain("/v1/projects/project-1/snapshot");
     const stepRail = screen.getByRole("navigation", { name: "Workbench steps" });
     for (const stepName of ["Source", "Inspect", "Generate", "Run", "Review"]) {
       expect(

--- a/frontend/src/pages/ProjectWorkbenchPage.tsx
+++ b/frontend/src/pages/ProjectWorkbenchPage.tsx
@@ -13,6 +13,7 @@ import ApiConnectionPanel from "../components/ApiConnectionPanel";
 import CodeEditor from "../components/CodeEditor";
 import {
   buildJobArtifactUrl,
+  buildProjectSnapshotUrl,
   createRun,
   deleteProjectJob,
   discoverModel,
@@ -1838,6 +1839,13 @@ export default function ProjectWorkbenchPage() {
           </p>
         </div>
         <div className="header-actions">
+          <a
+            className="secondary-button"
+            download={`knives-out-project-${draft.id}.zip`}
+            href={buildProjectSnapshotUrl(draft.id)}
+          >
+            Export snapshot
+          </a>
           {!isReviewBundleProject ? (
             <button
               className="secondary-button"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -266,10 +266,22 @@ pre {
 .primary-button,
 .secondary-button,
 .ghost-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 44px;
   padding: 0 16px;
   cursor: pointer;
+  text-decoration: none;
   transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+
+.primary-button:disabled,
+.secondary-button:disabled,
+.ghost-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
 }
 
 .primary-button {
@@ -370,6 +382,7 @@ pre {
 
 .project-card-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 }
 


### PR DESCRIPTION
## Summary
- Add a home-page project snapshot import flow that posts snapshot zips to the new API and opens the imported project.
- Add project snapshot export links to project cards and the workbench header.
- Surface snapshot upload validation errors in the existing home-page error banner.
- Cover snapshot import/export affordances in frontend API, home-page, and workbench tests.

Closes #130.

## Validation
- `npm test -- --run HomePage ProjectWorkbenchPage api`
- `npm run build`
- `npm test -- --run`
- `git diff --check`
- Hosted pull_request CI passed on `87768e2`: backend `test`, `frontend`, and `container`