### PR TITLE
[codex] Add project snapshot inspection CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It helps developers break their APIs on purpose before someone else does.
   - [`report`](#report)
   - [`bundle`](#bundle)
   - [`inspect-bundle`](#inspect-bundle)
+  - [`inspect-snapshot`](#inspect-snapshot)
   - [`export`](#export)
   - [`verify`](#verify)
   - [`promote`](#promote)
@@ -339,7 +340,8 @@ recomputes summary, verification, and reports from bundled `results.json`, optio
 optional suppressions YAML, and optional request/response artifacts.
 For full local project moves, the API can also export and import project snapshots that include
 the saved source, drafts, cached generated suite, project-scoped job history, stored results, and
-artifacts.
+artifacts. Use `knives-out inspect-snapshot project-snapshot.zip` to validate a snapshot before
+importing or sharing it.
 
 ## Local API
 
@@ -802,6 +804,23 @@ knives-out inspect-bundle review-bundle.zip --format json
 The command reuses the same bundle validation as workbench import, including manifest version,
 required `current/results.json`, optional baseline and suppressions expectations, artifact path
 safety, and artifact counts.
+
+### `inspect-snapshot`
+
+Validates a portable project snapshot zip and prints the import-ready manifest details.
+
+```bash
+knives-out inspect-snapshot project-snapshot.zip
+```
+
+Use JSON output when CI needs to gate or annotate a snapshot artifact:
+
+```bash
+knives-out inspect-snapshot project-snapshot.zip --format json
+```
+
+The command reuses the same snapshot validation as workbench import, including manifest version,
+project/job consistency, expected result and artifact counts, and artifact path safety.
 
 ### `export`
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -232,6 +232,21 @@ the existing review tabs, suppressions editor, run history, and artifact inspect
 Use `knives-out inspect-bundle review-bundle.zip --format json` when a CI job needs a
 machine-readable validation step before publishing the zip as an artifact.
 
+## Optional: project snapshot validation
+
+Project snapshots are exported from the local API or workbench when a developer needs to move a
+rerunnable saved project, including source, drafts, generated suite, project-scoped job history,
+stored results, and artifacts. Before publishing or importing that archive, validate it with the
+same loader used by workbench import:
+
+```bash
+knives-out inspect-snapshot project-snapshot.zip
+knives-out inspect-snapshot project-snapshot.zip --format json
+```
+
+The JSON form exposes manifest counts and job status counts for CI gates that need to confirm the
+archive is complete before attaching it to a workflow run or handing it to another workbench.
+
 ## Optional: stateful workflow coverage
 
 Start simple with request-only generation:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,6 +62,7 @@ review loops:
 - smoother baseline handoff across bundle generations
 - richer imported-run history and evidence metadata
 - easier bundle production and retrieval in GitHub Actions or other CI systems
+- offline validation commands for portable snapshot artifacts before import
 - smaller, higher-signal review summaries for long-lived regression programs
 
 The integration baseline now has two layers. `tests/test_integration_smoke.py` protects

--- a/src/knives_out/cli.py
+++ b/src/knives_out/cli.py
@@ -19,6 +19,7 @@ from knives_out.extensions import (
     register_cli_extensions,
 )
 from knives_out.models import AttackResults, PreflightWarning
+from knives_out.project_snapshots import ProjectSnapshotInspection, inspect_project_snapshot
 from knives_out.promotion import PromotionError
 from knives_out.reporting import render_markdown_summary
 from knives_out.review_bundles import ReviewBundleInspection, inspect_review_bundle
@@ -266,6 +267,28 @@ def _print_review_bundle_inspection(inspection: ReviewBundleInspection) -> None:
         artifacts_table.add_row(f"... {inspection.artifact_count - 20} more")
     console.print("")
     console.print(artifacts_table)
+
+
+def _print_project_snapshot_inspection(inspection: ProjectSnapshotInspection) -> None:
+    manifest = inspection.manifest
+    table = Table(title="Project snapshot")
+    table.add_column("Field")
+    table.add_column("Value", overflow="fold")
+    table.add_row("Name", manifest.name)
+    table.add_row("Source mode", manifest.source_mode)
+    table.add_row("Created at", manifest.created_at.isoformat())
+    table.add_row("Original project", manifest.project_id)
+    table.add_row("Active step", inspection.active_step)
+    table.add_row("Source", inspection.source_name or "none")
+    table.add_row("Jobs", str(manifest.job_count))
+    table.add_row("Results", str(manifest.result_count))
+    table.add_row("Artifacts", str(manifest.artifact_count))
+    table.add_row(
+        "Job statuses",
+        ", ".join(f"{status}: {count}" for status, count in inspection.job_status_counts.items())
+        or "none",
+    )
+    console.print(table)
 
 
 @app.command()
@@ -799,6 +822,31 @@ def inspect_bundle(
         return
 
     _print_review_bundle_inspection(inspection)
+
+
+@app.command()
+def inspect_snapshot(
+    snapshot: Path,
+    format: Annotated[
+        InspectFormatOption,
+        typer.Option(help="Output format for project snapshot inspection."),
+    ] = InspectFormatOption.text,
+) -> None:
+    """Validate and summarize a portable project snapshot zip."""
+    try:
+        inspection = inspect_project_snapshot(snapshot.read_bytes())
+    except OSError as exc:
+        message = exc.strerror or str(exc)
+        error = f"Could not read project snapshot '{snapshot}': {message}"
+        raise typer.BadParameter(error) from exc
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    if format == InspectFormatOption.json:
+        typer.echo(json.dumps(inspection.model_dump(mode="json", exclude_none=True), indent=2))
+        return
+
+    _print_project_snapshot_inspection(inspection)
 
 
 @app.command()

--- a/src/knives_out/project_snapshots.py
+++ b/src/knives_out/project_snapshots.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from io import BytesIO
@@ -49,6 +49,13 @@ class ProjectSnapshot:
     manifest: ProjectSnapshotManifest
     project: ProjectRecord
     jobs: list[ProjectSnapshotJob]
+
+
+class ProjectSnapshotInspection(BaseModel):
+    manifest: ProjectSnapshotManifest
+    active_step: str
+    source_name: str | None = None
+    job_status_counts: dict[str, int] = Field(default_factory=dict)
 
 
 def _safe_member_name(name: str) -> str:
@@ -239,6 +246,18 @@ def load_project_snapshot(raw: bytes) -> ProjectSnapshot:
         )
 
     return ProjectSnapshot(manifest=manifest, project=project, jobs=jobs)
+
+
+def inspect_project_snapshot(raw: bytes) -> ProjectSnapshotInspection:
+    snapshot = load_project_snapshot(raw)
+    return ProjectSnapshotInspection(
+        manifest=snapshot.manifest,
+        active_step=snapshot.project.active_step.value,
+        source_name=snapshot.project.source.name if snapshot.project.source is not None else None,
+        job_status_counts=dict(
+            sorted(Counter(job.record.status.value for job in snapshot.jobs).items())
+        ),
+    )
 
 
 def _write_snapshot_artifacts(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import json
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 from textwrap import dedent
 from zipfile import ZipFile
@@ -7,6 +8,15 @@ from zipfile import ZipFile
 from fastapi import FastAPI
 from typer.testing import CliRunner
 
+from knives_out.api_models import (
+    ApiJobStatus,
+    JobRecord,
+    ProjectRecord,
+    ProjectSourceMode,
+    ProjectStep,
+    SourcePayload,
+)
+from knives_out.api_store import JobStore
 from knives_out.auth_plugins import PluginRuntimeError
 from knives_out.cli import app
 from knives_out.models import (
@@ -18,6 +28,8 @@ from knives_out.models import (
     LoadedOperations,
     PreflightWarning,
 )
+from knives_out.project_snapshots import render_project_snapshot
+from knives_out.project_store import ProjectStore
 from knives_out.suppressions import load_suppressions
 
 runner = CliRunner()
@@ -57,6 +69,36 @@ def _results_with_findings(*results: AttackResult) -> AttackResults:
         base_url="https://example.com",
         results=list(results),
     )
+
+
+def _write_snapshot(path: Path, data_dir: Path) -> None:
+    project_store = ProjectStore(data_dir)
+    job_store = JobStore(data_dir)
+    project = project_store.create_project(
+        ProjectRecord(
+            id="project-1",
+            name="Snapshot demo",
+            source_mode=ProjectSourceMode.openapi,
+            active_step=ProjectStep.review,
+            source=SourcePayload(name="openapi.yaml", content="openapi: 3.0.3\n"),
+        )
+    )
+    job = job_store.create_job(
+        JobRecord(
+            id="job-1",
+            status=ApiJobStatus.completed,
+            created_at=datetime(2026, 4, 13, 11, 59, tzinfo=UTC),
+            started_at=datetime(2026, 4, 13, 11, 59, tzinfo=UTC),
+            completed_at=datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+            base_url="https://example.com",
+            attack_count=1,
+            project_id=project.id,
+        )
+    )
+    job_store.write_result(job.id, _results_with_findings())
+    artifact_path = job_store.artifact_dir(job.id) / "atk_api.json"
+    artifact_path.write_text('{"attack":{"id":"atk_api"}}', encoding="utf-8")
+    path.write_bytes(render_project_snapshot(project_store, job_store, project.id))
 
 
 def _normalized_output(output: str) -> str:
@@ -2718,3 +2760,51 @@ def test_inspect_bundle_command_rejects_invalid_archives(tmp_path: Path) -> None
 
     assert result.exit_code == 2
     assert "Review bundle must be a zip archive." in result.stderr
+
+
+def test_inspect_snapshot_command_prints_project_snapshot_summary(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "project-snapshot.zip"
+    _write_snapshot(snapshot_path, tmp_path / "api-data")
+
+    result = runner.invoke(app, ["inspect-snapshot", str(snapshot_path)])
+
+    assert result.exit_code == 0
+    assert "Project snapshot" in result.stdout
+    assert "Snapshot demo" in result.stdout
+    assert "Source mode" in result.stdout
+    assert "openapi" in result.stdout
+    assert "Original project" in result.stdout
+    assert "project-1" in result.stdout
+    assert "Active step" in result.stdout
+    assert "review" in result.stdout
+    assert "Job statuses" in result.stdout
+    assert "completed: 1" in result.stdout
+
+
+def test_inspect_snapshot_command_prints_json_summary(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "project-snapshot.zip"
+    _write_snapshot(snapshot_path, tmp_path / "api-data")
+
+    result = runner.invoke(app, ["inspect-snapshot", str(snapshot_path), "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["manifest"]["name"] == "Snapshot demo"
+    assert payload["manifest"]["snapshot_kind"] == "project_snapshot"
+    assert payload["manifest"]["project_id"] == "project-1"
+    assert payload["manifest"]["job_count"] == 1
+    assert payload["manifest"]["result_count"] == 1
+    assert payload["manifest"]["artifact_count"] == 1
+    assert payload["active_step"] == "review"
+    assert payload["source_name"] == "openapi.yaml"
+    assert payload["job_status_counts"] == {"completed": 1}
+
+
+def test_inspect_snapshot_command_rejects_invalid_archives(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "project-snapshot.zip"
+    snapshot_path.write_bytes(b"not a zip")
+
+    result = runner.invoke(app, ["inspect-snapshot", str(snapshot_path)])
+
+    assert result.exit_code == 2
+    assert "Project snapshot must be a zip archive." in result.stderr


### PR DESCRIPTION
## Summary
- Add `inspect_project_snapshot` and a `knives-out inspect-snapshot` CLI command for validating portable project snapshot zips.
- Support text and JSON output with manifest counts, active step, source name, and job status counts.
- Document the snapshot validation flow in README, CI docs, and the v0.22 roadmap.

Closes #134.

## Validation
- `python3.12 -m compileall src tests/test_cli.py tests/test_project_snapshots.py`
- `git diff --check`
- GitHub Actions `ci` run #457 passed for test, frontend, and container jobs on `fa91c424fb44b33def72c2fc877fa01b212322ac`.

## Notes
- Targeted pytest could not run locally in this sandbox because project dependencies and pytest were not installed, and a throwaway `pip install -e ".[dev]"` failed on blocked PyPI DNS while trying to fetch `hatchling`. CI installed dependencies and ran the full Python test job successfully.