### PR TITLE
[codex] add project snapshot validation coverage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,9 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.8",
         "vitest": "^4.1.4"
+      },
+      "overrides": {
+        "dompurify": "^3.4.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1614,9 +1617,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,5 +28,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "dompurify": "^3.4.0"
   }
 }

--- a/tests/test_project_snapshots.py
+++ b/tests/test_project_snapshots.py
@@ -8,6 +8,8 @@ import pytest
 
 from knives_out.project_snapshots import load_project_snapshot
 
+CREATED_AT = "2026-04-13T12:00:00Z"
+
 
 def _zip_bytes(entries: dict[str, bytes | str]) -> bytes:
     raw = BytesIO()
@@ -15,6 +17,59 @@ def _zip_bytes(entries: dict[str, bytes | str]) -> bytes:
         for name, content in entries.items():
             archive.writestr(name, content)
     return raw.getvalue()
+
+
+def _manifest(**overrides: object) -> str:
+    payload = {
+        "snapshot_kind": "project_snapshot",
+        "snapshot_version": 1,
+        "name": "Snapshot demo",
+        "created_at": CREATED_AT,
+        "project_id": "project-1",
+        "source_mode": "openapi",
+        "job_count": 0,
+        "result_count": 0,
+        "artifact_count": 0,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _project(**overrides: object) -> str:
+    payload = {
+        "id": "project-1",
+        "name": "Snapshot demo",
+        "source_mode": "openapi",
+        "active_step": "source",
+        "created_at": CREATED_AT,
+        "updated_at": CREATED_AT,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _job(**overrides: object) -> str:
+    payload = {
+        "id": "job-1",
+        "status": "completed",
+        "created_at": CREATED_AT,
+        "base_url": "https://api.example",
+        "attack_count": 1,
+        "project_id": "project-1",
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _results(**overrides: object) -> str:
+    payload = {
+        "source": "demo.yaml",
+        "base_url": "https://api.example",
+        "executed_at": CREATED_AT,
+        "results": [],
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
 
 
 def test_project_snapshot_loader_rejects_unsupported_kind() -> None:
@@ -41,8 +96,141 @@ def test_project_snapshot_loader_rejects_unsupported_kind() -> None:
         load_project_snapshot(raw)
 
 
+def test_project_snapshot_loader_rejects_unsupported_version() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(snapshot_version=2),
+            "project/project.json": _project(),
+        }
+    )
+
+    with pytest.raises(ValueError, match="Unsupported project snapshot version"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_empty_uploads() -> None:
+    with pytest.raises(ValueError, match="Project snapshot is empty"):
+        load_project_snapshot(b"")
+
+
+def test_project_snapshot_loader_rejects_non_zip_uploads() -> None:
+    with pytest.raises(ValueError, match="must be a zip archive"):
+        load_project_snapshot(b"not a zip")
+
+
+def test_project_snapshot_loader_rejects_missing_manifest() -> None:
+    raw = _zip_bytes({"project/project.json": _project()})
+
+    with pytest.raises(ValueError, match="missing manifest.json"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_invalid_manifest_json() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": "{}",
+            "project/project.json": _project(),
+        }
+    )
+
+    with pytest.raises(ValueError, match="manifest is invalid"):
+        load_project_snapshot(raw)
+
+
 def test_project_snapshot_loader_rejects_unsafe_member_paths() -> None:
     raw = _zip_bytes({"../escape.txt": "nope"})
 
     with pytest.raises(ValueError, match="unsafe path"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_mismatched_project_id() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(project_id="project-1"),
+            "project/project.json": _project(id="project-2"),
+        }
+    )
+
+    with pytest.raises(ValueError, match="project_id does not match"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_unknown_result_jobs() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(result_count=1),
+            "project/project.json": _project(),
+            "jobs/missing/result.json": _results(),
+        }
+    )
+
+    with pytest.raises(ValueError, match="results for an unknown job"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_unknown_artifact_jobs() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(artifact_count=1),
+            "project/project.json": _project(),
+            "jobs/missing/artifacts/request.json": "{}",
+        }
+    )
+
+    with pytest.raises(ValueError, match="artifacts for an unknown job"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_unsupported_job_members() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(),
+            "project/project.json": _project(),
+            "jobs/job-1/notes.txt": "unsupported",
+        }
+    )
+
+    with pytest.raises(ValueError, match="unsupported job member"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_job_path_id_mismatch() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(job_count=1),
+            "project/project.json": _project(),
+            "jobs/job-path/job.json": _job(id="job-record"),
+        }
+    )
+
+    with pytest.raises(ValueError, match="job path does not match"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_jobs_from_other_projects() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(job_count=1),
+            "project/project.json": _project(),
+            "jobs/job-1/job.json": _job(project_id="project-2"),
+        }
+    )
+
+    with pytest.raises(ValueError, match="job does not belong"):
+        load_project_snapshot(raw)
+
+
+def test_project_snapshot_loader_rejects_manifest_count_mismatches() -> None:
+    raw = _zip_bytes(
+        {
+            "manifest.json": _manifest(job_count=2, result_count=1, artifact_count=1),
+            "project/project.json": _project(),
+            "jobs/job-1/job.json": _job(),
+            "jobs/job-1/result.json": _results(),
+            "jobs/job-1/artifacts/request.json": "{}",
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"expects 2 job record"):
         load_project_snapshot(raw)


### PR DESCRIPTION
## Summary
- Add focused project snapshot loader tests for malformed archives, invalid manifests, unsafe members, orphaned job payloads, and job/project mismatches.
- Recover source coverage after the main-maintenance gate failed on a 0.03 percentage-point drop from 91.95% to 91.93%.
- Override Monaco's transitive `dompurify` dependency to 3.4.0, clearing the current moderate DOMPurify Dependabot alerts.

## Validation
- Local: `python3.12 -m py_compile tests/test_project_snapshots.py scripts/check_coverage_drop.py`
- Local: `npm ci --offline` (reported 0 vulnerabilities)
- Local: `npm audit --offline --json` (0 vulnerabilities)
- Local: `npm ls dompurify --depth=2` (`dompurify@3.4.0 overridden`)
- Local: `npm run build`
- Local: `npm test -- --run`
- GitHub Actions `ci`: success on 0534570
  - Ruff passed
  - Pytest: 392 passed, 2 warnings; total coverage 92%; `project_snapshots.py` improved to 96%
  - Frontend install reported 0 vulnerabilities; build/test passed with 5 files / 28 tests
  - Container build reported 0 npm vulnerabilities and smoke test passed

Local Python pytest/ruff execution was blocked because this environment cannot install PyPI dependencies offline; GitHub CI completed the full Python verification.